### PR TITLE
Initialize the SignLab research project

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[{*.md,*.json,*.yml,*.yaml,*.ts,*.tsx}]
+indent_style = space
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+* text=auto eol=lf
+
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.webp binary
+*.mp4 binary
+*.onnx binary
+*.parquet binary

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,29 @@
+name: Bug report
+description: Report reproducible incorrect behavior
+title: "[Bug]: "
+labels: ["type: bug"]
+body:
+  - type: textarea
+    id: behavior
+    attributes:
+      label: Observed behavior
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Include the smallest reproducible example and relevant version identifiers.
+    validations:
+      required: true
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: Explain affected data, metrics, models, or user workflows.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security or privacy concern
+    url: https://github.com/peterbucci/signlab/security/advisories/new
+    about: Report security or participant-data concerns privately.

--- a/.github/ISSUE_TEMPLATE/story.yml
+++ b/.github/ISSUE_TEMPLATE/story.yml
@@ -1,0 +1,41 @@
+name: User story
+description: Plan a testable unit of product or research work
+title: "[Story]: "
+labels: ["type: story"]
+body:
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Outcome
+      description: Describe the user, research, or operational outcome.
+      placeholder: As a ..., I want ..., so that ...
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Why this work is needed and which decision it supports.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Use a checklist of independently verifiable conditions.
+      value: |
+        - [ ]
+        - [ ]
+        - [ ]
+    validations:
+      required: true
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies
+      description: Link prerequisite issues or write None.
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Tests, reports, screenshots, metrics, or artifacts that prove completion.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Outcome
+
+Describe the behavior, research decision, or artifact delivered by this change.
+
+## Validation
+
+- [ ] Relevant automated tests pass.
+- [ ] Data/split leakage invariants still pass when applicable.
+- [ ] Contracts, manifests, and documentation were updated when applicable.
+- [ ] No raw participant video, secrets, machine-specific paths, or unlicensed data were committed.
+- [ ] Performance/evaluation claims link to versioned evidence.
+
+## Related work
+
+Closes #

--- a/.gitignore
+++ b/.gitignore
@@ -1,218 +1,54 @@
-# Byte-compiled / optimized / DLL files
+# Python
 __pycache__/
-*.py[codz]
-*$py.class
-
-# C extensions
-*.so
-
-# Distribution / packaging
-.Python
-build/
-develop-eggs/
-dist/
-downloads/
-eggs/
-.eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
-wheels/
-share/python-wheels/
-*.egg-info/
-.installed.cfg
-*.egg
-MANIFEST
-
-# PyInstaller
-#   Usually these files are written by a python script from a template
-#   before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
-
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
-
-# Unit test / coverage reports
-htmlcov/
-.tox/
-.nox/
-.coverage
-.coverage.*
-.cache
-nosetests.xml
-coverage.xml
-*.cover
-*.py.cover
-.hypothesis/
+*.py[cod]
+*.pyd
 .pytest_cache/
-cover/
-
-# Translations
-*.mo
-*.pot
-
-# Django stuff:
-*.log
-local_settings.py
-db.sqlite3
-db.sqlite3-journal
-
-# Flask stuff:
-instance/
-.webassets-cache
-
-# Scrapy stuff:
-.scrapy
-
-# Sphinx documentation
-docs/_build/
-
-# PyBuilder
-.pybuilder/
-target/
-
-# Jupyter Notebook
-.ipynb_checkpoints
-
-# IPython
-profile_default/
-ipython_config.py
-
-# pyenv
-#   For a library or package, you might want to ignore these files since the code is
-#   intended to run in multiple environments; otherwise, check them in:
-# .python-version
-
-# pipenv
-#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
-#   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don't work, or not
-#   install all needed dependencies.
-# Pipfile.lock
-
-# UV
-#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
-#   This is especially recommended for binary packages to ensure reproducibility, and is more
-#   commonly ignored for libraries.
-# uv.lock
-
-# poetry
-#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
-#   This is especially recommended for binary packages to ensure reproducibility, and is more
-#   commonly ignored for libraries.
-#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
-# poetry.lock
-# poetry.toml
-
-# pdm
-#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
-#   pdm recommends including project-wide configuration in pdm.toml, but excluding .pdm-python.
-#   https://pdm-project.org/en/latest/usage/project/#working-with-version-control
-# pdm.lock
-# pdm.toml
-.pdm-python
-.pdm-build/
-
-# pixi
-#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
-# pixi.lock
-#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
-#   in the .venv directory. It is recommended not to include this directory in version control.
-.pixi
-
-# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
-__pypackages__/
-
-# Celery stuff
-celerybeat-schedule
-celerybeat.pid
-
-# Redis
-*.rdb
-*.aof
-*.pid
-
-# RabbitMQ
-mnesia/
-rabbitmq/
-rabbitmq-data/
-
-# ActiveMQ
-activemq-data/
-
-# SageMath parsed files
-*.sage.py
-
-# Environments
-.env
-.envrc
-.venv
-env/
-venv/
-ENV/
-env.bak/
-venv.bak/
-
-# Spyder project settings
-.spyderproject
-.spyproject
-
-# Rope project settings
-.ropeproject
-
-# mkdocs documentation
-/site
-
-# mypy
 .mypy_cache/
-.dmypy.json
-dmypy.json
-
-# Pyre type checker
-.pyre/
-
-# pytype static type analyzer
-.pytype/
-
-# Cython debug symbols
-cython_debug/
-
-# PyCharm
-#   JetBrains specific template is maintained in a separate JetBrains.gitignore that can
-#   be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
-#   and can be added to the global gitignore or merged into this file.  For a more nuclear
-#   option (not recommended) you can uncomment the following to ignore the entire idea folder.
-# .idea/
-
-# Abstra
-#   Abstra is an AI-powered process automation framework.
-#   Ignore directories containing user credentials, local state, and settings.
-#   Learn more at https://abstra.io/docs
-.abstra/
-
-# Visual Studio Code
-#   Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
-#   that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
-#   and can be added to the global gitignore or merged into this file. However, if you prefer, 
-#   you could uncomment the following to ignore the entire vscode folder
-# .vscode/
-# Temporary file for partial code execution
-tempCodeRunnerFile.py
-
-# Ruff stuff:
 .ruff_cache/
+.venv/
+dist/
+build/
+*.egg-info/
 
-# PyPI configuration file
-.pypirc
+# JavaScript
+node_modules/
+apps/web/dist/
+*.tsbuildinfo
 
-# Marimo
-marimo/_static/
-marimo/_lsp/
-__marimo__/
+# IDE and OS
+.idea/
+.vscode/
+.DS_Store
+Thumbs.db
 
-# Streamlit
-.streamlit/secrets.toml
+# Environment and secrets
+.env
+.env.*
+!.env.example
+*.pem
+*.key
+
+# Private data and generated ML artifacts
+data/raw/
+data/interim/
+data/processed/
+artifacts/
+models/
+runs/
+mlruns/
+*.onnx
+*.keras
+*.h5
+*.pt
+*.pth
+
+# Local databases and caches
+*.db
+*.sqlite
+*.sqlite3
+.dvc/cache/
+
+# Keep lightweight contracts, manifests, fixtures, reports, and DVC pointers.
+!data/manifests/
+!data/splits/
+!tests/fixtures/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contributing
+
+## Workflow
+
+1. Start from a GitHub issue with explicit acceptance criteria.
+2. Keep raw participant data and credentials outside Git.
+3. Use a focused feature branch and reference the issue in the pull request.
+4. Add tests for contracts, split invariants, preprocessing, or runtime parity as applicable.
+5. Update model/data documentation whenever a result or intended use changes.
+
+## Definition of done
+
+A story is complete when its acceptance criteria pass, evidence is attached, relevant
+documentation is current, and the change can be reproduced from versioned inputs.
+
+Experimental results must include the dataset version, split version, resolved
+configuration, seed, Git commit, environment, and exact evaluation protocol.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,71 @@
-# signlab
-Reproducible signer-aware hand-gesture recognition research and privacy-preserving browser inference.
+# SignLab
+
+SignLab is a reproducible research and deployment project for a small-vocabulary,
+continuous hand-gesture recognition system. It replaces an earlier Streamlit
+prototype with a UI-independent ML pipeline, leakage-resistant evaluation, and
+a privacy-preserving browser demo.
+
+## Project goals
+
+- Evaluate on unseen signers and sessions rather than random clip splits.
+- Preserve local hand shape, body-relative placement, timing, and detection quality.
+- Model `inactive`, learned `other`, and calibrated `abstain` as separate states.
+- Measure continuous-video event accuracy, false activations, and end-to-end latency.
+- Export an immutable ONNX model bundle with Python/TypeScript parity tests.
+- Publish a zero-install React demo that performs webcam inference on-device.
+
+## Initial architecture
+
+```text
+Private research data
+  raw videos -> versioned manifest -> MediaPipe Tasks extraction
+             -> feature variants -> train/calibrate/evaluate -> model bundle
+
+Local research tools
+  Python CLI + DVC + MLflow + Parquet
+
+Public product
+  React/Vite -> MediaPipe Web Worker -> ONNX Runtime Web
+```
+
+The public demo is intentionally independent of the optional training platform.
+FastAPI, Prefect, PostgreSQL, object storage, and a custom experiment Studio are
+deferred until a concrete workflow requires them.
+
+## Research questions
+
+1. Does body-relative context improve signer-held-out generalization?
+2. How much do learned hard negatives and calibrated abstention reduce false activations?
+3. Which temporal model is sufficient for this dataset: a simple baseline, GRU, or TCN?
+4. Does exported browser inference preserve the behavior of the research implementation?
+
+## Roadmap
+
+The delivery plan is organized into six phases:
+
+0. Preserve and audit the legacy school project.
+1. Build the reproducible, consent-aware data foundation.
+2. Establish trustworthy baselines and continuous evaluation.
+3. Export and validate a portable inference bundle.
+4. Ship the static browser demo and portfolio release.
+5. Add an interactive research platform only if justified.
+
+See [docs/ROADMAP.md](docs/ROADMAP.md), [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md),
+and the linked GitHub Project for the implementation backlog.
+
+## Repository status
+
+This repository is in project-initialization. The first milestone is a reproducible
+legacy audit and a frozen dataset/experiment contract; no headline model result is
+considered valid until those foundations are complete.
+
+## Data and privacy
+
+Raw participant video and contributed feedback are not committed to Git. Private
+data is tracked through DVC pointers and a controlled remote. Public fixtures must
+be synthetic, explicitly consented, or separately licensed.
+
+## License
+
+Code is licensed under the MIT License. Dataset and model artifacts may have
+separate terms documented in their data and model cards.

--- a/README.md
+++ b/README.md
@@ -41,17 +41,19 @@ deferred until a concrete workflow requires them.
 
 ## Roadmap
 
-The delivery plan is organized into six phases:
+The delivery plan is organized into seven phases:
 
 0. Preserve and audit the legacy school project.
 1. Build the reproducible, consent-aware data foundation.
 2. Establish trustworthy baselines and continuous evaluation.
 3. Export and validate a portable inference bundle.
-4. Ship the static browser demo and portfolio release.
-5. Add an interactive research platform only if justified.
+4. Build and validate the static browser demo.
+5. Publish the portfolio release, evidence, and tutorials.
+6. Add an interactive research platform only if justified.
 
 See [docs/ROADMAP.md](docs/ROADMAP.md), [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md),
-and the linked GitHub Project for the implementation backlog.
+and the [SignLab Roadmap](https://github.com/users/peterbucci/projects/5) for the
+implementation backlog.
 
 ## Repository status
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,57 @@
+# Architecture
+
+## Core release
+
+```text
+Raw private videos
+  -> versioned sample manifest and frozen split manifest
+  -> MediaPipe Tasks extraction
+     - image-space and world hand landmarks
+     - selected body anchors
+     - timestamps, validity masks, handedness, confidence
+  -> versioned feature representations
+  -> train -> calibrate -> evaluate -> continuous replay benchmark
+  -> immutable ONNX model bundle
+
+Research surface: Python CLI, DVC, MLflow, Parquet
+Public surface: React/Vite, Web Worker, MediaPipe Tasks, ONNX Runtime Web
+```
+
+## State model
+
+- **Inactive:** no candidate event is currently present; owned by the candidate-event detector.
+- **Other:** a candidate event occurred but is not one of the target gestures; learned negative class.
+- **Abstain:** evidence is insufficient to name a target; calibrated decision policy.
+
+The candidate-event detector, classifier, calibrator, and decision policy are
+versioned and evaluated separately.
+
+## Data contracts
+
+The sample manifest will include stable identifiers for clips, signers, sessions,
+source recordings, devices, capture conditions, handedness, mirroring, consent,
+and checksums. Derived samples inherit the source recording and split.
+
+The model bundle will eventually contain:
+
+```text
+model.onnx
+labels.json
+input-schema.json
+preprocess.json
+segmenter.json
+decision-policy.json
+calibration.json
+manifest.json
+model-card.md
+golden/
+```
+
+## Optional platform
+
+Only after the static release is complete, a local React Studio may call FastAPI
+to start durable Prefect jobs and query MLflow/DuckDB. PostgreSQL and S3-compatible
+storage are introduced only after local SQLite/artifacts become limiting.
+
+The optional platform must reuse the same Python functions and contracts; it must
+not become a second implementation of the pipeline.

--- a/docs/LEGACY_AUDIT_TEMPLATE.md
+++ b/docs/LEGACY_AUDIT_TEMPLATE.md
@@ -1,0 +1,32 @@
+# Legacy audit
+
+## Snapshot
+
+- Git commit/tag:
+- Dataset inventory and checksum:
+- Number of signers and sessions:
+- Run inventory:
+- Promoted models:
+- Live-feedback attempts:
+
+## Reported results
+
+Record the original split, sample counts, exact preprocessing, model configuration,
+seed, checkpoint-selection rule, and integer confusion matrix—not only percentages.
+
+## Known limitations
+
+- Random clip-level rather than signer/session-grouped evaluation.
+- Small test set where a single prediction materially changes rankings.
+- Legacy `nothing`/label-map mismatch.
+- Potential training/live preprocessing drift.
+- First-detected-hand extraction and repeated last-valid frames.
+- Historically mislabeled `legacy_dense_temporal` model.
+
+## Preservation outputs
+
+- Run index and summary table.
+- Promoted model bundles and hashes.
+- Exported feedback/replay corpus.
+- Preprocessing plans and label maps.
+- Reproduction notes and environment record.

--- a/docs/PROJECT_BOARD.md
+++ b/docs/PROJECT_BOARD.md
@@ -1,7 +1,8 @@
 # Project board
 
-The GitHub Project is the delivery source of truth. Work is organized by phase,
-priority, status, and effort; repository labels identify technical areas.
+The [SignLab Roadmap](https://github.com/users/peterbucci/projects/5) is the delivery
+source of truth. Work is organized by phase, priority, status, and effort;
+repository labels identify technical areas.
 
 ## Workflow
 

--- a/docs/PROJECT_BOARD.md
+++ b/docs/PROJECT_BOARD.md
@@ -1,0 +1,31 @@
+# Project board
+
+The GitHub Project is the delivery source of truth. Work is organized by phase,
+priority, status, and effort; repository labels identify technical areas.
+
+## Workflow
+
+- **Backlog:** accepted work that is not yet ready to start.
+- **Ready:** scoped, dependency-ready, and acceptance criteria are testable.
+- **In progress:** actively owned work; keep work-in-progress deliberately small.
+- **In review:** implementation and evidence are ready for review.
+- **Done:** acceptance criteria and the repository definition of done are satisfied.
+
+## Priority
+
+- **P0:** required to protect validity, privacy, or the critical path.
+- **P1:** required for the first credible public release.
+- **P2:** valuable follow-up after the first release.
+- **P3:** explicitly deferred or optional platform work.
+
+## Effort
+
+- **S:** usually a focused change with limited integration risk.
+- **M:** several coordinated changes or a bounded experiment.
+- **L:** cross-cutting work that should be decomposed before implementation.
+
+## Phase gates
+
+The board intentionally prevents platform infrastructure from competing with the
+scientific and browser-release critical path. Optional-platform stories remain P3
+until the static public release is complete and a concrete workflow justifies them.

--- a/docs/PROJECT_CHARTER.md
+++ b/docs/PROJECT_CHARTER.md
@@ -1,0 +1,51 @@
+# Project charter
+
+## Problem
+
+The legacy application successfully demonstrated five hand gestures, model
+experimentation, live segmentation, and user feedback. Its results are difficult
+to reproduce or generalize because experiment artifacts outgrew the UI, clips were
+not grouped by signer/session during evaluation, inference preprocessing could
+drift from training, and idle/unknown behavior was underspecified.
+
+## Product claim
+
+Until validated by fluent signers and a documented language source, SignLab is:
+
+> A five-class isolated hand-gesture recognition system with continuous webcam
+> segmentation and calibrated rejection.
+
+It is not described as sign-language translation, a complete accessibility
+solution, or a system that understands a sign language.
+
+## Primary outcome
+
+A recruiter or reviewer can open a URL, understand the research question and
+limitations, run the model locally in their browser, and trace every published
+metric to a reproducible dataset, split, configuration, commit, and model bundle.
+
+## Success measures
+
+- Signer-held-out macro-F1 and per-class recall.
+- Event-level precision, recall, and F1 on continuous sessions.
+- False activations per hour on negative-only sessions.
+- Coverage and accepted error rate at the deployed rejection policy.
+- p50/p95 landmark, model, and post-gesture decision latency.
+- Python/ONNX/TypeScript prediction parity within declared tolerances.
+- A clean clone can run a synthetic end-to-end fixture in CI.
+
+## Non-goals for the core release
+
+- Continuous sign-language translation.
+- Public cloud training or server-side video inference.
+- A large model zoo or unbounded hyperparameter sweeps.
+- Kubernetes, microservice sprawl, or a desktop installer.
+- Uploading webcam frames by default.
+
+## Operating principles
+
+1. The CLI and versioned contracts are the source of truth; UIs only invoke or present them.
+2. Preserve raw signals and derive representations in versioned feature stages.
+3. Never select a model or threshold using the locked final test set.
+4. Prefer one justified experiment over a broad architecture sweep.
+5. Make privacy, consent, failure modes, and limitations visible in the product.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -23,13 +23,18 @@ and report signer/session-level uncertainty and runtime metrics through MLflow.
 Define the model-bundle schema, export ONNX, and validate Python-to-ONNX,
 Python-to-TypeScript feature, decision-policy, and continuous-replay parity.
 
-## Phase 4 — Browser and portfolio release
+## Phase 4 — Browser demo
 
 Build a static React application with worker-based camera/replay inference, local
-feedback, curated results, model/data cards, accessibility guidance, performance
-budgets, CI, deployment, and a short demonstration video.
+feedback, accessibility guidance, performance budgets, deterministic replay, and
+cross-browser validation.
 
-## Phase 5 — Optional research platform
+## Phase 5 — Portfolio release
+
+Publish curated results, model/data cards, limitations, reproducibility tutorials,
+CI-backed deployment, rollback guidance, and a short captioned demonstration video.
+
+## Phase 6 — Optional research platform
 
 If a real interactive workflow justifies it, add FastAPI, Prefect, SSE progress,
 DuckDB error analysis, PostgreSQL/object storage, and custom Studio features that

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,43 @@
+# Roadmap
+
+## Phase 0 — Preserve and audit
+
+Archive the legacy repository, inventory runs and promoted models, export live
+feedback, reproduce reported results, and publish an honest baseline report with
+known limitations.
+
+## Phase 1 — Reproducible data foundation
+
+Define consent-aware manifests, DVC versioning, grouped split generation, a shared
+MediaPipe Tasks extractor, raw landmark/timestamp/mask storage, quality validation,
+and a pilot multi-signer collection protocol.
+
+## Phase 2 — Trustworthy ML core
+
+Implement a simple baseline, GRU and TCN; evaluate representation ablations;
+collect hard negatives; calibrate abstention; implement continuous event matching;
+and report signer/session-level uncertainty and runtime metrics through MLflow.
+
+## Phase 3 — Portable inference
+
+Define the model-bundle schema, export ONNX, and validate Python-to-ONNX,
+Python-to-TypeScript feature, decision-policy, and continuous-replay parity.
+
+## Phase 4 — Browser and portfolio release
+
+Build a static React application with worker-based camera/replay inference, local
+feedback, curated results, model/data cards, accessibility guidance, performance
+budgets, CI, deployment, and a short demonstration video.
+
+## Phase 5 — Optional research platform
+
+If a real interactive workflow justifies it, add FastAPI, Prefect, SSE progress,
+DuckDB error analysis, PostgreSQL/object storage, and custom Studio features that
+MLflow does not already provide.
+
+## Milestone gates
+
+- Do not tune architectures before split-leakage tests pass.
+- Do not publish accuracy before signer/session-held-out evaluation exists.
+- Do not build the browser demo before an immutable bundle and parity fixtures exist.
+- Do not build the optional platform before the static public release is complete.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "signlab"
+version = "0.1.0"
+description = "Reproducible hand-gesture recognition research and browser inference"
+readme = "README.md"
+requires-python = ">=3.12"
+license = { text = "MIT" }
+authors = [{ name = "Peter Bucci" }]
+dependencies = []
+
+[project.scripts]
+signlab = "signlab.cli:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/signlab"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]

--- a/src/signlab/__init__.py
+++ b/src/signlab/__init__.py
@@ -1,0 +1,3 @@
+"""SignLab research and inference package."""
+
+__version__ = "0.1.0"

--- a/src/signlab/cli.py
+++ b/src/signlab/cli.py
@@ -1,0 +1,25 @@
+"""Command-line entry point for the UI-independent SignLab pipeline."""
+
+from __future__ import annotations
+
+import argparse
+
+from signlab import __version__
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="signlab",
+        description="Reproducible hand-gesture recognition research pipeline.",
+    )
+    parser.add_argument("--version", action="version", version=__version__)
+    return parser
+
+
+def main() -> None:
+    """Run the SignLab command-line interface."""
+    build_parser().parse_args()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,0 +1,10 @@
+from signlab import __version__
+from signlab.cli import build_parser
+
+
+def test_package_version_is_exposed() -> None:
+    assert __version__ == "0.1.0"
+
+
+def test_cli_parser_has_expected_program_name() -> None:
+    assert build_parser().prog == "signlab"


### PR DESCRIPTION
## Outcome

Establishes the initial SignLab project charter, architecture, roadmap, repository workflow, Python package skeleton, privacy-aware ignore rules, and GitHub contribution templates.

## Validation

- CLI version smoke test passes with `PYTHONPATH=src python -m signlab.cli --version`.
- Python source and tests compile successfully.
- No raw participant data, model artifacts, credentials, or machine-specific paths are included.

This is intentionally a planning and packaging foundation; implementation work will be tracked on the SignLab Roadmap project.