### PR TITLE
Export portable legacy evidence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,5 @@ mlruns/
 !tests/fixtures/
 !tests/fixtures/public/
 !tests/fixtures/public/**
+!docs/legacy/export/v1/runs/
+!docs/legacy/export/v1/runs/*.json

--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ uv run python scripts/verify_distribution.py dist
 See [docs/development.md](docs/development.md) for directory ownership, dependency
 updates, generated-file policy, and the Python-version decision.
 
+The [legacy audit](docs/legacy-audit.md) and
+[portable evidence export](docs/legacy-export.md) document what was retained from
+the school project, why it is development-only, and how to validate it without any
+legacy application dependencies.
+
 ## Research questions
 
 1. Does body-relative context improve signer-held-out generalization?
@@ -87,15 +92,17 @@ implementation backlog.
 
 ## Repository status
 
-The immutable legacy audit and reproducible developer foundation are established.
-Dataset, experiment, and bundle contracts are still under construction; no headline
-model result is considered valid until the grouped evaluation foundations are complete.
+The immutable legacy audit, reproducible developer foundation, and sanitized legacy
+evidence export are established. Taxonomy and core contracts are still under
+construction; no headline model result is considered valid until the grouped
+evaluation foundations are complete.
 
 ## Data and privacy
 
-Raw participant video and contributed feedback are not committed to Git. Private
-data is tracked through DVC pointers and a controlled remote. Public fixtures must
-be synthetic, explicitly consented, or separately licensed.
+Raw participant video and contributed feedback are not committed to Git. The legacy
+quarantine is currently local-only and explicitly not a durable backup; a later
+private-DVC story will place approved data behind a controlled remote. Public fixtures
+must be synthetic, explicitly consented, or separately licensed.
 
 ## License
 

--- a/docs/legacy-audit.md
+++ b/docs/legacy-audit.md
@@ -125,10 +125,10 @@ was therefore repeatedly inspected and cannot serve as a locked final test set.
 | Asset | Decision | Rationale |
 | --- | --- | --- |
 | Exact Git commit | Preserve by hash | Historical code and behavior reference |
-| Four live-imported model files | Preserve hashes; export under #8 | Useful parity and regression candidates, not champions |
-| Run summaries, predictions, configs, label maps | Sanitize and index under #8 | Reproduces historical integer outcomes and failure cases |
+| Four live-imported model files | Preserved in the #8 quarantine with public hashes | Useful parity and regression candidates, not champions |
+| Run summaries, predictions, configs, label maps | Sanitized and indexed by #8 | Reproduces historical integer outcomes and failure cases |
 | Preprocessing plans | Preserve as historical evidence | Inputs for parity tests; not yet portable contracts |
-| Feedback and live attempts | Quarantine and sanitize under #8 | Previously inspected development data with privacy risk |
+| Feedback and live attempts | Quarantined and sanitized by #8 | Previously inspected development data with privacy risk |
 | Raw videos | Do not migrate until consent review | Unknown redistribution/training scope |
 | Derived landmarks | Re-create from approved media | Extractor/version provenance is incomplete |
 | Sweep checkpoints and old result trees | Retire after compact indexing | High storage cost and invalid selection protocol |
@@ -160,6 +160,10 @@ evidence only; it must never be described as a durable backup.
 These hashes identify the source material for story #8. They do not grant consent,
 make the old evaluation valid, or authorize copying private content. Any exported
 record must be schema-validated, sanitized, and marked as development evidence.
+The resulting two-layer format and standalone validation commands are documented in
+[`docs/legacy-export.md`](legacy-export.md). The committed layer contains only
+portable manifests, schemas, aggregate counts, and hashes; participant-derived bytes
+remain in the ignored, local-only quarantine.
 
 ## Baseline conclusion
 

--- a/docs/legacy-export.md
+++ b/docs/legacy-export.md
@@ -1,0 +1,86 @@
+# Legacy evidence export
+
+Story #8 preserves the useful evidence from the school project without importing its
+Streamlit/PyQt architecture or publishing participant-derived artifacts. The export
+has two deliberately separate layers.
+
+## Public evidence layer
+
+`docs/legacy/export/v1/` is safe to review and version in Git. It contains:
+
+- a sharded index of every legacy run, its sanitized configuration and metrics,
+  portable `legacy://` artifact locators, availability, and explicit validity notes;
+- the historical preprocessing plans and label maps used by the four promoted runs;
+- content hashes and sizes for the promoted models, without model bytes;
+- a receipt for the private quarantine, with aggregate counts and component digests;
+- closed JSON Schemas for every public and private record format.
+
+The run index is historical development evidence. Its sample-level split lacked
+signer/session grouping, the saved test split was repeatedly inspected, the trained
+models had no learned negative class, and the legacy `mamba` name did not describe a
+Mamba state-space model. No row is eligible for a locked final-test claim.
+Each row has an ordinal `record_id` and a unique `source_run_id`; the latter rebuilds
+the legacy sweep/run identity used by promoted artifacts and live records, so those
+references can be checked across stores even when the raw `run_name` was reused.
+
+## Private quarantine layer
+
+`data/private/legacy/v1/` is ignored by Git. The exporter creates a deterministic,
+content-addressed quarantine containing:
+
+- the four promoted Keras files and their small metadata inputs;
+- every captured live-evaluation segment as an opaque byte object;
+- all live attempts, annotations, earlier detections, and sessions as sanitized
+  JSON Lines records; and
+- a manifest that binds each `quarantine://sha256/...` URI to its byte count and
+  SHA-256 digest.
+
+The exporter never deserializes a model or landmark array. It opens SQLite sources
+with immutable, query-only connections and copies approved files as bytes. Raw UUIDs,
+database row IDs, participant/live-record wall-clock timestamps, absolute paths,
+free-form notes, and legacy errors are excluded from the sanitized record streams.
+Stable ordinal aliases preserve joins, while relative offsets, duration, confidence,
+prediction, correction, segmentation settings, and source role retain the development
+value of each attempt. Historical training-run and preprocessing-plan timestamps remain
+as non-participant chronology and are never presented as capture times.
+
+Historical label text is preserved exactly in this evidence layer, including the
+spaced `thank you` label and the legacy idle token `nothing`. The taxonomy contract
+defines the explicit import alias and keeps `nothing` quarantined; the exporter does
+not silently relabel either value.
+
+Quarantined feedback and segments are `development-only`; they cannot be used as a
+locked final test. This local copy is not an off-machine backup. A later private-DVC
+story must place it in an authenticated private remote before the legacy source can be
+retired.
+
+## Export and verification
+
+Supply every location explicitly so no command depends on the caller's current
+directory or stores a machine path:
+
+```shell
+uv run signlab data export-legacy --legacy-root <legacy-root> --audit-snapshot docs/legacy/legacy-state.json --public-output docs/legacy/export/v1 --quarantine-output data/private/legacy/v1
+```
+
+The command first matches the source Git/database/artifact fingerprints recorded by
+the immutable audit. Output targets must not already contain files. Generation is
+atomic; a failed export leaves neither a partial public index nor a partial private
+quarantine.
+
+The committed public evidence can be checked on any clone without the legacy project:
+
+```shell
+uv run signlab data validate-legacy --public-root docs/legacy/export/v1
+```
+
+An operator who has the private quarantine can additionally verify its component
+digests and referential integrity:
+
+```shell
+uv run signlab data validate-legacy --public-root docs/legacy/export/v1 --quarantine-root data/private/legacy/v1
+```
+
+Validation rejects unsupported versions, unrecognized fields, broken component
+hashes, nonportable locators, raw identifiers, absolute machine paths, private values
+in the public layer, and count or join mismatches.

--- a/docs/legacy/export/v1/manifest.json
+++ b/docs/legacy/export/v1/manifest.json
@@ -1,0 +1,131 @@
+{
+  "components": [
+    {
+      "bytes": 3827,
+      "path": "preprocessing-plans.json",
+      "records": 3,
+      "sha256": "184aeb6477004204ddbd44e3870034a929fb1880a18c9e731114ea8bb7b4ea5d"
+    },
+    {
+      "bytes": 4790,
+      "path": "promoted-artifacts.json",
+      "records": 4,
+      "sha256": "b034352d8805f8703df5d0cebcae71882a1526dd4a8452879b60eb5bf7fd3ae0"
+    },
+    {
+      "bytes": 1492,
+      "path": "quarantine-receipt.json",
+      "sha256": "59867cda2be825bf237150a35221a688cb9ed358c696604f545de800bea2a7f4"
+    },
+    {
+      "bytes": 437984,
+      "path": "runs/runs-000.json",
+      "records": 100,
+      "sha256": "04c581c88b36345842447b1c24fb95ef03c2b4141c4e9ff13fc755b4d7b7f03a"
+    },
+    {
+      "bytes": 534099,
+      "path": "runs/runs-001.json",
+      "records": 100,
+      "sha256": "f35426618fd07ea252df4b024c9812d3e8747797ada67da4305cd8a161b2f39e"
+    },
+    {
+      "bytes": 542597,
+      "path": "runs/runs-002.json",
+      "records": 100,
+      "sha256": "74461df02ec6d0dc1694dbe76777ada31b6ba62558f1d54bf975918e3b7e191c"
+    },
+    {
+      "bytes": 508328,
+      "path": "runs/runs-003.json",
+      "records": 100,
+      "sha256": "34fe9d9a3dd7cad85a5f92964458f440b2464c11f5273fbe41cceb7e0e7c6ad0"
+    },
+    {
+      "bytes": 329438,
+      "path": "runs/runs-004.json",
+      "records": 64,
+      "sha256": "c2c6ff2c6da385108f3c8d93ad5fa821cefe5cf163fc4ab132b824bb4f259d7a"
+    },
+    {
+      "bytes": 1085,
+      "path": "schemas/annotation.schema.json",
+      "sha256": "578376d66bc4e3c02a223242a07e69750ecb6a669fe695f1844cc3a0b53f7df1"
+    },
+    {
+      "bytes": 1377,
+      "path": "schemas/detection.schema.json",
+      "sha256": "b49811f2542f97705483d970dd7b1ec08687e5c9765244ae15e40eaf842db123"
+    },
+    {
+      "bytes": 2047,
+      "path": "schemas/live-attempt.schema.json",
+      "sha256": "25272bae9a41c9720234ee55e79a746ae57432a47a71165386437606403b8487"
+    },
+    {
+      "bytes": 1977,
+      "path": "schemas/preprocessing-plans.schema.json",
+      "sha256": "e176057e2892387ce5b0a745b368f5fd75de081d89dc2649faebcb830e5c8617"
+    },
+    {
+      "bytes": 3843,
+      "path": "schemas/promoted-artifacts.schema.json",
+      "sha256": "541c9dd65902a172951aaaa0b2d7692ab80a9111081a8821caa32881af818320"
+    },
+    {
+      "bytes": 4202,
+      "path": "schemas/public-manifest.schema.json",
+      "sha256": "1706ab34123067973c229830ebdaa28b8d648a6a5afa5d85de1700612cbce52e"
+    },
+    {
+      "bytes": 4467,
+      "path": "schemas/quarantine-manifest.schema.json",
+      "sha256": "591974703d263728d9a2f42484651e3a8340c90098e06e7318e1a83e60bb94a4"
+    },
+    {
+      "bytes": 3298,
+      "path": "schemas/quarantine-receipt.schema.json",
+      "sha256": "e1febf61a2b6aebf9592d23fc863e87961299d26efee007f8ed8ab4000c3c7c8"
+    },
+    {
+      "bytes": 18139,
+      "path": "schemas/run-index.schema.json",
+      "sha256": "4d8054707d19bd867c725ed6bd2a61f745ff13f728a71a31f2c3713237bd2690"
+    },
+    {
+      "bytes": 707,
+      "path": "schemas/session.schema.json",
+      "sha256": "3862ba02c6343e68b6c662697fe1cce6bf06390256e0416423121cc84a8ec67a"
+    }
+  ],
+  "counts": {
+    "annotated_attempts": 401,
+    "annotations": 408,
+    "attempts": 532,
+    "detections": 45,
+    "orphan_segments": 4,
+    "preprocessing_plans": 3,
+    "promoted_models": 4,
+    "referenced_segments": 525,
+    "runs": 464,
+    "runs_failed": 6,
+    "runs_running": 1,
+    "runs_succeeded": 457,
+    "segments": 529,
+    "sessions": 5,
+    "unannotated_attempts": 131
+  },
+  "kind": "signlab.legacy-public-export",
+  "policy": {
+    "contains_private_artifacts": false,
+    "data_role": "development-only",
+    "durability": "local-only-pending-private-remote",
+    "eligible_for_locked_test": false
+  },
+  "schema_version": 1,
+  "source": {
+    "audit_sha256": "4e107edbbdc95f280e2e33b15083db57b613cbb7c369417a9960a22b11ab4155",
+    "head_commit": "0e630168727e0d526a1f040ce912db26c1cefc72",
+    "tree_object": "828edda9a38ef5bdd0f0e501265482b49de000be"
+  }
+}

--- a/docs/legacy/export/v1/preprocessing-plans.json
+++ b/docs/legacy/export/v1/preprocessing-plans.json
@@ -1,0 +1,143 @@
+{
+  "kind": "signlab.legacy-preprocessing-plans",
+  "plans": {
+    "baseline_pos_handscale_30f": {
+      "created_at": "2025-11-29T17:10:00",
+      "description": "Baseline: centered wrist positions, scaled by hand length, resampled to 30 frames. Good simple starting point for position-only models.",
+      "name": "baseline_pos_handscale_30f",
+      "steps": [
+        {
+          "key": "drop_short_sequences",
+          "params": {}
+        },
+        {
+          "key": "center_wrist",
+          "params": {}
+        },
+        {
+          "key": "scale_by_hand_length",
+          "params": {
+            "ref_landmark": 9
+          }
+        },
+        {
+          "key": "resample_sequence",
+          "params": {
+            "mode": "uniform_pad_zeros",
+            "seq_len": 30
+          }
+        },
+        {
+          "key": "zscore_per_sequence",
+          "params": {}
+        }
+      ],
+      "updated_at": "2025-11-29T17:10:00"
+    },
+    "pos_vel_handscale_smooth_30f": {
+      "created_at": "2025-11-29T17:10:00",
+      "description": "Positions + central velocity with light smoothing, hand-length scale, and 30-frame resampling. Good for signs where motion matters (e.g., yes/no/thank you).",
+      "name": "pos_vel_handscale_smooth_30f",
+      "steps": [
+        {
+          "key": "drop_short_sequences",
+          "params": {}
+        },
+        {
+          "key": "center_wrist",
+          "params": {}
+        },
+        {
+          "key": "scale_by_hand_length",
+          "params": {
+            "ref_landmark": 9
+          }
+        },
+        {
+          "key": "smooth_moving_average",
+          "params": {
+            "window": 3
+          }
+        },
+        {
+          "key": "resample_sequence",
+          "params": {
+            "mode": "uniform_or_tile_if_T1",
+            "seq_len": 30
+          }
+        },
+        {
+          "key": "add_central_velocity",
+          "params": {}
+        },
+        {
+          "key": "zscore_per_sequence",
+          "params": {}
+        }
+      ],
+      "updated_at": "2025-11-29T17:10:00"
+    },
+    "shape_motion_angles_robust_30f": {
+      "created_at": "2025-11-29T17:10:00",
+      "description": "Rotation-normalized positions + motion + shape descriptors (pairwise distances, finger angles), with smoothing and clipping. Designed to be robust to orientation/scale and small jitters for subtle sign distinctions.",
+      "name": "shape_motion_angles_robust_30f",
+      "steps": [
+        {
+          "key": "drop_short_sequences",
+          "params": {}
+        },
+        {
+          "key": "center_wrist",
+          "params": {}
+        },
+        {
+          "key": "canonical_rotate_wrist_middle",
+          "params": {
+            "ref_landmark": 9
+          }
+        },
+        {
+          "key": "scale_global_max_abs",
+          "params": {}
+        },
+        {
+          "key": "smooth_moving_average",
+          "params": {
+            "window": 3
+          }
+        },
+        {
+          "key": "resample_sequence",
+          "params": {
+            "mode": "uniform_pad_zeros",
+            "seq_len": 30
+          }
+        },
+        {
+          "key": "add_central_velocity",
+          "params": {}
+        },
+        {
+          "key": "add_pairwise_distances",
+          "params": {}
+        },
+        {
+          "key": "add_finger_angles",
+          "params": {}
+        },
+        {
+          "key": "clip_max_abs",
+          "params": {}
+        },
+        {
+          "key": "zscore_per_sequence",
+          "params": {}
+        }
+      ],
+      "updated_at": "2025-11-29T17:10:00"
+    }
+  },
+  "quarantine_uri": "quarantine://sha256/5a727cc6218dcc2f82cb72cdec00bd7348f1f9d924677011548e2200d32cea0d.json",
+  "schema_version": 1,
+  "source_sha256": "5a727cc6218dcc2f82cb72cdec00bd7348f1f9d924677011548e2200d32cea0d"
+}

--- a/docs/legacy/export/v1/promoted-artifacts.json
+++ b/docs/legacy/export/v1/promoted-artifacts.json
@@ -1,0 +1,135 @@
+{
+  "artifacts": [
+    {
+      "label_map": {
+        "bytes": 88,
+        "labels": {
+          "0": "hello",
+          "1": "no",
+          "2": "please",
+          "3": "thank you",
+          "4": "yes"
+        },
+        "quarantine_uri": "quarantine://sha256/c0a1e624ee1d6353d6377c2391030df15106ec2bea193323c07f0da1a4c9499d.json",
+        "sha256": "c0a1e624ee1d6353d6377c2391030df15106ec2bea193323c07f0da1a4c9499d"
+      },
+      "model": {
+        "bytes": 2428032,
+        "quarantine_uri": "quarantine://sha256/f69c07838a477df0853a6cdb71b1acb9a933e0de1491359da0cae5462584e46c.keras",
+        "sha256": "f69c07838a477df0853a6cdb71b1acb9a933e0de1491359da0cae5462584e46c",
+        "storage_status": "local-quarantine"
+      },
+      "model_key": "causal_gru",
+      "preprocessing_plan": "pos_vel_handscale_smooth_30f",
+      "run_id": "20251222_154233_gru_phase_3_run_001",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "notes": [
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "parity-candidate-not-champion"
+        ]
+      }
+    },
+    {
+      "label_map": {
+        "bytes": 88,
+        "labels": {
+          "0": "hello",
+          "1": "no",
+          "2": "please",
+          "3": "thank you",
+          "4": "yes"
+        },
+        "quarantine_uri": "quarantine://sha256/c0a1e624ee1d6353d6377c2391030df15106ec2bea193323c07f0da1a4c9499d.json",
+        "sha256": "c0a1e624ee1d6353d6377c2391030df15106ec2bea193323c07f0da1a4c9499d"
+      },
+      "model": {
+        "bytes": 3210098,
+        "quarantine_uri": "quarantine://sha256/b175174c2daa4ccd33bb9fb49120d7399a61aab95c3bdfa378ba40aa57ace7ee.keras",
+        "sha256": "b175174c2daa4ccd33bb9fb49120d7399a61aab95c3bdfa378ba40aa57ace7ee",
+        "storage_status": "local-quarantine"
+      },
+      "model_key": "causal_lstm",
+      "preprocessing_plan": "pos_vel_handscale_smooth_30f",
+      "run_id": "20251222_161016_lstm_phase_c_run_003",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "notes": [
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "parity-candidate-not-champion"
+        ]
+      }
+    },
+    {
+      "label_map": {
+        "bytes": 88,
+        "labels": {
+          "0": "hello",
+          "1": "no",
+          "2": "please",
+          "3": "thank you",
+          "4": "yes"
+        },
+        "quarantine_uri": "quarantine://sha256/c0a1e624ee1d6353d6377c2391030df15106ec2bea193323c07f0da1a4c9499d.json",
+        "sha256": "c0a1e624ee1d6353d6377c2391030df15106ec2bea193323c07f0da1a4c9499d"
+      },
+      "model": {
+        "bytes": 2458533,
+        "quarantine_uri": "quarantine://sha256/d5e3d15cead7436342c15229e94a6becdfd41b1254f3caa5332cf64ad9cf3f0c.keras",
+        "sha256": "d5e3d15cead7436342c15229e94a6becdfd41b1254f3caa5332cf64ad9cf3f0c",
+        "storage_status": "local-quarantine"
+      },
+      "model_key": "causal_tcn",
+      "preprocessing_plan": "pos_vel_handscale_smooth_30f",
+      "run_id": "20251222_162425_tcn_phase_c_run_003",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "notes": [
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "parity-candidate-not-champion"
+        ]
+      }
+    },
+    {
+      "label_map": {
+        "bytes": 88,
+        "labels": {
+          "0": "hello",
+          "1": "no",
+          "2": "please",
+          "3": "thank you",
+          "4": "yes"
+        },
+        "quarantine_uri": "quarantine://sha256/c0a1e624ee1d6353d6377c2391030df15106ec2bea193323c07f0da1a4c9499d.json",
+        "sha256": "c0a1e624ee1d6353d6377c2391030df15106ec2bea193323c07f0da1a4c9499d"
+      },
+      "model": {
+        "bytes": 467230,
+        "quarantine_uri": "quarantine://sha256/89647b516068950818bffabb9c269f31bef924bdcce0230ea509af9fea17559e.keras",
+        "sha256": "89647b516068950818bffabb9c269f31bef924bdcce0230ea509af9fea17559e",
+        "storage_status": "local-quarantine"
+      },
+      "model_key": "mamba",
+      "preprocessing_plan": "pos_vel_handscale_smooth_30f",
+      "run_id": "20251222_163528_mamba_phase_c_run_001",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "notes": [
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "parity-candidate-not-champion",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    }
+  ],
+  "kind": "signlab.legacy-promoted-artifacts",
+  "schema_version": 1
+}

--- a/docs/legacy/export/v1/quarantine-receipt.json
+++ b/docs/legacy/export/v1/quarantine-receipt.json
@@ -1,0 +1,55 @@
+{
+  "components": [
+    {
+      "bytes": 208692,
+      "path": "manifest.json",
+      "sha256": "afb191e2602df4af78c7a9b6c56f0bf9c296abd5bf7a9d8d1527db7a93e191aa"
+    },
+    {
+      "bytes": 356220,
+      "path": "records/attempts.jsonl",
+      "records": 532,
+      "sha256": "c15dbc64e5f7186f101d58ed9a8ed75be7f2ac6871b8793e1b031b57ef5f40c4"
+    },
+    {
+      "bytes": 79681,
+      "path": "records/annotations.jsonl",
+      "records": 408,
+      "sha256": "5f8af684f83cfeacedcff2c6ea57596883c7b616dc7ec627b2ef84445c6981fb"
+    },
+    {
+      "bytes": 787,
+      "path": "records/sessions.jsonl",
+      "records": 5,
+      "sha256": "5aa1ea9984fd8aeb6edf8328fe0e50ca78dd5082f5f285f2afb6c7ea0ada4606"
+    },
+    {
+      "bytes": 9238,
+      "path": "records/detections.jsonl",
+      "records": 45,
+      "sha256": "8fc9136d9eaaff058680f010b77c9f3dd1dafa84b2990999727d5a08747ce252"
+    }
+  ],
+  "counts": {
+    "annotated_attempts": 401,
+    "annotations": 408,
+    "attempts": 532,
+    "detections": 45,
+    "orphan_segments": 4,
+    "promoted_models": 4,
+    "quarantine_objects": 535,
+    "referenced_segments": 525,
+    "segments": 529,
+    "sessions": 5,
+    "unannotated_attempts": 131
+  },
+  "kind": "signlab.legacy-quarantine-receipt",
+  "policy": {
+    "contains_individual_object_hashes": false,
+    "data_role": "development-only",
+    "durability": "local-only-pending-private-remote",
+    "eligible_for_locked_test": false,
+    "publishable": false
+  },
+  "schema_version": 1
+}

--- a/docs/legacy/export/v1/runs/runs-000.json
+++ b/docs/legacy/export/v1/runs/runs-000.json
@@ -1,0 +1,12980 @@
+{
+  "kind": "signlab.legacy-run-index",
+  "records": [
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "not-recorded",
+          "registered_locator": null,
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251128_172059",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "not-recorded",
+          "registered_locator": null,
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "not-recorded",
+          "registered_locator": null,
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "not-recorded",
+          "registered_locator": null,
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "not-recorded",
+          "registered_locator": null,
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "not-recorded",
+          "registered_locator": null,
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 33,
+        "data_locator": "legacy://data/landmarks/pos_vel_angles_augmented_v1",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 33,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/pos_vel_angles_augmented_v1",
+          "epochs": 30,
+          "fps": 15,
+          "seq_len": 32,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "seq_window": 32
+        },
+        "sequence_length": 32,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-11-28T22:21:07",
+      "metrics": {
+        "quick": null,
+        "samples_test": null,
+        "samples_train": null,
+        "samples_validation": null,
+        "test_accuracy": null,
+        "test_loss": null
+      },
+      "model_key": "mamba",
+      "record_id": "run-000001",
+      "run_name": "mamba_20251128_172059",
+      "source_run_id": "mamba_20251128_172059",
+      "started_at": "2025-11-28T22:21:06",
+      "status": "failed",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": true,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name",
+          "failed-run"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "not-recorded",
+          "registered_locator": null,
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251128_172125",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "not-recorded",
+          "registered_locator": null,
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "not-recorded",
+          "registered_locator": null,
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "not-recorded",
+          "registered_locator": null,
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "not-recorded",
+          "registered_locator": null,
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "not-recorded",
+          "registered_locator": null,
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 33,
+        "data_locator": "legacy://data/landmarks/pos_vel_angles_augmented_v1",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 33,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/pos_vel_angles_augmented_v1",
+          "epochs": 30,
+          "fps": 15,
+          "seq_len": 32,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 32
+        },
+        "sequence_length": 32,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-11-28T22:21:32",
+      "metrics": {
+        "quick": null,
+        "samples_test": null,
+        "samples_train": null,
+        "samples_validation": null,
+        "test_accuracy": null,
+        "test_loss": null
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000002",
+      "run_name": "causal_lstm_20251128_172125",
+      "source_run_id": "causal_lstm_20251128_172125",
+      "started_at": "2025-11-28T22:21:26",
+      "status": "failed",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": true,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "failed-run"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251128_172328/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251128_172328",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251128_172328/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251128_172328/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251128_172328/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251128_172328/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251128_172328/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 33,
+        "data_locator": "legacy://data/landmarks/pos_vel_angles_augmented_v1",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 33,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/pos_vel_angles_augmented_v1",
+          "epochs": 30,
+          "fps": 15,
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "seq_window": 32
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-11-28T22:23:56",
+      "metrics": {
+        "quick": {
+          "num_classes": 5,
+          "samples_test": 38,
+          "samples_train": 172,
+          "samples_val": 37,
+          "test_accuracy": 0.28947368264198303,
+          "test_loss": 1.5511003732681274
+        },
+        "samples_test": 38,
+        "samples_train": 172,
+        "samples_validation": 37,
+        "test_accuracy": 0.28947368264198303,
+        "test_loss": 1.5511003732681274
+      },
+      "model_key": "mamba",
+      "record_id": "run-000003",
+      "run_name": "mamba_20251128_172328",
+      "source_run_id": "mamba_20251128_172328",
+      "started_at": "2025-11-28T22:23:28",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251128_172534/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251128_172534",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251128_172534/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251128_172534/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251128_172534/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251128_172534/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251128_172534/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 33,
+        "data_locator": "legacy://data/landmarks/pos_vel_angles_augmented_v1",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 33,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/pos_vel_angles_augmented_v1",
+          "epochs": 30,
+          "fps": 15,
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.2,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "num_layers": 3,
+          "seq_window": 32
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-11-28T22:25:46",
+      "metrics": {
+        "quick": {
+          "num_classes": 5,
+          "samples_test": 38,
+          "samples_train": 172,
+          "samples_val": 37,
+          "test_accuracy": 0.6842105388641357,
+          "test_loss": 1.0509858131408691
+        },
+        "samples_test": 38,
+        "samples_train": 172,
+        "samples_validation": 37,
+        "test_accuracy": 0.6842105388641357,
+        "test_loss": 1.0509858131408691
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000004",
+      "run_name": "causal_tcn_20251128_172534",
+      "source_run_id": "causal_tcn_20251128_172534",
+      "started_at": "2025-11-28T22:25:34",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251129_162528/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251129_162528",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251129_162528/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251129_162528/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251129_162528/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251129_162528/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251129_162528/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_angles_augmented_v1",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "causal_tcn",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/pos_vel_angles_augmented_v1",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.2,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-11-29T21:25:57",
+      "metrics": {
+        "quick": {
+          "num_classes": 5,
+          "samples_test": 38,
+          "samples_train": 172,
+          "samples_val": 37,
+          "test_accuracy": 0.7105262875556946,
+          "test_loss": 0.9820199012756348
+        },
+        "samples_test": 38,
+        "samples_train": 172,
+        "samples_validation": 37,
+        "test_accuracy": 0.7105262875556946,
+        "test_loss": 0.9820199012756348
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000005",
+      "run_name": "causal_tcn_20251129_162528",
+      "source_run_id": "causal_tcn_20251129_162528",
+      "started_at": "2025-11-29T21:25:29",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251129_162615/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251129_162615",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251129_162615/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251129_162615/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251129_162615/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251129_162615/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251129_162615/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_angles_augmented_v1",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "causal_tcn",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/pos_vel_angles_augmented_v1",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "layer",
+          "seq_window": 30,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-11-29T21:26:48",
+      "metrics": {
+        "quick": {
+          "num_classes": 5,
+          "samples_test": 38,
+          "samples_train": 172,
+          "samples_val": 37,
+          "test_accuracy": 0.4736842215061188,
+          "test_loss": 1.1512912511825562
+        },
+        "samples_test": 38,
+        "samples_train": 172,
+        "samples_validation": 37,
+        "test_accuracy": 0.4736842215061188,
+        "test_loss": 1.1512912511825562
+      },
+      "model_key": "mamba",
+      "record_id": "run-000006",
+      "run_name": "mamba_20251129_162615",
+      "source_run_id": "mamba_20251129_162615",
+      "started_at": "2025-11-29T21:26:15",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251129_162911/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251129_162911",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251129_162911/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251129_162911/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251129_162911/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251129_162911/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251129_162911/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_angles_augmented_v1",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "causal_tcn",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/pos_vel_angles_augmented_v1",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-11-29T21:29:55",
+      "metrics": {
+        "quick": {
+          "num_classes": 5,
+          "samples_test": 38,
+          "samples_train": 172,
+          "samples_val": 37,
+          "test_accuracy": 0.6315789222717285,
+          "test_loss": 0.9695963859558105
+        },
+        "samples_test": 38,
+        "samples_train": 172,
+        "samples_validation": 37,
+        "test_accuracy": 0.6315789222717285,
+        "test_loss": 0.9695963859558105
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000007",
+      "run_name": "causal_gru_20251129_162911",
+      "source_run_id": "causal_gru_20251129_162911",
+      "started_at": "2025-11-29T21:29:12",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251129_163001/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251129_163001",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251129_163001/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251129_163001/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251129_163001/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251129_163001/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251129_163001/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_angles_augmented_v1",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "causal_tcn",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/pos_vel_angles_augmented_v1",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-11-29T21:30:35",
+      "metrics": {
+        "quick": {
+          "num_classes": 5,
+          "samples_test": 38,
+          "samples_train": 172,
+          "samples_val": 37,
+          "test_accuracy": 0.31578946113586426,
+          "test_loss": 1.5833097696304321
+        },
+        "samples_test": 38,
+        "samples_train": 172,
+        "samples_validation": 37,
+        "test_accuracy": 0.31578946113586426,
+        "test_loss": 1.5833097696304321
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000008",
+      "run_name": "causal_lstm_20251129_163001",
+      "source_run_id": "causal_lstm_20251129_163001",
+      "started_at": "2025-11-29T21:30:01",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251129_172423/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251129_172423",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251129_172423/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251129_172423/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251129_172423/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251129_172423/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251129_172423/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/baseline_pos_handscale_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "causal_tcn",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/baseline_pos_handscale_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-11-29T22:24:59",
+      "metrics": {
+        "quick": {
+          "num_classes": 5,
+          "samples_test": 38,
+          "samples_train": 172,
+          "samples_val": 37,
+          "test_accuracy": 0.3684210479259491,
+          "test_loss": 1.3112021684646606
+        },
+        "samples_test": 38,
+        "samples_train": 172,
+        "samples_validation": 37,
+        "test_accuracy": 0.3684210479259491,
+        "test_loss": 1.3112021684646606
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000009",
+      "run_name": "causal_gru_20251129_172423",
+      "source_run_id": "causal_gru_20251129_172423",
+      "started_at": "2025-11-29T22:24:23",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251129_172505/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251129_172505",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251129_172505/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251129_172505/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251129_172505/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251129_172505/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251129_172505/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/baseline_pos_handscale_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "causal_tcn",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/baseline_pos_handscale_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-11-29T22:25:40",
+      "metrics": {
+        "quick": {
+          "num_classes": 5,
+          "samples_test": 38,
+          "samples_train": 172,
+          "samples_val": 37,
+          "test_accuracy": 0.3947368562221527,
+          "test_loss": 1.288338303565979
+        },
+        "samples_test": 38,
+        "samples_train": 172,
+        "samples_validation": 37,
+        "test_accuracy": 0.3947368562221527,
+        "test_loss": 1.288338303565979
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000010",
+      "run_name": "causal_lstm_20251129_172505",
+      "source_run_id": "causal_lstm_20251129_172505",
+      "started_at": "2025-11-29T22:25:05",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251129_172545/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251129_172545",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251129_172545/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251129_172545/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251129_172545/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251129_172545/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251129_172545/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/baseline_pos_handscale_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "causal_tcn",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/baseline_pos_handscale_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.2,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-11-29T22:26:31",
+      "metrics": {
+        "quick": {
+          "num_classes": 5,
+          "samples_test": 38,
+          "samples_train": 172,
+          "samples_val": 37,
+          "test_accuracy": 0.6315789222717285,
+          "test_loss": 1.2863810062408447
+        },
+        "samples_test": 38,
+        "samples_train": 172,
+        "samples_validation": 37,
+        "test_accuracy": 0.6315789222717285,
+        "test_loss": 1.2863810062408447
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000011",
+      "run_name": "causal_tcn_20251129_172545",
+      "source_run_id": "causal_tcn_20251129_172545",
+      "started_at": "2025-11-29T22:25:45",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251129_172637/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251129_172637",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251129_172637/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251129_172637/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251129_172637/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251129_172637/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251129_172637/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/baseline_pos_handscale_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "causal_tcn",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/baseline_pos_handscale_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "layer",
+          "seq_window": 30,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-11-29T22:27:12",
+      "metrics": {
+        "quick": {
+          "num_classes": 5,
+          "samples_test": 38,
+          "samples_train": 172,
+          "samples_val": 37,
+          "test_accuracy": 0.7894737124443054,
+          "test_loss": 0.9378470182418823
+        },
+        "samples_test": 38,
+        "samples_train": 172,
+        "samples_validation": 37,
+        "test_accuracy": 0.7894737124443054,
+        "test_loss": 0.9378470182418823
+      },
+      "model_key": "mamba",
+      "record_id": "run-000012",
+      "run_name": "mamba_20251129_172637",
+      "source_run_id": "mamba_20251129_172637",
+      "started_at": "2025-11-29T22:26:37",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251129_173115/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251129_173115",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251129_173115/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251129_173115/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251129_173115/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251129_173115/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251129_173115/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "causal_tcn",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-11-29T22:32:13",
+      "metrics": {
+        "quick": {
+          "num_classes": 5,
+          "samples_test": 38,
+          "samples_train": 172,
+          "samples_val": 37,
+          "test_accuracy": 0.42105263471603394,
+          "test_loss": 1.3096489906311035
+        },
+        "samples_test": 38,
+        "samples_train": 172,
+        "samples_validation": 37,
+        "test_accuracy": 0.42105263471603394,
+        "test_loss": 1.3096489906311035
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000013",
+      "run_name": "causal_gru_20251129_173115",
+      "source_run_id": "causal_gru_20251129_173115",
+      "started_at": "2025-11-29T22:31:22",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251129_173355/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251129_173355",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251129_173355/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251129_173355/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251129_173355/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251129_173355/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251129_173355/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "causal_tcn",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-11-29T22:34:44",
+      "metrics": {
+        "quick": {
+          "num_classes": 5,
+          "samples_test": 38,
+          "samples_train": 172,
+          "samples_val": 37,
+          "test_accuracy": 0.5789473652839661,
+          "test_loss": 1.147775650024414
+        },
+        "samples_test": 38,
+        "samples_train": 172,
+        "samples_validation": 37,
+        "test_accuracy": 0.5789473652839661,
+        "test_loss": 1.147775650024414
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000014",
+      "run_name": "causal_lstm_20251129_173355",
+      "source_run_id": "causal_lstm_20251129_173355",
+      "started_at": "2025-11-29T22:33:55",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251129_173452/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251129_173452",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251129_173452/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251129_173452/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251129_173452/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251129_173452/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251129_173452/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "causal_tcn",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.2,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-11-29T22:35:37",
+      "metrics": {
+        "quick": {
+          "num_classes": 5,
+          "samples_test": 38,
+          "samples_train": 172,
+          "samples_val": 37,
+          "test_accuracy": 0.6052631735801697,
+          "test_loss": 1.143577218055725
+        },
+        "samples_test": 38,
+        "samples_train": 172,
+        "samples_validation": 37,
+        "test_accuracy": 0.6052631735801697,
+        "test_loss": 1.143577218055725
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000015",
+      "run_name": "causal_tcn_20251129_173452",
+      "source_run_id": "causal_tcn_20251129_173452",
+      "started_at": "2025-11-29T22:34:52",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251129_173546/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251129_173546",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251129_173546/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251129_173546/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251129_173546/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251129_173546/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251129_173546/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "causal_tcn",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "layer",
+          "seq_window": 30,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-11-29T22:36:32",
+      "metrics": {
+        "quick": {
+          "num_classes": 5,
+          "samples_test": 38,
+          "samples_train": 172,
+          "samples_val": 37,
+          "test_accuracy": 0.5789473652839661,
+          "test_loss": 1.2030134201049805
+        },
+        "samples_test": 38,
+        "samples_train": 172,
+        "samples_validation": 37,
+        "test_accuracy": 0.5789473652839661,
+        "test_loss": 1.2030134201049805
+      },
+      "model_key": "mamba",
+      "record_id": "run-000016",
+      "run_name": "mamba_20251129_173546",
+      "source_run_id": "mamba_20251129_173546",
+      "started_at": "2025-11-29T22:35:47",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251129_173802/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251129_173802",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251129_173802/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251129_173802/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251129_173802/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251129_173802/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251129_173802/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "causal_tcn",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-11-29T22:38:58",
+      "metrics": {
+        "quick": {
+          "num_classes": 5,
+          "samples_test": 38,
+          "samples_train": 172,
+          "samples_val": 37,
+          "test_accuracy": 0.5789473652839661,
+          "test_loss": 1.216383934020996
+        },
+        "samples_test": 38,
+        "samples_train": 172,
+        "samples_validation": 37,
+        "test_accuracy": 0.5789473652839661,
+        "test_loss": 1.216383934020996
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000017",
+      "run_name": "causal_gru_20251129_173802",
+      "source_run_id": "causal_gru_20251129_173802",
+      "started_at": "2025-11-29T22:38:10",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251129_173910/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251129_173910",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251129_173910/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251129_173910/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251129_173910/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251129_173910/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251129_173910/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "causal_tcn",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-11-29T22:40:01",
+      "metrics": {
+        "quick": {
+          "num_classes": 5,
+          "samples_test": 38,
+          "samples_train": 172,
+          "samples_val": 37,
+          "test_accuracy": 0.6315789222717285,
+          "test_loss": 1.1108866930007935
+        },
+        "samples_test": 38,
+        "samples_train": 172,
+        "samples_validation": 37,
+        "test_accuracy": 0.6315789222717285,
+        "test_loss": 1.1108866930007935
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000018",
+      "run_name": "causal_lstm_20251129_173910",
+      "source_run_id": "causal_lstm_20251129_173910",
+      "started_at": "2025-11-29T22:39:10",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251129_174008/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251129_174008",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251129_174008/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251129_174008/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251129_174008/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251129_174008/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251129_174008/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "causal_tcn",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.2,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-11-29T22:40:56",
+      "metrics": {
+        "quick": {
+          "num_classes": 5,
+          "samples_test": 38,
+          "samples_train": 172,
+          "samples_val": 37,
+          "test_accuracy": 0.7631579041481018,
+          "test_loss": 0.816705584526062
+        },
+        "samples_test": 38,
+        "samples_train": 172,
+        "samples_validation": 37,
+        "test_accuracy": 0.7631579041481018,
+        "test_loss": 0.816705584526062
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000019",
+      "run_name": "causal_tcn_20251129_174008",
+      "source_run_id": "causal_tcn_20251129_174008",
+      "started_at": "2025-11-29T22:40:08",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251129_174105/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251129_174105",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251129_174105/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251129_174105/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251129_174105/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251129_174105/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251129_174105/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "causal_tcn",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "layer",
+          "seq_window": 30,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-11-29T22:41:52",
+      "metrics": {
+        "quick": {
+          "num_classes": 5,
+          "samples_test": 38,
+          "samples_train": 172,
+          "samples_val": 37,
+          "test_accuracy": 0.8157894611358643,
+          "test_loss": 0.7440534830093384
+        },
+        "samples_test": 38,
+        "samples_train": 172,
+        "samples_validation": 37,
+        "test_accuracy": 0.8157894611358643,
+        "test_loss": 0.7440534830093384
+      },
+      "model_key": "mamba",
+      "record_id": "run-000020",
+      "run_name": "mamba_20251129_174105",
+      "source_run_id": "mamba_20251129_174105",
+      "started_at": "2025-11-29T22:41:05",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251205_205056/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251205_205056",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251205_205056/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251205_205056/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251205_205056/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251205_205056/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251205_205056/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "causal_tcn",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-06T01:51:35",
+      "metrics": {
+        "quick": {
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.4893617033958435,
+          "test_loss": 1.5343345403671265
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.4893617033958435,
+        "test_loss": 1.5343345403671265
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000021",
+      "run_name": "causal_gru_20251205_205056",
+      "source_run_id": "causal_gru_20251205_205056",
+      "started_at": "2025-12-06T01:51:03",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251205_205145/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251205_205145",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251205_205145/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251205_205145/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251205_205145/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251205_205145/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251205_205145/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "causal_tcn",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-06T01:52:35",
+      "metrics": {
+        "quick": {
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.6170212626457214,
+          "test_loss": 1.013250470161438
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.6170212626457214,
+        "test_loss": 1.013250470161438
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000022",
+      "run_name": "causal_lstm_20251205_205145",
+      "source_run_id": "causal_lstm_20251205_205145",
+      "started_at": "2025-12-06T01:51:46",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251205_205245/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251205_205245",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251205_205245/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251205_205245/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251205_205245/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251205_205245/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251205_205245/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "causal_tcn",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.2,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-06T01:53:20",
+      "metrics": {
+        "quick": {
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.8297872543334961,
+          "test_loss": 0.5586080551147461
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.8297872543334961,
+        "test_loss": 0.5586080551147461
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000023",
+      "run_name": "causal_tcn_20251205_205245",
+      "source_run_id": "causal_tcn_20251205_205245",
+      "started_at": "2025-12-06T01:52:45",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251205_205326/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251205_205326",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251205_205326/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251205_205326/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251205_205326/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251205_205326/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251205_205326/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "causal_tcn",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "layer",
+          "seq_window": 30,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-06T01:53:47",
+      "metrics": {
+        "quick": {
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7872340679168701,
+          "test_loss": 0.5637014508247375
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7872340679168701,
+        "test_loss": 0.5637014508247375
+      },
+      "model_key": "mamba",
+      "record_id": "run-000024",
+      "run_name": "mamba_20251205_205326",
+      "source_run_id": "mamba_20251205_205326",
+      "started_at": "2025-12-06T01:53:27",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "not-recorded",
+          "registered_locator": null,
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251205_205714",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "not-recorded",
+          "registered_locator": null,
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "not-recorded",
+          "registered_locator": null,
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "not-recorded",
+          "registered_locator": null,
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "not-recorded",
+          "registered_locator": null,
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "not-recorded",
+          "registered_locator": null,
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "layer",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-06T01:57:31",
+      "metrics": {
+        "quick": null,
+        "samples_test": null,
+        "samples_train": null,
+        "samples_validation": null,
+        "test_accuracy": null,
+        "test_loss": null
+      },
+      "model_key": "mamba",
+      "record_id": "run-000025",
+      "run_name": "mamba_20251205_205714",
+      "source_run_id": "mamba_20251205_205714",
+      "started_at": "2025-12-06T01:57:15",
+      "status": "failed",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": true,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name",
+          "failed-run"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251205_205800/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251205_205800",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251205_205800/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251205_205800/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251205_205800/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251205_205800/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251205_205800/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "layer",
+          "seq_window": 30,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-06T01:58:35",
+      "metrics": {
+        "quick": {
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.8085106611251831,
+          "test_loss": 0.7755811810493469
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.8085106611251831,
+        "test_loss": 0.7755811810493469
+      },
+      "model_key": "mamba",
+      "record_id": "run-000026",
+      "run_name": "mamba_20251205_205800",
+      "source_run_id": "mamba_20251205_205800",
+      "started_at": "2025-12-06T01:58:00",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_002557/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_002557",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_002557/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_002557/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_002557/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_002557/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_002557/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "layer",
+          "seq_window": 30,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-06T05:28:03",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "nothing": 1237,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "num_classes": 6,
+          "samples_test": 233,
+          "samples_train": 1082,
+          "samples_val": 232,
+          "test_accuracy": 0.9484978318214417,
+          "test_loss": 0.17698274552822113
+        },
+        "samples_test": 233,
+        "samples_train": 1082,
+        "samples_validation": 232,
+        "test_accuracy": 0.9484978318214417,
+        "test_loss": 0.17698274552822113
+      },
+      "model_key": "mamba",
+      "record_id": "run-000027",
+      "run_name": "mamba_20251206_002557",
+      "source_run_id": "mamba_20251206_002557",
+      "started_at": "2025-12-06T05:26:04",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251206_010432/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251206_010432",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251206_010432/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251206_010432/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251206_010432/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251206_010432/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251206_010432/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-06T06:05:56",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "nothing": 1237,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "num_classes": 6,
+          "samples_test": 233,
+          "samples_train": 1082,
+          "samples_val": 232,
+          "test_accuracy": 0.9570815563201904,
+          "test_loss": 0.20028533041477203
+        },
+        "samples_test": 233,
+        "samples_train": 1082,
+        "samples_validation": 232,
+        "test_accuracy": 0.9570815563201904,
+        "test_loss": 0.20028533041477203
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000028",
+      "run_name": "causal_lstm_20251206_010432",
+      "source_run_id": "causal_lstm_20251206_010432",
+      "started_at": "2025-12-06T06:04:32",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251206_010644/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251206_010644",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251206_010644/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251206_010644/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251206_010644/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251206_010644/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251206_010644/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.2,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-06T06:08:04",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "nothing": 1237,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "num_classes": 6,
+          "samples_test": 233,
+          "samples_train": 1082,
+          "samples_val": 232,
+          "test_accuracy": 0.9356223344802856,
+          "test_loss": 0.2440830022096634
+        },
+        "samples_test": 233,
+        "samples_train": 1082,
+        "samples_validation": 232,
+        "test_accuracy": 0.9356223344802856,
+        "test_loss": 0.2440830022096634
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000029",
+      "run_name": "causal_tcn_20251206_010644",
+      "source_run_id": "causal_tcn_20251206_010644",
+      "started_at": "2025-12-06T06:06:45",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251206_010833/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251206_010833",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251206_010833/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251206_010833/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251206_010833/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251206_010833/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251206_010833/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-06T06:09:55",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "nothing": 1237,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "num_classes": 6,
+          "samples_test": 233,
+          "samples_train": 1082,
+          "samples_val": 232,
+          "test_accuracy": 0.9313304424285889,
+          "test_loss": 0.2539232075214386
+        },
+        "samples_test": 233,
+        "samples_train": 1082,
+        "samples_validation": 232,
+        "test_accuracy": 0.9313304424285889,
+        "test_loss": 0.2539232075214386
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000030",
+      "run_name": "causal_gru_20251206_010833",
+      "source_run_id": "causal_gru_20251206_010833",
+      "started_at": "2025-12-06T06:08:33",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_125929/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_125929",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_125929/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_125929/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_125929/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_125929/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_125929/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "layer",
+          "seq_window": 30,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-06T18:01:20",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "nothing": 1237,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "num_classes": 6,
+          "samples_test": 233,
+          "samples_train": 1082,
+          "samples_val": 232,
+          "test_accuracy": 0.9442059993743896,
+          "test_loss": 0.1816074699163437
+        },
+        "samples_test": 233,
+        "samples_train": 1082,
+        "samples_validation": 232,
+        "test_accuracy": 0.9442059993743896,
+        "test_loss": 0.1816074699163437
+      },
+      "model_key": "mamba",
+      "record_id": "run-000031",
+      "run_name": "mamba_20251206_125929",
+      "source_run_id": "mamba_20251206_125929",
+      "started_at": "2025-12-06T18:00:04",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_130248/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_130248",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_130248/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_130248/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_130248/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_130248/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_130248/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "layer",
+          "seq_window": 30,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-06T18:06:14",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "nothing": 155,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "num_classes": 6,
+          "samples_test": 70,
+          "samples_train": 325,
+          "samples_val": 70,
+          "test_accuracy": 0.800000011920929,
+          "test_loss": 0.7041306495666504
+        },
+        "samples_test": 70,
+        "samples_train": 325,
+        "samples_validation": 70,
+        "test_accuracy": 0.800000011920929,
+        "test_loss": 0.7041306495666504
+      },
+      "model_key": "mamba",
+      "record_id": "run-000032",
+      "run_name": "mamba_20251206_130248",
+      "source_run_id": "mamba_20251206_130248",
+      "started_at": "2025-12-06T18:02:49",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_185131/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_185131",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_185131/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_185131/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_185131/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_185131/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_185131/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "layer",
+          "seq_window": 30,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-06T23:52:46",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "nothing": 155,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "num_classes": 6,
+          "samples_test": 70,
+          "samples_train": 325,
+          "samples_val": 70,
+          "test_accuracy": 0.8428571224212646,
+          "test_loss": 0.6181549429893494
+        },
+        "samples_test": 70,
+        "samples_train": 325,
+        "samples_validation": 70,
+        "test_accuracy": 0.8428571224212646,
+        "test_loss": 0.6181549429893494
+      },
+      "model_key": "mamba",
+      "record_id": "run-000033",
+      "run_name": "mamba_20251206_185131",
+      "source_run_id": "mamba_20251206_185131",
+      "started_at": "2025-12-06T23:51:31",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251206_195804/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251206_195804",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251206_195804/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251206_195804/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251206_195804/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251206_195804/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251206_195804/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-07T00:59:45",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "nothing": 155,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "num_classes": 6,
+          "samples_test": 70,
+          "samples_train": 325,
+          "samples_val": 70,
+          "test_accuracy": 0.7571428418159485,
+          "test_loss": 0.922561526298523
+        },
+        "samples_test": 70,
+        "samples_train": 325,
+        "samples_validation": 70,
+        "test_accuracy": 0.7571428418159485,
+        "test_loss": 0.922561526298523
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000034",
+      "run_name": "causal_gru_20251206_195804",
+      "source_run_id": "causal_gru_20251206_195804",
+      "started_at": "2025-12-07T00:58:04",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251206_200023/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251206_200023",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251206_200023/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251206_200023/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251206_200023/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251206_200023/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_lstm_20251206_200023/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-07T01:01:47",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "nothing": 155,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "num_classes": 6,
+          "samples_test": 70,
+          "samples_train": 325,
+          "samples_val": 70,
+          "test_accuracy": 0.8428571224212646,
+          "test_loss": 0.782684326171875
+        },
+        "samples_test": 70,
+        "samples_train": 325,
+        "samples_validation": 70,
+        "test_accuracy": 0.8428571224212646,
+        "test_loss": 0.782684326171875
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000035",
+      "run_name": "causal_lstm_20251206_200023",
+      "source_run_id": "causal_lstm_20251206_200023",
+      "started_at": "2025-12-07T01:00:23",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251206_200624/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251206_200624",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251206_200624/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251206_200624/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251206_200624/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251206_200624/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_tcn_20251206_200624/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.2,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-07T01:08:29",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "nothing": 155,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "num_classes": 6,
+          "samples_test": 70,
+          "samples_train": 325,
+          "samples_val": 70,
+          "test_accuracy": 0.8571428656578064,
+          "test_loss": 0.613908588886261
+        },
+        "samples_test": 70,
+        "samples_train": 325,
+        "samples_validation": 70,
+        "test_accuracy": 0.8571428656578064,
+        "test_loss": 0.613908588886261
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000036",
+      "run_name": "causal_tcn_20251206_200624",
+      "source_run_id": "causal_tcn_20251206_200624",
+      "started_at": "2025-12-07T01:06:24",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_200928/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_200928",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_200928/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_200928/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_200928/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_200928/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_200928/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "layer",
+          "seq_window": 30,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-07T01:10:46",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "nothing": 155,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "num_classes": 6,
+          "samples_test": 70,
+          "samples_train": 325,
+          "samples_val": 70,
+          "test_accuracy": 0.8428571224212646,
+          "test_loss": 0.6565473675727844
+        },
+        "samples_test": 70,
+        "samples_train": 325,
+        "samples_validation": 70,
+        "test_accuracy": 0.8428571224212646,
+        "test_loss": 0.6565473675727844
+      },
+      "model_key": "mamba",
+      "record_id": "run-000037",
+      "run_name": "mamba_20251206_200928",
+      "source_run_id": "mamba_20251206_200928",
+      "started_at": "2025-12-07T01:09:29",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_202313/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_202313",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_202313/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_202313/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_202313/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_202313/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_202313/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "layer",
+          "seq_window": 30,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-07T01:26:05",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "nothing": 155,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "num_classes": 6,
+          "samples_test": 70,
+          "samples_train": 325,
+          "samples_val": 70,
+          "test_accuracy": 0.8714285492897034,
+          "test_loss": 0.6759920120239258
+        },
+        "samples_test": 70,
+        "samples_train": 325,
+        "samples_validation": 70,
+        "test_accuracy": 0.8714285492897034,
+        "test_loss": 0.6759920120239258
+      },
+      "model_key": "mamba",
+      "record_id": "run-000038",
+      "run_name": "mamba_20251206_202313",
+      "source_run_id": "mamba_20251206_202313",
+      "started_at": "2025-12-07T01:23:13",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_202722/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_202722",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_202722/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_202722/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_202722/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_202722/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_202722/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "layer",
+          "seq_window": 30,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-07T01:27:37",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "nothing": 155,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "nothing": 23,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "nothing": 109,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "nothing": 23,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 6,
+          "samples_test": 70,
+          "samples_train": 325,
+          "samples_val": 70,
+          "test_accuracy": 0.8142856955528259,
+          "test_loss": 0.6190935373306274
+        },
+        "samples_test": 70,
+        "samples_train": 325,
+        "samples_validation": 70,
+        "test_accuracy": 0.8142856955528259,
+        "test_loss": 0.6190935373306274
+      },
+      "model_key": "mamba",
+      "record_id": "run-000039",
+      "run_name": "mamba_20251206_202722",
+      "source_run_id": "mamba_20251206_202722",
+      "started_at": "2025-12-07T01:27:22",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_211836/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_211836",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_211836/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_211836/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_211836/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_211836/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_211836/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "layer",
+          "seq_window": 30,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-07T02:18:46",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "nothing": 155,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "nothing": 23,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "nothing": 109,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "nothing": 23,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 6,
+          "samples_test": 70,
+          "samples_train": 325,
+          "samples_val": 70,
+          "test_accuracy": 0.7857142686843872,
+          "test_loss": 0.7698343396186829
+        },
+        "samples_test": 70,
+        "samples_train": 325,
+        "samples_validation": 70,
+        "test_accuracy": 0.7857142686843872,
+        "test_loss": 0.7698343396186829
+      },
+      "model_key": "mamba",
+      "record_id": "run-000040",
+      "run_name": "mamba_20251206_211836",
+      "source_run_id": "mamba_20251206_211836",
+      "started_at": "2025-12-07T02:18:36",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_211908/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_211908",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_211908/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_211908/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_211908/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_211908/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_211908/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "layer",
+          "seq_window": 30,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-07T02:19:25",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "nothing": 155,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "nothing": 23,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "nothing": 109,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "nothing": 23,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 6,
+          "samples_test": 70,
+          "samples_train": 325,
+          "samples_val": 70,
+          "test_accuracy": 0.8285714387893677,
+          "test_loss": 0.6042263507843018
+        },
+        "samples_test": 70,
+        "samples_train": 325,
+        "samples_validation": 70,
+        "test_accuracy": 0.8285714387893677,
+        "test_loss": 0.6042263507843018
+      },
+      "model_key": "mamba",
+      "record_id": "run-000041",
+      "run_name": "mamba_20251206_211908",
+      "source_run_id": "mamba_20251206_211908",
+      "started_at": "2025-12-07T02:19:09",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_211945/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_211945",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_211945/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_211945/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_211945/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_211945/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_211945/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "layer",
+          "seq_window": 30,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-07T02:19:57",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "nothing": 155,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "nothing": 23,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "nothing": 109,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "nothing": 23,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 6,
+          "samples_test": 70,
+          "samples_train": 325,
+          "samples_val": 70,
+          "test_accuracy": 0.8285714387893677,
+          "test_loss": 0.7397364377975464
+        },
+        "samples_test": 70,
+        "samples_train": 325,
+        "samples_validation": 70,
+        "test_accuracy": 0.8285714387893677,
+        "test_loss": 0.7397364377975464
+      },
+      "model_key": "mamba",
+      "record_id": "run-000042",
+      "run_name": "mamba_20251206_211945",
+      "source_run_id": "mamba_20251206_211945",
+      "started_at": "2025-12-07T02:19:45",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251206_212122/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251206_212122",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251206_212122/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251206_212122/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251206_212122/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251206_212122/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251206_212122/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-07T02:21:38",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "nothing": 155,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "nothing": 23,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "nothing": 109,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "nothing": 23,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 6,
+          "samples_test": 70,
+          "samples_train": 325,
+          "samples_val": 70,
+          "test_accuracy": 0.6857143044471741,
+          "test_loss": 0.9470661878585815
+        },
+        "samples_test": 70,
+        "samples_train": 325,
+        "samples_validation": 70,
+        "test_accuracy": 0.6857143044471741,
+        "test_loss": 0.9470661878585815
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000043",
+      "run_name": "causal_gru_20251206_212122",
+      "source_run_id": "causal_gru_20251206_212122",
+      "started_at": "2025-12-07T02:21:22",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "not-recorded",
+          "registered_locator": null,
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_212323",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "not-recorded",
+          "registered_locator": null,
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "not-recorded",
+          "registered_locator": null,
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "not-recorded",
+          "registered_locator": null,
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "not-recorded",
+          "registered_locator": null,
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "not-recorded",
+          "registered_locator": null,
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "layer",
+          "seq_window": 30,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-07T02:23:24",
+      "metrics": {
+        "quick": null,
+        "samples_test": null,
+        "samples_train": null,
+        "samples_validation": null,
+        "test_accuracy": null,
+        "test_loss": null
+      },
+      "model_key": "mamba",
+      "record_id": "run-000044",
+      "run_name": "mamba_20251206_212323",
+      "source_run_id": "mamba_20251206_212323",
+      "started_at": "2025-12-07T02:23:24",
+      "status": "failed",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": true,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name",
+          "failed-run"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "not-recorded",
+          "registered_locator": null,
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_212410",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "not-recorded",
+          "registered_locator": null,
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "not-recorded",
+          "registered_locator": null,
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "not-recorded",
+          "registered_locator": null,
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "not-recorded",
+          "registered_locator": null,
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "not-recorded",
+          "registered_locator": null,
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "layer",
+          "seq_window": 30,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-07T02:24:10",
+      "metrics": {
+        "quick": null,
+        "samples_test": null,
+        "samples_train": null,
+        "samples_validation": null,
+        "test_accuracy": null,
+        "test_loss": null
+      },
+      "model_key": "mamba",
+      "record_id": "run-000045",
+      "run_name": "mamba_20251206_212410",
+      "source_run_id": "mamba_20251206_212410",
+      "started_at": "2025-12-07T02:24:10",
+      "status": "failed",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": true,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name",
+          "failed-run"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_212706/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_212706",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_212706/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_212706/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_212706/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_212706/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_212706/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "layer",
+          "seq_window": 30,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-07T02:27:21",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "nothing": 155,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "nothing": 23,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "nothing": 109,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "nothing": 23,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 6,
+          "samples_test": 70,
+          "samples_train": 325,
+          "samples_val": 70,
+          "test_accuracy": 0.8428571224212646,
+          "test_loss": 0.5629130005836487
+        },
+        "samples_test": 70,
+        "samples_train": 325,
+        "samples_validation": 70,
+        "test_accuracy": 0.8428571224212646,
+        "test_loss": 0.5629130005836487
+      },
+      "model_key": "mamba",
+      "record_id": "run-000046",
+      "run_name": "mamba_20251206_212706",
+      "source_run_id": "mamba_20251206_212706",
+      "started_at": "2025-12-07T02:27:07",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_212807/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_212807",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_212807/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_212807/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_212807/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_212807/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_212807/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "layer",
+          "seq_window": 30,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-07T02:28:19",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "nothing": 155,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "nothing": 23,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "nothing": 109,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "nothing": 23,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 6,
+          "samples_test": 70,
+          "samples_train": 325,
+          "samples_val": 70,
+          "test_accuracy": 0.8142856955528259,
+          "test_loss": 0.6431686878204346
+        },
+        "samples_test": 70,
+        "samples_train": 325,
+        "samples_validation": 70,
+        "test_accuracy": 0.8142856955528259,
+        "test_loss": 0.6431686878204346
+      },
+      "model_key": "mamba",
+      "record_id": "run-000047",
+      "run_name": "mamba_20251206_212807",
+      "source_run_id": "mamba_20251206_212807",
+      "started_at": "2025-12-07T02:28:07",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_213429/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_213429",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_213429/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_213429/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_213429/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_213429/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_213429/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "layer",
+          "seq_window": 30,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-07T02:34:44",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "nothing": 155,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "nothing": 23,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "nothing": 109,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "nothing": 23,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 6,
+          "samples_test": 70,
+          "samples_train": 325,
+          "samples_val": 70,
+          "test_accuracy": 0.8428571224212646,
+          "test_loss": 0.6056074500083923
+        },
+        "samples_test": 70,
+        "samples_train": 325,
+        "samples_validation": 70,
+        "test_accuracy": 0.8428571224212646,
+        "test_loss": 0.6056074500083923
+      },
+      "model_key": "mamba",
+      "record_id": "run-000048",
+      "run_name": "mamba_20251206_213429",
+      "source_run_id": "mamba_20251206_213429",
+      "started_at": "2025-12-07T02:34:29",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_213518/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_213518",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_213518/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_213518/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_213518/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_213518/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_213518/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "layer",
+          "seq_window": 30,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-07T02:35:31",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "nothing": 155,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "nothing": 23,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "nothing": 109,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "nothing": 23,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 6,
+          "samples_test": 70,
+          "samples_train": 325,
+          "samples_val": 70,
+          "test_accuracy": 0.8142856955528259,
+          "test_loss": 0.6214688420295715
+        },
+        "samples_test": 70,
+        "samples_train": 325,
+        "samples_validation": 70,
+        "test_accuracy": 0.8142856955528259,
+        "test_loss": 0.6214688420295715
+      },
+      "model_key": "mamba",
+      "record_id": "run-000049",
+      "run_name": "mamba_20251206_213518",
+      "source_run_id": "mamba_20251206_213518",
+      "started_at": "2025-12-07T02:35:19",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_213544/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_213544",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_213544/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_213544/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_213544/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_213544/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_213544/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "layer",
+          "seq_window": 30,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-07T02:35:54",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "nothing": 155,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "nothing": 23,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "nothing": 109,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "nothing": 23,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 6,
+          "samples_test": 70,
+          "samples_train": 325,
+          "samples_val": 70,
+          "test_accuracy": 0.8142856955528259,
+          "test_loss": 0.805855393409729
+        },
+        "samples_test": 70,
+        "samples_train": 325,
+        "samples_validation": 70,
+        "test_accuracy": 0.8142856955528259,
+        "test_loss": 0.805855393409729
+      },
+      "model_key": "mamba",
+      "record_id": "run-000050",
+      "run_name": "mamba_20251206_213544",
+      "source_run_id": "mamba_20251206_213544",
+      "started_at": "2025-12-07T02:35:44",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_214300/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_214300",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_214300/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_214300/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_214300/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_214300/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_214300/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "layer",
+          "seq_window": 30,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-07T02:43:14",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "nothing": 155,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "nothing": 23,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "nothing": 109,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "nothing": 23,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 6,
+          "samples_test": 70,
+          "samples_train": 325,
+          "samples_val": 70,
+          "test_accuracy": 0.8285714387893677,
+          "test_loss": 0.5732333064079285
+        },
+        "samples_test": 70,
+        "samples_train": 325,
+        "samples_validation": 70,
+        "test_accuracy": 0.8285714387893677,
+        "test_loss": 0.5732333064079285
+      },
+      "model_key": "mamba",
+      "record_id": "run-000051",
+      "run_name": "mamba_20251206_214300",
+      "source_run_id": "mamba_20251206_214300",
+      "started_at": "2025-12-07T02:43:00",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_214347/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_214347",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_214347/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_214347/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_214347/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_214347/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_214347/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "layer",
+          "seq_window": 30,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-07T02:43:58",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "nothing": 155,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "nothing": 23,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "nothing": 109,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "nothing": 23,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 6,
+          "samples_test": 70,
+          "samples_train": 325,
+          "samples_val": 70,
+          "test_accuracy": 0.8142856955528259,
+          "test_loss": 0.7194518446922302,
+          "train_accuracy": 0.8830769230769231,
+          "val_accuracy": 0.7714285714285715
+        },
+        "samples_test": 70,
+        "samples_train": 325,
+        "samples_validation": 70,
+        "test_accuracy": 0.8142856955528259,
+        "test_loss": 0.7194518446922302
+      },
+      "model_key": "mamba",
+      "record_id": "run-000052",
+      "run_name": "mamba_20251206_214347",
+      "source_run_id": "mamba_20251206_214347",
+      "started_at": "2025-12-07T02:43:47",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_214441/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_214441",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_214441/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_214441/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_214441/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_214441/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_214441/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "layer",
+          "seq_window": 30,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-07T02:44:53",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "nothing": 155,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "nothing": 23,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "nothing": 109,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "nothing": 23,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 6,
+          "samples_test": 70,
+          "samples_train": 325,
+          "samples_val": 70,
+          "test_accuracy": 0.800000011920929,
+          "test_loss": 0.6966045498847961,
+          "train_accuracy": 0.9323076923076923,
+          "val_accuracy": 0.7714285714285715
+        },
+        "samples_test": 70,
+        "samples_train": 325,
+        "samples_validation": 70,
+        "test_accuracy": 0.800000011920929,
+        "test_loss": 0.6966045498847961
+      },
+      "model_key": "mamba",
+      "record_id": "run-000053",
+      "run_name": "mamba_20251206_214441",
+      "source_run_id": "mamba_20251206_214441",
+      "started_at": "2025-12-07T02:44:42",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_214616/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_214616",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_214616/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_214616/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_214616/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_214616/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_214616/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.2,
+          "val_frac": 0.2
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "layer",
+          "seq_window": 30,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-07T02:46:40",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "nothing": 155,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "nothing": 31,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "nothing": 93,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "nothing": 31,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 6,
+          "samples_test": 93,
+          "samples_train": 279,
+          "samples_val": 93,
+          "test_accuracy": 0.8387096524238586,
+          "test_loss": 0.4846296012401581,
+          "train_accuracy": 0.982078853046595,
+          "val_accuracy": 0.8817204301075269
+        },
+        "samples_test": 93,
+        "samples_train": 279,
+        "samples_validation": 93,
+        "test_accuracy": 0.8387096524238586,
+        "test_loss": 0.4846296012401581
+      },
+      "model_key": "mamba",
+      "record_id": "run-000054",
+      "run_name": "mamba_20251206_214616",
+      "source_run_id": "mamba_20251206_214616",
+      "started_at": "2025-12-07T02:46:17",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_222101/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_222101",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_222101/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_222101/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_222101/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_222101/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251206_222101/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.2,
+          "val_frac": 0.2
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "layer",
+          "seq_window": 30,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-07T03:21:18",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "nothing": 155,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "nothing": 31,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "nothing": 93,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "nothing": 31,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 6,
+          "samples_test": 93,
+          "samples_train": 279,
+          "samples_val": 93,
+          "test_accuracy": 0.8494623899459839,
+          "test_loss": 0.48462188243865967,
+          "train_accuracy": 0.978494623655914,
+          "val_accuracy": 0.8387096774193549
+        },
+        "samples_test": 93,
+        "samples_train": 279,
+        "samples_validation": 93,
+        "test_accuracy": 0.8494623899459839,
+        "test_loss": 0.48462188243865967
+      },
+      "model_key": "mamba",
+      "record_id": "run-000055",
+      "run_name": "mamba_20251206_222101",
+      "source_run_id": "mamba_20251206_222101",
+      "started_at": "2025-12-07T03:21:01",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251206_222623/config.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251206_222623/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251206_222623",
+          "resolved_locator": "legacy://data/results_old/mamba_20251206_222623"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251206_222623/history.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251206_222623/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251206_222623/label_map.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251206_222623/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251206_222623/metrics.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251206_222623/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251206_222623/sign_model_best.keras",
+          "resolved_locator": "legacy://data/results_old/mamba_20251206_222623/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251206_222623/predictions.csv",
+          "resolved_locator": "legacy://data/results_old/mamba_20251206_222623/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.2,
+          "val_frac": 0.2
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "layer",
+          "seq_window": 30,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-07T03:26:39",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "nothing": 155,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "nothing": 31,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "nothing": 93,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "nothing": 31,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 6,
+          "samples_test": 93,
+          "samples_train": 279,
+          "samples_val": 93,
+          "test_accuracy": 0.8387096524238586,
+          "test_loss": 0.5539762377738953,
+          "train_accuracy": 0.978494623655914,
+          "val_accuracy": 0.8494623655913979
+        },
+        "samples_test": 93,
+        "samples_train": 279,
+        "samples_validation": 93,
+        "test_accuracy": 0.8387096524238586,
+        "test_loss": 0.5539762377738953
+      },
+      "model_key": "mamba",
+      "record_id": "run-000056",
+      "run_name": "mamba_20251206_222623",
+      "source_run_id": "mamba_20251206_222623",
+      "started_at": "2025-12-07T03:26:23",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251206_222828/config.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251206_222828/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251206_222828",
+          "resolved_locator": "legacy://data/results_old/mamba_20251206_222828"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251206_222828/history.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251206_222828/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251206_222828/label_map.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251206_222828/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251206_222828/metrics.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251206_222828/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251206_222828/sign_model_best.keras",
+          "resolved_locator": "legacy://data/results_old/mamba_20251206_222828/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251206_222828/predictions.csv",
+          "resolved_locator": "legacy://data/results_old/mamba_20251206_222828/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.2,
+          "val_frac": 0.2
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "layer",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-07T03:28:48",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "nothing": 155,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "nothing": 31,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "nothing": 93,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "nothing": 31,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 6,
+          "samples_test": 93,
+          "samples_train": 279,
+          "samples_val": 93,
+          "test_accuracy": 0.8172042965888977,
+          "test_loss": 0.6117435693740845,
+          "train_accuracy": 0.982078853046595,
+          "val_accuracy": 0.8172043010752689
+        },
+        "samples_test": 93,
+        "samples_train": 279,
+        "samples_validation": 93,
+        "test_accuracy": 0.8172042965888977,
+        "test_loss": 0.6117435693740845
+      },
+      "model_key": "mamba",
+      "record_id": "run-000057",
+      "run_name": "mamba_20251206_222828",
+      "source_run_id": "mamba_20251206_222828",
+      "started_at": "2025-12-07T03:28:28",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251206_223011/config.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251206_223011/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251206_223011",
+          "resolved_locator": "legacy://data/results_old/mamba_20251206_223011"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251206_223011/history.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251206_223011/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251206_223011/label_map.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251206_223011/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251206_223011/metrics.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251206_223011/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251206_223011/sign_model_best.keras",
+          "resolved_locator": "legacy://data/results_old/mamba_20251206_223011/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251206_223011/predictions.csv",
+          "resolved_locator": "legacy://data/results_old/mamba_20251206_223011/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.2,
+          "val_frac": 0.2
+        },
+        "model_settings": {
+          "d_model": 64,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "layer",
+          "seq_window": 20,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-07T03:30:28",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "nothing": 155,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "nothing": 31,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "nothing": 93,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "nothing": 31,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 6,
+          "samples_test": 93,
+          "samples_train": 279,
+          "samples_val": 93,
+          "test_accuracy": 0.7956989407539368,
+          "test_loss": 0.5982378721237183,
+          "train_accuracy": 0.9713261648745519,
+          "val_accuracy": 0.8494623655913979
+        },
+        "samples_test": 93,
+        "samples_train": 279,
+        "samples_validation": 93,
+        "test_accuracy": 0.7956989407539368,
+        "test_loss": 0.5982378721237183
+      },
+      "model_key": "mamba",
+      "record_id": "run-000058",
+      "run_name": "mamba_20251206_223011",
+      "source_run_id": "mamba_20251206_223011",
+      "started_at": "2025-12-07T03:30:11",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251206_223054/config.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251206_223054/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251206_223054",
+          "resolved_locator": "legacy://data/results_old/mamba_20251206_223054"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251206_223054/history.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251206_223054/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251206_223054/label_map.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251206_223054/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251206_223054/metrics.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251206_223054/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251206_223054/sign_model_best.keras",
+          "resolved_locator": "legacy://data/results_old/mamba_20251206_223054/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251206_223054/predictions.csv",
+          "resolved_locator": "legacy://data/results_old/mamba_20251206_223054/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.2,
+          "val_frac": 0.2
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "layer",
+          "seq_window": 20,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-07T03:31:07",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "nothing": 155,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "nothing": 31,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "nothing": 93,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "nothing": 31,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 6,
+          "samples_test": 93,
+          "samples_train": 279,
+          "samples_val": 93,
+          "test_accuracy": 0.8172042965888977,
+          "test_loss": 0.5913519859313965,
+          "train_accuracy": 0.946236559139785,
+          "val_accuracy": 0.8387096774193549
+        },
+        "samples_test": 93,
+        "samples_train": 279,
+        "samples_validation": 93,
+        "test_accuracy": 0.8172042965888977,
+        "test_loss": 0.5913519859313965
+      },
+      "model_key": "mamba",
+      "record_id": "run-000059",
+      "run_name": "mamba_20251206_223054",
+      "source_run_id": "mamba_20251206_223054",
+      "started_at": "2025-12-07T03:30:55",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251206_223131/config.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251206_223131/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251206_223131",
+          "resolved_locator": "legacy://data/results_old/mamba_20251206_223131"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251206_223131/history.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251206_223131/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251206_223131/label_map.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251206_223131/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251206_223131/metrics.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251206_223131/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251206_223131/sign_model_best.keras",
+          "resolved_locator": "legacy://data/results_old/mamba_20251206_223131/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251206_223131/predictions.csv",
+          "resolved_locator": "legacy://data/results_old/mamba_20251206_223131/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.2,
+          "val_frac": 0.2
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-07T03:31:47",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "nothing": 155,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "nothing": 31,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "nothing": 93,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "nothing": 31,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 6,
+          "samples_test": 93,
+          "samples_train": 279,
+          "samples_val": 93,
+          "test_accuracy": 0.8494623899459839,
+          "test_loss": 0.4834584593772888,
+          "train_accuracy": 0.978494623655914,
+          "val_accuracy": 0.8817204301075269
+        },
+        "samples_test": 93,
+        "samples_train": 279,
+        "samples_validation": 93,
+        "test_accuracy": 0.8494623899459839,
+        "test_loss": 0.4834584593772888
+      },
+      "model_key": "mamba",
+      "record_id": "run-000060",
+      "run_name": "mamba_20251206_223131",
+      "source_run_id": "mamba_20251206_223131",
+      "started_at": "2025-12-07T03:31:32",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_tcn_20251206_233838/config.json",
+          "resolved_locator": "legacy://data/results_old/causal_tcn_20251206_233838/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_tcn_20251206_233838",
+          "resolved_locator": "legacy://data/results_old/causal_tcn_20251206_233838"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_tcn_20251206_233838/history.json",
+          "resolved_locator": "legacy://data/results_old/causal_tcn_20251206_233838/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_tcn_20251206_233838/label_map.json",
+          "resolved_locator": "legacy://data/results_old/causal_tcn_20251206_233838/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_tcn_20251206_233838/metrics.json",
+          "resolved_locator": "legacy://data/results_old/causal_tcn_20251206_233838/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_tcn_20251206_233838/sign_model_best.keras",
+          "resolved_locator": "legacy://data/results_old/causal_tcn_20251206_233838/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_tcn_20251206_233838/predictions.csv",
+          "resolved_locator": "legacy://data/results_old/causal_tcn_20251206_233838/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.2,
+          "val_frac": 0.2
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.2,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-07T04:39:03",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "nothing": 155,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "nothing": 31,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "nothing": 93,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "nothing": 31,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 6,
+          "samples_test": 93,
+          "samples_train": 279,
+          "samples_val": 93,
+          "test_accuracy": 0.8279569745063782,
+          "test_loss": 0.7023084163665771,
+          "train_accuracy": 0.982078853046595,
+          "val_accuracy": 0.8387096774193549
+        },
+        "samples_test": 93,
+        "samples_train": 279,
+        "samples_validation": 93,
+        "test_accuracy": 0.8279569745063782,
+        "test_loss": 0.7023084163665771
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000061",
+      "run_name": "causal_tcn_20251206_233838",
+      "source_run_id": "causal_tcn_20251206_233838",
+      "started_at": "2025-12-07T04:38:49",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251206_234012/config.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251206_234012/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251206_234012",
+          "resolved_locator": "legacy://data/results_old/mamba_20251206_234012"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251206_234012/history.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251206_234012/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251206_234012/label_map.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251206_234012/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251206_234012/metrics.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251206_234012/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251206_234012/sign_model_best.keras",
+          "resolved_locator": "legacy://data/results_old/mamba_20251206_234012/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251206_234012/predictions.csv",
+          "resolved_locator": "legacy://data/results_old/mamba_20251206_234012/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.2,
+          "val_frac": 0.2
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-07T04:40:30",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "nothing": 155,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "nothing": 31,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "nothing": 93,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "nothing": 31,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 6,
+          "samples_test": 93,
+          "samples_train": 279,
+          "samples_val": 93,
+          "test_accuracy": 0.8172042965888977,
+          "test_loss": 0.5606255531311035,
+          "train_accuracy": 0.982078853046595,
+          "val_accuracy": 0.8494623655913979
+        },
+        "samples_test": 93,
+        "samples_train": 279,
+        "samples_validation": 93,
+        "test_accuracy": 0.8172042965888977,
+        "test_loss": 0.5606255531311035
+      },
+      "model_key": "mamba",
+      "record_id": "run-000062",
+      "run_name": "mamba_20251206_234012",
+      "source_run_id": "mamba_20251206_234012",
+      "started_at": "2025-12-07T04:40:13",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_gru_20251208_001852/config.json",
+          "resolved_locator": "legacy://data/results_old/causal_gru_20251208_001852/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_gru_20251208_001852",
+          "resolved_locator": "legacy://data/results_old/causal_gru_20251208_001852"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_gru_20251208_001852/history.json",
+          "resolved_locator": "legacy://data/results_old/causal_gru_20251208_001852/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_gru_20251208_001852/label_map.json",
+          "resolved_locator": "legacy://data/results_old/causal_gru_20251208_001852/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_gru_20251208_001852/metrics.json",
+          "resolved_locator": "legacy://data/results_old/causal_gru_20251208_001852/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_gru_20251208_001852/sign_model_best.keras",
+          "resolved_locator": "legacy://data/results_old/causal_gru_20251208_001852/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_gru_20251208_001852/predictions.csv",
+          "resolved_locator": "legacy://data/results_old/causal_gru_20251208_001852/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/baseline_pos_handscale_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "causal_gru",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/baseline_pos_handscale_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.01,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-08T05:18:59",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.5744680762290955,
+          "test_loss": 0.9685570001602173,
+          "train_accuracy": 0.7870370370370371,
+          "val_accuracy": 0.6382978723404256
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.5744680762290955,
+        "test_loss": 0.9685570001602173
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000063",
+      "run_name": "causal_gru_20251208_001852",
+      "source_run_id": "causal_gru_20251208_001852",
+      "started_at": "2025-12-08T05:18:54",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "not-recorded",
+          "registered_locator": null,
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_gru_20251208_003300",
+          "resolved_locator": "legacy://data/results_old/causal_gru_20251208_003300"
+        },
+        "history": {
+          "availability": "not-recorded",
+          "registered_locator": null,
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "not-recorded",
+          "registered_locator": null,
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "not-recorded",
+          "registered_locator": null,
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "not-recorded",
+          "registered_locator": null,
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "not-recorded",
+          "registered_locator": null,
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "causal_gru",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.01,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": null,
+      "metrics": {
+        "quick": null,
+        "samples_test": null,
+        "samples_train": null,
+        "samples_validation": null,
+        "test_accuracy": null,
+        "test_loss": null
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000064",
+      "run_name": "causal_gru_20251208_003300",
+      "source_run_id": "causal_gru_20251208_003300",
+      "started_at": "2025-12-08T05:33:04",
+      "status": "running",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "stale-running-run"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_gru_20251208_003323/config.json",
+          "resolved_locator": "legacy://data/results_old/causal_gru_20251208_003323/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_gru_20251208_003323",
+          "resolved_locator": "legacy://data/results_old/causal_gru_20251208_003323"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_gru_20251208_003323/history.json",
+          "resolved_locator": "legacy://data/results_old/causal_gru_20251208_003323/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_gru_20251208_003323/label_map.json",
+          "resolved_locator": "legacy://data/results_old/causal_gru_20251208_003323/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_gru_20251208_003323/metrics.json",
+          "resolved_locator": "legacy://data/results_old/causal_gru_20251208_003323/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_gru_20251208_003323/sign_model_best.keras",
+          "resolved_locator": "legacy://data/results_old/causal_gru_20251208_003323/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_gru_20251208_003323/predictions.csv",
+          "resolved_locator": "legacy://data/results_old/causal_gru_20251208_003323/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "causal_gru",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.01,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-08T05:33:34",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.6382978558540344,
+          "test_loss": 0.8876228928565979,
+          "train_accuracy": 0.9398148148148148,
+          "val_accuracy": 0.6382978723404256
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.6382978558540344,
+        "test_loss": 0.8876228928565979
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000065",
+      "run_name": "causal_gru_20251208_003323",
+      "source_run_id": "causal_gru_20251208_003323",
+      "started_at": "2025-12-08T05:33:24",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_gru_20251208_003730/config.json",
+          "resolved_locator": "legacy://data/results_old/causal_gru_20251208_003730/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_gru_20251208_003730",
+          "resolved_locator": "legacy://data/results_old/causal_gru_20251208_003730"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_gru_20251208_003730/history.json",
+          "resolved_locator": "legacy://data/results_old/causal_gru_20251208_003730/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_gru_20251208_003730/label_map.json",
+          "resolved_locator": "legacy://data/results_old/causal_gru_20251208_003730/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_gru_20251208_003730/metrics.json",
+          "resolved_locator": "legacy://data/results_old/causal_gru_20251208_003730/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_gru_20251208_003730/sign_model_best.keras",
+          "resolved_locator": "legacy://data/results_old/causal_gru_20251208_003730/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_gru_20251208_003730/predictions.csv",
+          "resolved_locator": "legacy://data/results_old/causal_gru_20251208_003730/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "causal_gru",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.01,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-08T05:37:56",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "nothing": 155,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "nothing": 23,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "nothing": 109,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "nothing": 23,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 6,
+          "samples_test": 70,
+          "samples_train": 325,
+          "samples_val": 70,
+          "test_accuracy": 0.7285714149475098,
+          "test_loss": 1.1067945957183838,
+          "train_accuracy": 0.9692307692307692,
+          "val_accuracy": 0.7571428571428571
+        },
+        "samples_test": 70,
+        "samples_train": 325,
+        "samples_validation": 70,
+        "test_accuracy": 0.7285714149475098,
+        "test_loss": 1.1067945957183838
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000066",
+      "run_name": "causal_gru_20251208_003730",
+      "source_run_id": "causal_gru_20251208_003730",
+      "started_at": "2025-12-08T05:37:40",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_004425/config.json",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_004425/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_004425",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_004425"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_004425/history.json",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_004425/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_004425/label_map.json",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_004425/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_004425/metrics.json",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_004425/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_004425/sign_model_best.keras",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_004425/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_004425/predictions.csv",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_004425/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "causal_gru",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.01,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-08T05:44:40",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "nothing": 155,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "nothing": 23,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "nothing": 109,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "nothing": 23,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 6,
+          "samples_test": 70,
+          "samples_train": 325,
+          "samples_val": 70,
+          "test_accuracy": 0.7285714149475098,
+          "test_loss": 1.091718316078186,
+          "train_accuracy": 0.9784615384615385,
+          "val_accuracy": 0.7428571428571429
+        },
+        "samples_test": 70,
+        "samples_train": 325,
+        "samples_validation": 70,
+        "test_accuracy": 0.7285714149475098,
+        "test_loss": 1.091718316078186
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000067",
+      "run_name": "causal_lstm_20251208_004425",
+      "source_run_id": "causal_lstm_20251208_004425",
+      "started_at": "2025-12-08T05:44:25",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_gru_20251208_004645/config.json",
+          "resolved_locator": "legacy://data/results_old/causal_gru_20251208_004645/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_gru_20251208_004645",
+          "resolved_locator": "legacy://data/results_old/causal_gru_20251208_004645"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_gru_20251208_004645/history.json",
+          "resolved_locator": "legacy://data/results_old/causal_gru_20251208_004645/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_gru_20251208_004645/label_map.json",
+          "resolved_locator": "legacy://data/results_old/causal_gru_20251208_004645/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_gru_20251208_004645/metrics.json",
+          "resolved_locator": "legacy://data/results_old/causal_gru_20251208_004645/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_gru_20251208_004645/sign_model_best.keras",
+          "resolved_locator": "legacy://data/results_old/causal_gru_20251208_004645/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_gru_20251208_004645/predictions.csv",
+          "resolved_locator": "legacy://data/results_old/causal_gru_20251208_004645/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "causal_gru",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.01,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-08T05:46:57",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7021276354789734,
+          "test_loss": 1.075689673423767,
+          "train_accuracy": 0.9398148148148148,
+          "val_accuracy": 0.6595744680851063
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7021276354789734,
+        "test_loss": 1.075689673423767
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000068",
+      "run_name": "causal_gru_20251208_004645",
+      "source_run_id": "causal_gru_20251208_004645",
+      "started_at": "2025-12-08T05:46:46",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_004855/config.json",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_004855/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_004855",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_004855"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_004855/history.json",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_004855/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_004855/label_map.json",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_004855/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_004855/metrics.json",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_004855/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_004855/sign_model_best.keras",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_004855/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_004855/predictions.csv",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_004855/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "causal_gru",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.01,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-08T05:49:07",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7021276354789734,
+          "test_loss": 1.0782629251480103,
+          "train_accuracy": 0.9722222222222222,
+          "val_accuracy": 0.6382978723404256
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7021276354789734,
+        "test_loss": 1.0782629251480103
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000069",
+      "run_name": "causal_lstm_20251208_004855",
+      "source_run_id": "causal_lstm_20251208_004855",
+      "started_at": "2025-12-08T05:48:55",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_gru_20251208_005728/config.json",
+          "resolved_locator": "legacy://data/results_old/causal_gru_20251208_005728/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_gru_20251208_005728",
+          "resolved_locator": "legacy://data/results_old/causal_gru_20251208_005728"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_gru_20251208_005728/history.json",
+          "resolved_locator": "legacy://data/results_old/causal_gru_20251208_005728/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_gru_20251208_005728/label_map.json",
+          "resolved_locator": "legacy://data/results_old/causal_gru_20251208_005728/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_gru_20251208_005728/metrics.json",
+          "resolved_locator": "legacy://data/results_old/causal_gru_20251208_005728/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_gru_20251208_005728/sign_model_best.keras",
+          "resolved_locator": "legacy://data/results_old/causal_gru_20251208_005728/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_gru_20251208_005728/predictions.csv",
+          "resolved_locator": "legacy://data/results_old/causal_gru_20251208_005728/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "causal_gru",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.01,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.2,
+          "val_frac": 0.2
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-08T05:57:43",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.6774193644523621,
+          "test_loss": 1.3951672315597534,
+          "train_accuracy": 0.978494623655914,
+          "val_accuracy": 0.6612903225806451
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.6774193644523621,
+        "test_loss": 1.3951672315597534
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000070",
+      "run_name": "causal_gru_20251208_005728",
+      "source_run_id": "causal_gru_20251208_005728",
+      "started_at": "2025-12-08T05:57:28",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_005752/config.json",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_005752/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_005752",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_005752"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_005752/history.json",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_005752/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_005752/label_map.json",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_005752/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_005752/metrics.json",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_005752/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_005752/sign_model_best.keras",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_005752/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_005752/predictions.csv",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_005752/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "causal_gru",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.01,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.2,
+          "val_frac": 0.2
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-08T05:58:07",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.6774193644523621,
+          "test_loss": 1.160921335220337,
+          "train_accuracy": 0.967741935483871,
+          "val_accuracy": 0.7096774193548387
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.6774193644523621,
+        "test_loss": 1.160921335220337
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000071",
+      "run_name": "causal_lstm_20251208_005752",
+      "source_run_id": "causal_lstm_20251208_005752",
+      "started_at": "2025-12-08T05:57:52",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_005847/config.json",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_005847/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_005847",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_005847"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_005847/history.json",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_005847/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_005847/label_map.json",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_005847/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_005847/metrics.json",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_005847/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_005847/sign_model_best.keras",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_005847/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_005847/predictions.csv",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_005847/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "causal_gru",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.01,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.2,
+          "val_frac": 0.2
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-08T05:59:02",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.6612903475761414,
+          "test_loss": 1.220070719718933,
+          "train_accuracy": 0.9838709677419355,
+          "val_accuracy": 0.7419354838709677
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.6612903475761414,
+        "test_loss": 1.220070719718933
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000072",
+      "run_name": "causal_lstm_20251208_005847",
+      "source_run_id": "causal_lstm_20251208_005847",
+      "started_at": "2025-12-08T05:58:47",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_010023/config.json",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_010023/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_010023",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_010023"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_010023/history.json",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_010023/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_010023/label_map.json",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_010023/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_010023/metrics.json",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_010023/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_010023/sign_model_best.keras",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_010023/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_010023/predictions.csv",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_010023/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "causal_lstm",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.01,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 64,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-08T06:00:33",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.6595744490623474,
+          "test_loss": 1.0056449174880981,
+          "train_accuracy": 0.9351851851851852,
+          "val_accuracy": 0.6382978723404256
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.6595744490623474,
+        "test_loss": 1.0056449174880981
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000073",
+      "run_name": "causal_lstm_20251208_010023",
+      "source_run_id": "causal_lstm_20251208_010023",
+      "started_at": "2025-12-08T06:00:23",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_010140/config.json",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_010140/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_010140",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_010140"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_010140/history.json",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_010140/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_010140/label_map.json",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_010140/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_010140/metrics.json",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_010140/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_010140/sign_model_best.keras",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_010140/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_010140/predictions.csv",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_010140/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "causal_lstm",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.01,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-08T06:01:50",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.5319148898124695,
+          "test_loss": 1.2621405124664307,
+          "train_accuracy": 0.8564814814814815,
+          "val_accuracy": 0.6382978723404256
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.5319148898124695,
+        "test_loss": 1.2621405124664307
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000074",
+      "run_name": "causal_lstm_20251208_010140",
+      "source_run_id": "causal_lstm_20251208_010140",
+      "started_at": "2025-12-08T06:01:40",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_010233/config.json",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_010233/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_010233",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_010233"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_010233/history.json",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_010233/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_010233/label_map.json",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_010233/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_010233/metrics.json",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_010233/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_010233/sign_model_best.keras",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_010233/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_010233/predictions.csv",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_010233/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "causal_lstm",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.01,
+          "optimizer_type": "adamw",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-08T06:02:45",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.6595744490623474,
+          "test_loss": 1.001611351966858,
+          "train_accuracy": 0.9814814814814815,
+          "val_accuracy": 0.723404255319149
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.6595744490623474,
+        "test_loss": 1.001611351966858
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000075",
+      "run_name": "causal_lstm_20251208_010233",
+      "source_run_id": "causal_lstm_20251208_010233",
+      "started_at": "2025-12-08T06:02:33",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_010310/config.json",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_010310/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_010310",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_010310"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_010310/history.json",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_010310/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_010310/label_map.json",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_010310/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_010310/metrics.json",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_010310/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_010310/sign_model_best.keras",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_010310/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_lstm_20251208_010310/predictions.csv",
+          "resolved_locator": "legacy://data/results_old/causal_lstm_20251208_010310/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "causal_lstm",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.01,
+          "optimizer_type": "sgd",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-08T06:03:19",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.42553192377090454,
+          "test_loss": 1.443294644355774,
+          "train_accuracy": 0.5416666666666666,
+          "val_accuracy": 0.574468085106383
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.42553192377090454,
+        "test_loss": 1.443294644355774
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000076",
+      "run_name": "causal_lstm_20251208_010310",
+      "source_run_id": "causal_lstm_20251208_010310",
+      "started_at": "2025-12-08T06:03:10",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "not-recorded",
+          "registered_locator": null,
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_tcn_20251208_010338",
+          "resolved_locator": "legacy://data/results_old/causal_tcn_20251208_010338"
+        },
+        "history": {
+          "availability": "not-recorded",
+          "registered_locator": null,
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "not-recorded",
+          "registered_locator": null,
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "not-recorded",
+          "registered_locator": null,
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "not-recorded",
+          "registered_locator": null,
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "not-recorded",
+          "registered_locator": null,
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "causal_lstm",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.01,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.2,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-08T06:03:41",
+      "metrics": {
+        "quick": null,
+        "samples_test": null,
+        "samples_train": null,
+        "samples_validation": null,
+        "test_accuracy": null,
+        "test_loss": null
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000077",
+      "run_name": "causal_tcn_20251208_010338",
+      "source_run_id": "causal_tcn_20251208_010338",
+      "started_at": "2025-12-08T06:03:39",
+      "status": "failed",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": true,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "failed-run"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_tcn_20251208_010400/config.json",
+          "resolved_locator": "legacy://data/results_old/causal_tcn_20251208_010400/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_tcn_20251208_010400",
+          "resolved_locator": "legacy://data/results_old/causal_tcn_20251208_010400"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_tcn_20251208_010400/history.json",
+          "resolved_locator": "legacy://data/results_old/causal_tcn_20251208_010400/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_tcn_20251208_010400/label_map.json",
+          "resolved_locator": "legacy://data/results_old/causal_tcn_20251208_010400/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_tcn_20251208_010400/metrics.json",
+          "resolved_locator": "legacy://data/results_old/causal_tcn_20251208_010400/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_tcn_20251208_010400/sign_model_best.keras",
+          "resolved_locator": "legacy://data/results_old/causal_tcn_20251208_010400/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/causal_tcn_20251208_010400/predictions.csv",
+          "resolved_locator": "legacy://data/results_old/causal_tcn_20251208_010400/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "causal_tcn",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.01,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.2,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-08T06:04:15",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7234042286872864,
+          "test_loss": 0.6883249282836914,
+          "train_accuracy": 0.9629629629629629,
+          "val_accuracy": 0.723404255319149
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7234042286872864,
+        "test_loss": 0.6883249282836914
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000078",
+      "run_name": "causal_tcn_20251208_010400",
+      "source_run_id": "causal_tcn_20251208_010400",
+      "started_at": "2025-12-08T06:04:00",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251208_010637/config.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251208_010637/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251208_010637",
+          "resolved_locator": "legacy://data/results_old/mamba_20251208_010637"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251208_010637/history.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251208_010637/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251208_010637/label_map.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251208_010637/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251208_010637/metrics.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251208_010637/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251208_010637/sign_model_best.keras",
+          "resolved_locator": "legacy://data/results_old/mamba_20251208_010637/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251208_010637/predictions.csv",
+          "resolved_locator": "legacy://data/results_old/mamba_20251208_010637/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.01,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-08T06:06:52",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.8297872543334961,
+          "test_loss": 0.5474875569343567,
+          "train_accuracy": 0.9861111111111112,
+          "val_accuracy": 0.7659574468085106
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.8297872543334961,
+        "test_loss": 0.5474875569343567
+      },
+      "model_key": "mamba",
+      "record_id": "run-000079",
+      "run_name": "mamba_20251208_010637",
+      "source_run_id": "mamba_20251208_010637",
+      "started_at": "2025-12-08T06:06:37",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251208_010715/config.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251208_010715/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251208_010715",
+          "resolved_locator": "legacy://data/results_old/mamba_20251208_010715"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251208_010715/history.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251208_010715/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251208_010715/label_map.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251208_010715/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251208_010715/metrics.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251208_010715/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251208_010715/sign_model_best.keras",
+          "resolved_locator": "legacy://data/results_old/mamba_20251208_010715/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251208_010715/predictions.csv",
+          "resolved_locator": "legacy://data/results_old/mamba_20251208_010715/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.01,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-08T06:07:29",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.8510638475418091,
+          "test_loss": 0.5503569841384888,
+          "train_accuracy": 0.9722222222222222,
+          "val_accuracy": 0.723404255319149
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.8510638475418091,
+        "test_loss": 0.5503569841384888
+      },
+      "model_key": "mamba",
+      "record_id": "run-000080",
+      "run_name": "mamba_20251208_010715",
+      "source_run_id": "mamba_20251208_010715",
+      "started_at": "2025-12-08T06:07:15",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251208_010836/config.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251208_010836/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251208_010836",
+          "resolved_locator": "legacy://data/results_old/mamba_20251208_010836"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251208_010836/history.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251208_010836/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251208_010836/label_map.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251208_010836/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251208_010836/metrics.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251208_010836/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251208_010836/sign_model_best.keras",
+          "resolved_locator": "legacy://data/results_old/mamba_20251208_010836/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251208_010836/predictions.csv",
+          "resolved_locator": "legacy://data/results_old/mamba_20251208_010836/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.01,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.2,
+          "val_frac": 0.2
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-08T06:08:51",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.7903226017951965,
+          "test_loss": 0.7869395017623901,
+          "train_accuracy": 0.9838709677419355,
+          "val_accuracy": 0.7903225806451613
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.7903226017951965,
+        "test_loss": 0.7869395017623901
+      },
+      "model_key": "mamba",
+      "record_id": "run-000081",
+      "run_name": "mamba_20251208_010836",
+      "source_run_id": "mamba_20251208_010836",
+      "started_at": "2025-12-08T06:08:37",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251208_182329/config.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251208_182329/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251208_182329",
+          "resolved_locator": "legacy://data/results_old/mamba_20251208_182329"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251208_182329/history.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251208_182329/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251208_182329/label_map.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251208_182329/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251208_182329/metrics.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251208_182329/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251208_182329/sign_model_best.keras",
+          "resolved_locator": "legacy://data/results_old/mamba_20251208_182329/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251208_182329/predictions.csv",
+          "resolved_locator": "legacy://data/results_old/mamba_20251208_182329/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.01,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-08T23:23:50",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7872340679168701,
+          "test_loss": 0.6026381850242615,
+          "train_accuracy": 0.9537037037037037,
+          "val_accuracy": 0.7659574468085106
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7872340679168701,
+        "test_loss": 0.6026381850242615
+      },
+      "model_key": "mamba",
+      "record_id": "run-000082",
+      "run_name": "mamba_20251208_182329",
+      "source_run_id": "mamba_20251208_182329",
+      "started_at": "2025-12-08T23:23:37",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251221_123828/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251221_123828",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251221_123828/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251221_123828/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251221_123828/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251221_123828/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251221_123828/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.01,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-21T17:38:44",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.6808510422706604,
+          "test_loss": 0.8034824728965759,
+          "train_accuracy": 0.8842592592592593,
+          "val_accuracy": 0.723404255319149
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.6808510422706604,
+        "test_loss": 0.8034824728965759
+      },
+      "model_key": "mamba",
+      "record_id": "run-000083",
+      "run_name": "mamba_20251221_123828",
+      "source_run_id": "mamba_20251221_123828",
+      "started_at": "2025-12-21T17:38:33",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251221_124120/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251221_124120",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251221_124120/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251221_124120/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251221_124120/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251221_124120/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251221_124120/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.01,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-21T17:41:30",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.6808510422706604,
+          "test_loss": 0.8307347297668457,
+          "train_accuracy": 0.8287037037037037,
+          "val_accuracy": 0.7446808510638298
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.6808510422706604,
+        "test_loss": 0.8307347297668457
+      },
+      "model_key": "mamba",
+      "record_id": "run-000084",
+      "run_name": "mamba_20251221_124120",
+      "source_run_id": "mamba_20251221_124120",
+      "started_at": "2025-12-21T17:41:20",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251221_124513/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251221_124513",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251221_124513/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251221_124513/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251221_124513/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251221_124513/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251221_124513/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.01,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-21T17:45:27",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7659574747085571,
+          "test_loss": 0.7392498850822449,
+          "train_accuracy": 0.9675925925925926,
+          "val_accuracy": 0.7659574468085106
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7659574747085571,
+        "test_loss": 0.7392498850822449
+      },
+      "model_key": "mamba",
+      "record_id": "run-000085",
+      "run_name": "mamba_20251221_124513",
+      "source_run_id": "mamba_20251221_124513",
+      "started_at": "2025-12-21T17:45:14",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251221_144814/config.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251221_144814/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251221_144814",
+          "resolved_locator": "legacy://data/results_old/mamba_20251221_144814"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251221_144814/history.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251221_144814/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251221_144814/label_map.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251221_144814/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251221_144814/metrics.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251221_144814/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251221_144814/sign_model_best.keras",
+          "resolved_locator": "legacy://data/results_old/mamba_20251221_144814/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251221_144814/predictions.csv",
+          "resolved_locator": "legacy://data/results_old/mamba_20251221_144814/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.01,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-21T19:48:35",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.8297872543334961,
+          "test_loss": 0.5838001370429993,
+          "train_accuracy": 0.9768518518518519,
+          "val_accuracy": 0.723404255319149
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.8297872543334961,
+        "test_loss": 0.5838001370429993
+      },
+      "model_key": "mamba",
+      "record_id": "run-000086",
+      "run_name": "mamba_20251221_144814",
+      "source_run_id": "mamba_20251221_144814",
+      "started_at": "2025-12-21T19:48:21",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251221_152023/config.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251221_152023/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251221_152023",
+          "resolved_locator": "legacy://data/results_old/mamba_20251221_152023"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251221_152023/history.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251221_152023/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251221_152023/label_map.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251221_152023/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251221_152023/metrics.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251221_152023/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251221_152023/sign_model_best.keras",
+          "resolved_locator": "legacy://data/results_old/mamba_20251221_152023/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251221_152023/predictions.csv",
+          "resolved_locator": "legacy://data/results_old/mamba_20251221_152023/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.01,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-21T20:20:35",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7872340679168701,
+          "test_loss": 0.707696795463562,
+          "train_accuracy": 0.9629629629629629,
+          "val_accuracy": 0.7446808510638298
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7872340679168701,
+        "test_loss": 0.707696795463562
+      },
+      "model_key": "mamba",
+      "record_id": "run-000087",
+      "run_name": "mamba_20251221_152023",
+      "source_run_id": "mamba_20251221_152023",
+      "started_at": "2025-12-21T20:20:23",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251221_204755/config.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251221_204755/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251221_204755",
+          "resolved_locator": "legacy://data/results_old/mamba_20251221_204755"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251221_204755/history.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251221_204755/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251221_204755/label_map.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251221_204755/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251221_204755/metrics.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251221_204755/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251221_204755/sign_model_best.keras",
+          "resolved_locator": "legacy://data/results_old/mamba_20251221_204755/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251221_204755/predictions.csv",
+          "resolved_locator": "legacy://data/results_old/mamba_20251221_204755/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.01,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T01:48:17",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.8085106611251831,
+          "test_loss": 0.5370028018951416,
+          "train_accuracy": 0.9722222222222222,
+          "val_accuracy": 0.723404255319149
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.8085106611251831,
+        "test_loss": 0.5370028018951416
+      },
+      "model_key": "mamba",
+      "record_id": "run-000088",
+      "run_name": "mamba_20251221_204755",
+      "source_run_id": "mamba_20251221_204755",
+      "started_at": "2025-12-22T01:48:02",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251222_085705/config.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251222_085705/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251222_085705",
+          "resolved_locator": "legacy://data/results_old/mamba_20251222_085705"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251222_085705/history.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251222_085705/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251222_085705/label_map.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251222_085705/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251222_085705/metrics.json",
+          "resolved_locator": "legacy://data/results_old/mamba_20251222_085705/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251222_085705/sign_model_best.keras",
+          "resolved_locator": "legacy://data/results_old/mamba_20251222_085705/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://data/results/mamba_20251222_085705/predictions.csv",
+          "resolved_locator": "legacy://data/results_old/mamba_20251222_085705/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.01,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T13:57:13",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7872340679168701,
+          "test_loss": 0.6446836590766907,
+          "train_accuracy": 0.9675925925925926,
+          "val_accuracy": 0.7446808510638298
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7872340679168701,
+        "test_loss": 0.6446836590766907
+      },
+      "model_key": "mamba",
+      "record_id": "run-000089",
+      "run_name": "mamba_20251222_085705",
+      "source_run_id": "mamba_20251222_085705",
+      "started_at": "2025-12-22T13:57:08",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251222_090011/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251222_090011",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251222_090011/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251222_090011/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251222_090011/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251222_090011/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251222_090011/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.01,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T14:00:14",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.6595744490623474,
+          "test_loss": 0.6745067238807678,
+          "train_accuracy": 0.9212962962962963,
+          "val_accuracy": 0.6595744680851063
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.6595744490623474,
+        "test_loss": 0.6745067238807678
+      },
+      "model_key": "mamba",
+      "record_id": "run-000090",
+      "run_name": "mamba_20251222_090011",
+      "source_run_id": "mamba_20251222_090011",
+      "started_at": "2025-12-22T14:00:11",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251222_090028/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251222_090028",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251222_090028/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251222_090028/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251222_090028/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251222_090028/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251222_090028/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "confidence_threshold": 0.6,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "fps": 15,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.01,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "smoothing_window": 7,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T14:00:32",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7446808218955994,
+          "test_loss": 0.7692374587059021,
+          "train_accuracy": 0.9675925925925926,
+          "val_accuracy": 0.7872340425531915
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7446808218955994,
+        "test_loss": 0.7692374587059021
+      },
+      "model_key": "mamba",
+      "record_id": "run-000091",
+      "run_name": "mamba_20251222_090028",
+      "source_run_id": "mamba_20251222_090028",
+      "started_at": "2025-12-22T14:00:28",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251222_094006/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251222_094006",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251222_094006/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251222_094006/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251222_094006/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251222_094006/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251222_094006/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/baseline_pos_handscale_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/baseline_pos_handscale_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.01,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T14:40:13",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7021276354789734,
+          "test_loss": 0.8514536023139954,
+          "train_accuracy": 0.875,
+          "val_accuracy": 0.7659574468085106
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7021276354789734,
+        "test_loss": 0.8514536023139954
+      },
+      "model_key": "mamba",
+      "record_id": "run-000092",
+      "run_name": "mamba_20251222_094006",
+      "source_run_id": "mamba_20251222_094006",
+      "started_at": "2025-12-22T14:40:09",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251222_095354/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251222_095354",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251222_095354/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251222_095354/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251222_095354/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251222_095354/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/mamba_20251222_095354/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.01,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "test_frac": 0.15,
+          "val_frac": 0.15
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T14:53:58",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7872340679168701,
+          "test_loss": 0.6215293407440186,
+          "train_accuracy": 0.9351851851851852,
+          "val_accuracy": 0.7872340425531915
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7872340679168701,
+        "test_loss": 0.6215293407440186
+      },
+      "model_key": "mamba",
+      "record_id": "run-000093",
+      "run_name": "mamba_20251222_095354",
+      "source_run_id": "mamba_20251222_095354",
+      "started_at": "2025-12-22T14:53:54",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_001/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_001/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_001",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_001"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_001/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_001/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_001/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_001/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_001/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_001/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_001/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_001/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_001/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_001/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123136_phasea_train_recipe_causal_gru",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:31:50",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.4893617033958435,
+          "test_loss": 1.3753665685653687,
+          "train_accuracy": 0.6759259259259259,
+          "val_accuracy": 0.48936170212765956
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.4893617033958435,
+        "test_loss": 1.3753665685653687
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000094",
+      "run_name": "run_001",
+      "source_run_id": "20251222_123136_phasea_train_recipe_causal_gru_run_001",
+      "started_at": "2025-12-22T17:31:45",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_002/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_002/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_002",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_002"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_002/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_002/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_002/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_002/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_002/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_002/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_002/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_002/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_002/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_002/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123136_phasea_train_recipe_causal_gru",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:31:55",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.3617021143436432,
+          "test_loss": 1.5054571628570557,
+          "train_accuracy": 0.5787037037037037,
+          "val_accuracy": 0.48936170212765956
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.3617021143436432,
+        "test_loss": 1.5054571628570557
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000095",
+      "run_name": "run_002",
+      "source_run_id": "20251222_123136_phasea_train_recipe_causal_gru_run_002",
+      "started_at": "2025-12-22T17:31:51",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_003/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_003/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_003",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_003"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_003/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_003/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_003/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_003/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_003/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_003/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_003/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_003/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_003/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_003/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123136_phasea_train_recipe_causal_gru",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:31:59",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.3404255211353302,
+          "test_loss": 1.5336780548095703,
+          "train_accuracy": 0.5092592592592593,
+          "val_accuracy": 0.48936170212765956
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.3404255211353302,
+        "test_loss": 1.5336780548095703
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000096",
+      "run_name": "run_003",
+      "source_run_id": "20251222_123136_phasea_train_recipe_causal_gru_run_003",
+      "started_at": "2025-12-22T17:31:55",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_004/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_004/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_004",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_004"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_004/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_004/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_004/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_004/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_004/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_004/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_004/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_004/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_004/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_004/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123136_phasea_train_recipe_causal_gru",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:32:03",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.2978723347187042,
+          "test_loss": 1.5538921356201172,
+          "train_accuracy": 0.4675925925925926,
+          "val_accuracy": 0.48936170212765956
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.2978723347187042,
+        "test_loss": 1.5538921356201172
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000097",
+      "run_name": "run_004",
+      "source_run_id": "20251222_123136_phasea_train_recipe_causal_gru_run_004",
+      "started_at": "2025-12-22T17:31:59",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_005/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_005/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_005",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_005"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_005/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_005/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_005/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_005/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_005/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_005/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_005/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_005/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_005/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_005/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123136_phasea_train_recipe_causal_gru",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.4,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:32:06",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.3191489279270172,
+          "test_loss": 1.6563528776168823,
+          "train_accuracy": 0.25,
+          "val_accuracy": 0.2553191489361702
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.3191489279270172,
+        "test_loss": 1.6563528776168823
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000098",
+      "run_name": "run_005",
+      "source_run_id": "20251222_123136_phasea_train_recipe_causal_gru_run_005",
+      "started_at": "2025-12-22T17:32:04",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_006/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_006/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_006",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_006"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_006/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_006/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_006/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_006/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_006/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_006/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_006/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_006/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_006/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_006/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123136_phasea_train_recipe_causal_gru",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:32:11",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.4893617033958435,
+          "test_loss": 1.3753665685653687,
+          "train_accuracy": 0.6759259259259259,
+          "val_accuracy": 0.48936170212765956
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.4893617033958435,
+        "test_loss": 1.3753665685653687
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000099",
+      "run_name": "run_006",
+      "source_run_id": "20251222_123136_phasea_train_recipe_causal_gru_run_006",
+      "started_at": "2025-12-22T17:32:06",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_007/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_007/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_007",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_007"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_007/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_007/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_007/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_007/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_007/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_007/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_007/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_007/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_007/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_007/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123136_phasea_train_recipe_causal_gru",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:32:16",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.3617021143436432,
+          "test_loss": 1.5054571628570557,
+          "train_accuracy": 0.5787037037037037,
+          "val_accuracy": 0.48936170212765956
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.3617021143436432,
+        "test_loss": 1.5054571628570557
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000100",
+      "run_name": "run_007",
+      "source_run_id": "20251222_123136_phasea_train_recipe_causal_gru_run_007",
+      "started_at": "2025-12-22T17:32:12",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    }
+  ],
+  "schema_version": 1,
+  "shard": 0
+}

--- a/docs/legacy/export/v1/runs/runs-001.json
+++ b/docs/legacy/export/v1/runs/runs-001.json
@@ -1,0 +1,14014 @@
+{
+  "kind": "signlab.legacy-run-index",
+  "records": [
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_008/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_008/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_008",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_008"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_008/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_008/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_008/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_008/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_008/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_008/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_008/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_008/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_008/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_008/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123136_phasea_train_recipe_causal_gru",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:32:20",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.3404255211353302,
+          "test_loss": 1.5336780548095703,
+          "train_accuracy": 0.5092592592592593,
+          "val_accuracy": 0.48936170212765956
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.3404255211353302,
+        "test_loss": 1.5336780548095703
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000101",
+      "run_name": "run_008",
+      "source_run_id": "20251222_123136_phasea_train_recipe_causal_gru_run_008",
+      "started_at": "2025-12-22T17:32:16",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_009/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_009/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_009",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_009"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_009/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_009/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_009/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_009/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_009/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_009/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_009/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_009/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_009/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_009/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123136_phasea_train_recipe_causal_gru",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:32:25",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.2978723347187042,
+          "test_loss": 1.5538921356201172,
+          "train_accuracy": 0.4675925925925926,
+          "val_accuracy": 0.48936170212765956
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.2978723347187042,
+        "test_loss": 1.5538921356201172
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000102",
+      "run_name": "run_009",
+      "source_run_id": "20251222_123136_phasea_train_recipe_causal_gru_run_009",
+      "started_at": "2025-12-22T17:32:20",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_010/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_010/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_010",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_010"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_010/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_010/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_010/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_010/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_010/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_010/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_010/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_010/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_010/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_010/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123136_phasea_train_recipe_causal_gru",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.4,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:32:27",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.3191489279270172,
+          "test_loss": 1.6563528776168823,
+          "train_accuracy": 0.25,
+          "val_accuracy": 0.2553191489361702
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.3191489279270172,
+        "test_loss": 1.6563528776168823
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000103",
+      "run_name": "run_010",
+      "source_run_id": "20251222_123136_phasea_train_recipe_causal_gru_run_010",
+      "started_at": "2025-12-22T17:32:25",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_011/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_011/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_011",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_011"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_011/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_011/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_011/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_011/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_011/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_011/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_011/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_011/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_011/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_011/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123136_phasea_train_recipe_causal_gru",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:32:31",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.5106382966041565,
+          "test_loss": 1.3695837259292603,
+          "train_accuracy": 0.6805555555555556,
+          "val_accuracy": 0.5319148936170213
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.5106382966041565,
+        "test_loss": 1.3695837259292603
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000104",
+      "run_name": "run_011",
+      "source_run_id": "20251222_123136_phasea_train_recipe_causal_gru_run_011",
+      "started_at": "2025-12-22T17:32:28",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_012/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_012/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_012",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_012"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_012/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_012/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_012/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_012/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_012/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_012/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_012/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_012/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_012/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_012/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123136_phasea_train_recipe_causal_gru",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:32:34",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.40425533056259155,
+          "test_loss": 1.4723105430603027,
+          "train_accuracy": 0.6342592592592593,
+          "val_accuracy": 0.5106382978723404
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.40425533056259155,
+        "test_loss": 1.4723105430603027
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000105",
+      "run_name": "run_012",
+      "source_run_id": "20251222_123136_phasea_train_recipe_causal_gru_run_012",
+      "started_at": "2025-12-22T17:32:31",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_013/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_013/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_013",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_013"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_013/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_013/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_013/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_013/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_013/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_013/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_013/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_013/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_013/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_013/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123136_phasea_train_recipe_causal_gru",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:32:38",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.44680851697921753,
+          "test_loss": 1.4379788637161255,
+          "train_accuracy": 0.6481481481481481,
+          "val_accuracy": 0.5531914893617021
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.44680851697921753,
+        "test_loss": 1.4379788637161255
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000106",
+      "run_name": "run_013",
+      "source_run_id": "20251222_123136_phasea_train_recipe_causal_gru_run_013",
+      "started_at": "2025-12-22T17:32:34",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_014/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_014/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_014",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_014"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_014/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_014/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_014/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_014/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_014/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_014/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_014/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_014/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_014/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_014/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123136_phasea_train_recipe_causal_gru",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:32:44",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.5319148898124695,
+          "test_loss": 1.3251993656158447,
+          "train_accuracy": 0.7777777777777778,
+          "val_accuracy": 0.5957446808510638
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.5319148898124695,
+        "test_loss": 1.3251993656158447
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000107",
+      "run_name": "run_014",
+      "source_run_id": "20251222_123136_phasea_train_recipe_causal_gru_run_014",
+      "started_at": "2025-12-22T17:32:38",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_015/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_015/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_015",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_015"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_015/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_015/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_015/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_015/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_015/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_015/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_015/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_015/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_015/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_015/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123136_phasea_train_recipe_causal_gru",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.4,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:32:48",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.40425533056259155,
+          "test_loss": 1.4983251094818115,
+          "train_accuracy": 0.5833333333333334,
+          "val_accuracy": 0.5106382978723404
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.40425533056259155,
+        "test_loss": 1.4983251094818115
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000108",
+      "run_name": "run_015",
+      "source_run_id": "20251222_123136_phasea_train_recipe_causal_gru_run_015",
+      "started_at": "2025-12-22T17:32:44",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_016/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_016/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_016",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_016"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_016/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_016/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_016/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_016/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_016/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_016/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_016/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_016/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_016/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_016/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123136_phasea_train_recipe_causal_gru",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:32:51",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.5106382966041565,
+          "test_loss": 1.3695837259292603,
+          "train_accuracy": 0.6805555555555556,
+          "val_accuracy": 0.5319148936170213
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.5106382966041565,
+        "test_loss": 1.3695837259292603
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000109",
+      "run_name": "run_016",
+      "source_run_id": "20251222_123136_phasea_train_recipe_causal_gru_run_016",
+      "started_at": "2025-12-22T17:32:48",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_017/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_017/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_017",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_017"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_017/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_017/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_017/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_017/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_017/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_017/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_017/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_017/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_017/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_017/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123136_phasea_train_recipe_causal_gru",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:32:55",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.40425533056259155,
+          "test_loss": 1.4723105430603027,
+          "train_accuracy": 0.6342592592592593,
+          "val_accuracy": 0.5106382978723404
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.40425533056259155,
+        "test_loss": 1.4723105430603027
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000110",
+      "run_name": "run_017",
+      "source_run_id": "20251222_123136_phasea_train_recipe_causal_gru_run_017",
+      "started_at": "2025-12-22T17:32:51",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_018/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_018/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_018",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_018"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_018/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_018/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_018/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_018/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_018/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_018/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_018/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_018/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_018/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_018/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123136_phasea_train_recipe_causal_gru",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:32:58",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.44680851697921753,
+          "test_loss": 1.4379788637161255,
+          "train_accuracy": 0.6481481481481481,
+          "val_accuracy": 0.5531914893617021
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.44680851697921753,
+        "test_loss": 1.4379788637161255
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000111",
+      "run_name": "run_018",
+      "source_run_id": "20251222_123136_phasea_train_recipe_causal_gru_run_018",
+      "started_at": "2025-12-22T17:32:55",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_019/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_019/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_019",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_019"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_019/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_019/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_019/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_019/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_019/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_019/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_019/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_019/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_019/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_019/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123136_phasea_train_recipe_causal_gru",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:33:04",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.5319148898124695,
+          "test_loss": 1.3251993656158447,
+          "train_accuracy": 0.7777777777777778,
+          "val_accuracy": 0.5957446808510638
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.5319148898124695,
+        "test_loss": 1.3251993656158447
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000112",
+      "run_name": "run_019",
+      "source_run_id": "20251222_123136_phasea_train_recipe_causal_gru_run_019",
+      "started_at": "2025-12-22T17:32:59",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_020/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_020/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_020",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_020"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_020/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_020/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_020/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_020/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_020/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_020/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_020/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_020/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_020/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_020/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123136_phasea_train_recipe_causal_gru",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.4,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:33:09",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.40425533056259155,
+          "test_loss": 1.4983251094818115,
+          "train_accuracy": 0.5833333333333334,
+          "val_accuracy": 0.5106382978723404
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.40425533056259155,
+        "test_loss": 1.4983251094818115
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000113",
+      "run_name": "run_020",
+      "source_run_id": "20251222_123136_phasea_train_recipe_causal_gru_run_020",
+      "started_at": "2025-12-22T17:33:05",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_021/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_021/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_021",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_021"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_021/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_021/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_021/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_021/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_021/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_021/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_021/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_021/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_021/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_021/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123136_phasea_train_recipe_causal_gru",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:33:12",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.5319148898124695,
+          "test_loss": 1.34305739402771,
+          "train_accuracy": 0.7268518518518519,
+          "val_accuracy": 0.5531914893617021
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.5319148898124695,
+        "test_loss": 1.34305739402771
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000114",
+      "run_name": "run_021",
+      "source_run_id": "20251222_123136_phasea_train_recipe_causal_gru_run_021",
+      "started_at": "2025-12-22T17:33:09",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_022/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_022/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_022",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_022"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_022/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_022/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_022/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_022/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_022/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_022/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_022/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_022/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_022/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_022/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123136_phasea_train_recipe_causal_gru",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:33:17",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.5957446694374084,
+          "test_loss": 1.0039557218551636,
+          "train_accuracy": 0.9768518518518519,
+          "val_accuracy": 0.6595744680851063
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.5957446694374084,
+        "test_loss": 1.0039557218551636
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000115",
+      "run_name": "run_022",
+      "source_run_id": "20251222_123136_phasea_train_recipe_causal_gru_run_022",
+      "started_at": "2025-12-22T17:33:12",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_023/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_023/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_023",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_023"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_023/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_023/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_023/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_023/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_023/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_023/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_023/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_023/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_023/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_023/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123136_phasea_train_recipe_causal_gru",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:33:20",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.5319148898124695,
+          "test_loss": 1.2884501218795776,
+          "train_accuracy": 0.7824074074074074,
+          "val_accuracy": 0.5957446808510638
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.5319148898124695,
+        "test_loss": 1.2884501218795776
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000116",
+      "run_name": "run_023",
+      "source_run_id": "20251222_123136_phasea_train_recipe_causal_gru_run_023",
+      "started_at": "2025-12-22T17:33:17",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_024/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_024/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_024",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_024"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_024/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_024/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_024/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_024/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_024/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_024/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_024/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_024/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_024/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_024/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123136_phasea_train_recipe_causal_gru",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:33:24",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.5744680762290955,
+          "test_loss": 1.2082726955413818,
+          "train_accuracy": 0.8425925925925926,
+          "val_accuracy": 0.5957446808510638
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.5744680762290955,
+        "test_loss": 1.2082726955413818
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000117",
+      "run_name": "run_024",
+      "source_run_id": "20251222_123136_phasea_train_recipe_causal_gru_run_024",
+      "started_at": "2025-12-22T17:33:21",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_025/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_025/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_025",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_025"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_025/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_025/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_025/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_025/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_025/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_025/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_025/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_025/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_025/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_025/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123136_phasea_train_recipe_causal_gru",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.4,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:33:29",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.5531914830207825,
+          "test_loss": 1.2504712343215942,
+          "train_accuracy": 0.8148148148148148,
+          "val_accuracy": 0.5957446808510638
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.5531914830207825,
+        "test_loss": 1.2504712343215942
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000118",
+      "run_name": "run_025",
+      "source_run_id": "20251222_123136_phasea_train_recipe_causal_gru_run_025",
+      "started_at": "2025-12-22T17:33:25",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_026/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_026/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_026",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_026"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_026/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_026/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_026/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_026/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_026/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_026/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_026/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_026/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_026/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_026/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123136_phasea_train_recipe_causal_gru",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:33:32",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.5319148898124695,
+          "test_loss": 1.34305739402771,
+          "train_accuracy": 0.7268518518518519,
+          "val_accuracy": 0.5531914893617021
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.5319148898124695,
+        "test_loss": 1.34305739402771
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000119",
+      "run_name": "run_026",
+      "source_run_id": "20251222_123136_phasea_train_recipe_causal_gru_run_026",
+      "started_at": "2025-12-22T17:33:29",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_027/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_027/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_027",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_027"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_027/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_027/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_027/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_027/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_027/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_027/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_027/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_027/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_027/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_027/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123136_phasea_train_recipe_causal_gru",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:33:37",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.5957446694374084,
+          "test_loss": 1.0039557218551636,
+          "train_accuracy": 0.9768518518518519,
+          "val_accuracy": 0.6595744680851063
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.5957446694374084,
+        "test_loss": 1.0039557218551636
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000120",
+      "run_name": "run_027",
+      "source_run_id": "20251222_123136_phasea_train_recipe_causal_gru_run_027",
+      "started_at": "2025-12-22T17:33:32",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_028/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_028/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_028",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_028"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_028/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_028/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_028/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_028/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_028/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_028/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_028/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_028/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_028/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_028/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123136_phasea_train_recipe_causal_gru",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:33:40",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.5319148898124695,
+          "test_loss": 1.2884501218795776,
+          "train_accuracy": 0.7824074074074074,
+          "val_accuracy": 0.5957446808510638
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.5319148898124695,
+        "test_loss": 1.2884501218795776
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000121",
+      "run_name": "run_028",
+      "source_run_id": "20251222_123136_phasea_train_recipe_causal_gru_run_028",
+      "started_at": "2025-12-22T17:33:37",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_029/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_029/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_029",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_029"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_029/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_029/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_029/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_029/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_029/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_029/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_029/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_029/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_029/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_029/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123136_phasea_train_recipe_causal_gru",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:33:44",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.5744680762290955,
+          "test_loss": 1.2082726955413818,
+          "train_accuracy": 0.8425925925925926,
+          "val_accuracy": 0.5957446808510638
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.5744680762290955,
+        "test_loss": 1.2082726955413818
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000122",
+      "run_name": "run_029",
+      "source_run_id": "20251222_123136_phasea_train_recipe_causal_gru_run_029",
+      "started_at": "2025-12-22T17:33:41",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_030/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_030/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_030",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_030"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_030/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_030/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_030/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_030/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_030/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_030/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_030/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_030/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_030/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123136_phasea_train_recipe_causal_gru/run_030/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123136_phasea_train_recipe_causal_gru",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.4,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:33:49",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.5531914830207825,
+          "test_loss": 1.2504712343215942,
+          "train_accuracy": 0.8148148148148148,
+          "val_accuracy": 0.5957446808510638
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.5531914830207825,
+        "test_loss": 1.2504712343215942
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000123",
+      "run_name": "run_030",
+      "source_run_id": "20251222_123136_phasea_train_recipe_causal_gru_run_030",
+      "started_at": "2025-12-22T17:33:45",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_001/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_001/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_001",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_001"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_001/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_001/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_001/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_001/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_001/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_001/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_001/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_001/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_001/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_001/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123907_baseline_sweep",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 64,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:39:12",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.4680851101875305,
+          "test_loss": 1.4128893613815308,
+          "train_accuracy": 0.6018518518518519,
+          "val_accuracy": 0.48936170212765956
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.4680851101875305,
+        "test_loss": 1.4128893613815308
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000124",
+      "run_name": "run_001",
+      "source_run_id": "20251222_123907_baseline_sweep_run_001",
+      "started_at": "2025-12-22T17:39:07",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_002/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_002/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_002",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_002"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_002/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_002/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_002/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_002/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_002/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_002/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_002/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_002/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_002/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_002/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123907_baseline_sweep",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 64,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:39:17",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.5319148898124695,
+          "test_loss": 1.3052092790603638,
+          "train_accuracy": 0.6574074074074074,
+          "val_accuracy": 0.5957446808510638
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.5319148898124695,
+        "test_loss": 1.3052092790603638
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000125",
+      "run_name": "run_002",
+      "source_run_id": "20251222_123907_baseline_sweep_run_002",
+      "started_at": "2025-12-22T17:39:12",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_003/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_003/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_003",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_003"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_003/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_003/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_003/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_003/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_003/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_003/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_003/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_003/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_003/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_003/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123907_baseline_sweep",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 64,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:39:21",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.42553192377090454,
+          "test_loss": 1.5724003314971924,
+          "train_accuracy": 0.4305555555555556,
+          "val_accuracy": 0.5319148936170213
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.42553192377090454,
+        "test_loss": 1.5724003314971924
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000126",
+      "run_name": "run_003",
+      "source_run_id": "20251222_123907_baseline_sweep_run_003",
+      "started_at": "2025-12-22T17:39:17",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_004/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_004/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_004",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_004"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_004/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_004/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_004/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_004/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_004/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_004/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_004/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_004/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_004/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_004/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123907_baseline_sweep",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 64,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:39:30",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.5531914830207825,
+          "test_loss": 1.190377950668335,
+          "train_accuracy": 0.8101851851851852,
+          "val_accuracy": 0.6808510638297872
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.5531914830207825,
+        "test_loss": 1.190377950668335
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000127",
+      "run_name": "run_004",
+      "source_run_id": "20251222_123907_baseline_sweep_run_004",
+      "started_at": "2025-12-22T17:39:22",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_005/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_005/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_005",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_005"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_005/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_005/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_005/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_005/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_005/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_005/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_005/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_005/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_005/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_005/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123907_baseline_sweep",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 64,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 3,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:39:36",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.3617021143436432,
+          "test_loss": 1.4397072792053223,
+          "train_accuracy": 0.5462962962962963,
+          "val_accuracy": 0.48936170212765956
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.3617021143436432,
+        "test_loss": 1.4397072792053223
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000128",
+      "run_name": "run_005",
+      "source_run_id": "20251222_123907_baseline_sweep_run_005",
+      "started_at": "2025-12-22T17:39:30",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_006/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_006/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_006",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_006"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_006/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_006/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_006/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_006/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_006/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_006/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_006/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_006/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_006/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_006/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123907_baseline_sweep",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 64,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 3,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:39:45",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.5319148898124695,
+          "test_loss": 1.4015189409255981,
+          "train_accuracy": 0.625,
+          "val_accuracy": 0.5957446808510638
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.5319148898124695,
+        "test_loss": 1.4015189409255981
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000129",
+      "run_name": "run_006",
+      "source_run_id": "20251222_123907_baseline_sweep_run_006",
+      "started_at": "2025-12-22T17:39:36",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_007/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_007/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_007",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_007"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_007/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_007/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_007/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_007/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_007/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_007/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_007/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_007/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_007/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_007/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123907_baseline_sweep",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:39:50",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.4893617033958435,
+          "test_loss": 1.3753665685653687,
+          "train_accuracy": 0.6759259259259259,
+          "val_accuracy": 0.48936170212765956
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.4893617033958435,
+        "test_loss": 1.3753665685653687
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000130",
+      "run_name": "run_007",
+      "source_run_id": "20251222_123907_baseline_sweep_run_007",
+      "started_at": "2025-12-22T17:39:45",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_008/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_008/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_008",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_008"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_008/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_008/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_008/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_008/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_008/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_008/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_008/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_008/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_008/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_008/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123907_baseline_sweep",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:39:53",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.4680851101875305,
+          "test_loss": 1.4836409091949463,
+          "train_accuracy": 0.5972222222222222,
+          "val_accuracy": 0.5531914893617021
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.4680851101875305,
+        "test_loss": 1.4836409091949463
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000131",
+      "run_name": "run_008",
+      "source_run_id": "20251222_123907_baseline_sweep_run_008",
+      "started_at": "2025-12-22T17:39:50",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_009/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_009/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_009",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_009"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_009/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_009/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_009/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_009/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_009/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_009/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_009/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_009/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_009/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_009/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123907_baseline_sweep",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:39:59",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.44680851697921753,
+          "test_loss": 1.439115285873413,
+          "train_accuracy": 0.6296296296296297,
+          "val_accuracy": 0.5319148936170213
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.44680851697921753,
+        "test_loss": 1.439115285873413
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000132",
+      "run_name": "run_009",
+      "source_run_id": "20251222_123907_baseline_sweep_run_009",
+      "started_at": "2025-12-22T17:39:53",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_010/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_010/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_010",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_010"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_010/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_010/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_010/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_010/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_010/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_010/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_010/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_010/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_010/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_010/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123907_baseline_sweep",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:40:07",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7659574747085571,
+          "test_loss": 1.119161605834961,
+          "train_accuracy": 0.7870370370370371,
+          "val_accuracy": 0.723404255319149
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7659574747085571,
+        "test_loss": 1.119161605834961
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000133",
+      "run_name": "run_010",
+      "source_run_id": "20251222_123907_baseline_sweep_run_010",
+      "started_at": "2025-12-22T17:40:00",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_011/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_011/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_011",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_011"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_011/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_011/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_011/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_011/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_011/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_011/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_011/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_011/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_011/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_011/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123907_baseline_sweep",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 3,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:40:14",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.44680851697921753,
+          "test_loss": 1.4340161085128784,
+          "train_accuracy": 0.5925925925925926,
+          "val_accuracy": 0.574468085106383
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.44680851697921753,
+        "test_loss": 1.4340161085128784
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000134",
+      "run_name": "run_011",
+      "source_run_id": "20251222_123907_baseline_sweep_run_011",
+      "started_at": "2025-12-22T17:40:07",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_012/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_012/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_012",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_012"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_012/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_012/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_012/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_012/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_012/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_012/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_012/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_012/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_012/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_012/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123907_baseline_sweep",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 3,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:40:24",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7021276354789734,
+          "test_loss": 1.0675914287567139,
+          "train_accuracy": 0.8611111111111112,
+          "val_accuracy": 0.6808510638297872
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7021276354789734,
+        "test_loss": 1.0675914287567139
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000135",
+      "run_name": "run_012",
+      "source_run_id": "20251222_123907_baseline_sweep_run_012",
+      "started_at": "2025-12-22T17:40:15",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_013/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_013/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_013",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_013"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_013/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_013/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_013/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_013/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_013/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_013/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_013/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_013/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_013/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_013/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123907_baseline_sweep",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 256,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:40:30",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.4893617033958435,
+          "test_loss": 1.3557888269424438,
+          "train_accuracy": 0.7175925925925926,
+          "val_accuracy": 0.5319148936170213
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.4893617033958435,
+        "test_loss": 1.3557888269424438
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000136",
+      "run_name": "run_013",
+      "source_run_id": "20251222_123907_baseline_sweep_run_013",
+      "started_at": "2025-12-22T17:40:24",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_014/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_014/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_014",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_014"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_014/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_014/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_014/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_014/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_014/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_014/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_014/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_014/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_014/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_014/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123907_baseline_sweep",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 256,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:40:36",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.6170212626457214,
+          "test_loss": 1.0971665382385254,
+          "train_accuracy": 0.7962962962962963,
+          "val_accuracy": 0.5531914893617021
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.6170212626457214,
+        "test_loss": 1.0971665382385254
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000137",
+      "run_name": "run_014",
+      "source_run_id": "20251222_123907_baseline_sweep_run_014",
+      "started_at": "2025-12-22T17:40:30",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_015/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_015/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_015",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_015"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_015/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_015/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_015/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_015/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_015/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_015/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_015/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_015/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_015/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_015/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123907_baseline_sweep",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 256,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:40:46",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.6808510422706604,
+          "test_loss": 1.1073802709579468,
+          "train_accuracy": 0.7962962962962963,
+          "val_accuracy": 0.574468085106383
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.6808510422706604,
+        "test_loss": 1.1073802709579468
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000138",
+      "run_name": "run_015",
+      "source_run_id": "20251222_123907_baseline_sweep_run_015",
+      "started_at": "2025-12-22T17:40:36",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_016/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_016/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_016",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_016"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_016/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_016/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_016/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_016/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_016/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_016/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_016/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_016/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_016/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_016/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123907_baseline_sweep",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 256,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:40:55",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.6808510422706604,
+          "test_loss": 0.9966776371002197,
+          "train_accuracy": 0.8055555555555556,
+          "val_accuracy": 0.6382978723404256
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.6808510422706604,
+        "test_loss": 0.9966776371002197
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000139",
+      "run_name": "run_016",
+      "source_run_id": "20251222_123907_baseline_sweep_run_016",
+      "started_at": "2025-12-22T17:40:46",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_017/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_017/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_017",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_017"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_017/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_017/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_017/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_017/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_017/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_017/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_017/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_017/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_017/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_017/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123907_baseline_sweep",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 256,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 3,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:41:03",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.5106382966041565,
+          "test_loss": 1.433794379234314,
+          "train_accuracy": 0.5879629629629629,
+          "val_accuracy": 0.5531914893617021
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.5106382966041565,
+        "test_loss": 1.433794379234314
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000140",
+      "run_name": "run_017",
+      "source_run_id": "20251222_123907_baseline_sweep_run_017",
+      "started_at": "2025-12-22T17:40:55",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_018/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_018/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_018",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_018"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_018/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_018/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_018/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_018/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_018/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_018/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_018/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_018/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_018/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_123907_baseline_sweep/run_018/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_123907_baseline_sweep",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 256,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 3,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:41:16",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.6595744490623474,
+          "test_loss": 1.2050734758377075,
+          "train_accuracy": 0.8333333333333334,
+          "val_accuracy": 0.6595744680851063
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.6595744490623474,
+        "test_loss": 1.2050734758377075
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000141",
+      "run_name": "run_018",
+      "source_run_id": "20251222_123907_baseline_sweep_run_018",
+      "started_at": "2025-12-22T17:41:04",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_001/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_001/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_001",
+          "resolved_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_001"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_001/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_001/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_001/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_001/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_001/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_001/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_001/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_001/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_001/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_001/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 8,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_124622_phasec_train_recipe_causal_gru",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:46:28",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.4893617033958435,
+          "test_loss": 1.3753665685653687,
+          "train_accuracy": 0.6759259259259259,
+          "val_accuracy": 0.48936170212765956
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.4893617033958435,
+        "test_loss": 1.3753665685653687
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000142",
+      "run_name": "run_001",
+      "source_run_id": "20251222_124622_phasec_train_recipe_causal_gru_run_001",
+      "started_at": "2025-12-22T17:46:22",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_002/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_002/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_002",
+          "resolved_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_002"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_002/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_002/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_002/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_002/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_002/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_002/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_002/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_002/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_002/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_002/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 8,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 43,
+          "seq_len": 30,
+          "sweep_id": "20251222_124622_phasec_train_recipe_causal_gru",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:46:33",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.4893617033958435,
+          "test_loss": 1.3952696323394775,
+          "train_accuracy": 0.6620370370370371,
+          "val_accuracy": 0.48936170212765956
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.4893617033958435,
+        "test_loss": 1.3952696323394775
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000143",
+      "run_name": "run_002",
+      "source_run_id": "20251222_124622_phasec_train_recipe_causal_gru_run_002",
+      "started_at": "2025-12-22T17:46:28",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_003/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_003/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_003",
+          "resolved_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_003"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_003/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_003/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_003/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_003/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_003/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_003/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_003/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_003/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_003/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_003/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 8,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 44,
+          "seq_len": 30,
+          "sweep_id": "20251222_124622_phasec_train_recipe_causal_gru",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:46:38",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.4893617033958435,
+          "test_loss": 1.5135070085525513,
+          "train_accuracy": 0.5833333333333334,
+          "val_accuracy": 0.425531914893617
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.4893617033958435,
+        "test_loss": 1.5135070085525513
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000144",
+      "run_name": "run_003",
+      "source_run_id": "20251222_124622_phasec_train_recipe_causal_gru_run_003",
+      "started_at": "2025-12-22T17:46:33",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_004/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_004/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_004",
+          "resolved_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_004"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_004/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_004/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_004/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_004/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_004/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_004/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_004/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_004/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_004/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_004/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 8,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 45,
+          "seq_len": 30,
+          "sweep_id": "20251222_124622_phasec_train_recipe_causal_gru",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:46:43",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.4893617033958435,
+          "test_loss": 1.4557360410690308,
+          "train_accuracy": 0.6203703703703703,
+          "val_accuracy": 0.48936170212765956
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.4893617033958435,
+        "test_loss": 1.4557360410690308
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000145",
+      "run_name": "run_004",
+      "source_run_id": "20251222_124622_phasec_train_recipe_causal_gru_run_004",
+      "started_at": "2025-12-22T17:46:38",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_005/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_005/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_005",
+          "resolved_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_005"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_005/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_005/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_005/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_005/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_005/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_005/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_005/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_005/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_005/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_124622_phasec_train_recipe_causal_gru/run_005/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 8,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 46,
+          "seq_len": 30,
+          "sweep_id": "20251222_124622_phasec_train_recipe_causal_gru",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T17:46:48",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.4893617033958435,
+          "test_loss": 1.3690953254699707,
+          "train_accuracy": 0.6527777777777778,
+          "val_accuracy": 0.5319148936170213
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.4893617033958435,
+        "test_loss": 1.3690953254699707
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000146",
+      "run_name": "run_005",
+      "source_run_id": "20251222_124622_phasec_train_recipe_causal_gru_run_005",
+      "started_at": "2025-12-22T17:46:43",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_001/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_001/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_001",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_001"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_001/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_001/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_001/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_001/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_001/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_001/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_001/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_001/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_001/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_001/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_130219_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:02:23",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.5531914830207825,
+          "test_loss": 1.292212963104248,
+          "train_accuracy": 0.7962962962962963,
+          "val_accuracy": 0.6170212765957447
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.5531914830207825,
+        "test_loss": 1.292212963104248
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000147",
+      "run_name": "run_001",
+      "source_run_id": "20251222_130219_phasea_train_recipe_causal_lstm_run_001",
+      "started_at": "2025-12-22T18:02:19",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_002/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_002/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_002",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_002"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_002/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_002/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_002/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_002/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_002/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_002/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_002/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_002/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_002/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_002/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_130219_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:02:29",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.6595744490623474,
+          "test_loss": 1.1313587427139282,
+          "train_accuracy": 0.8379629629629629,
+          "val_accuracy": 0.6382978723404256
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.6595744490623474,
+        "test_loss": 1.1313587427139282
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000148",
+      "run_name": "run_002",
+      "source_run_id": "20251222_130219_phasea_train_recipe_causal_lstm_run_002",
+      "started_at": "2025-12-22T18:02:23",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_003/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_003/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_003",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_003"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_003/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_003/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_003/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_003/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_003/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_003/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_003/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_003/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_003/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_003/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_130219_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:02:33",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.6382978558540344,
+          "test_loss": 1.4040549993515015,
+          "train_accuracy": 0.5601851851851852,
+          "val_accuracy": 0.5319148936170213
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.6382978558540344,
+        "test_loss": 1.4040549993515015
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000149",
+      "run_name": "run_003",
+      "source_run_id": "20251222_130219_phasea_train_recipe_causal_lstm_run_003",
+      "started_at": "2025-12-22T18:02:29",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_004/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_004/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_004",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_004"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_004/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_004/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_004/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_004/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_004/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_004/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_004/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_004/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_004/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_004/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_130219_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:02:37",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.6170212626457214,
+          "test_loss": 1.397007703781128,
+          "train_accuracy": 0.5740740740740741,
+          "val_accuracy": 0.5319148936170213
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.6170212626457214,
+        "test_loss": 1.397007703781128
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000150",
+      "run_name": "run_004",
+      "source_run_id": "20251222_130219_phasea_train_recipe_causal_lstm_run_004",
+      "started_at": "2025-12-22T18:02:33",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_005/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_005/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_005",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_005"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_005/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_005/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_005/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_005/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_005/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_005/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_005/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_005/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_005/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_005/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_130219_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.4,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:02:42",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.5957446694374084,
+          "test_loss": 1.4069362878799438,
+          "train_accuracy": 0.5601851851851852,
+          "val_accuracy": 0.5319148936170213
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.5957446694374084,
+        "test_loss": 1.4069362878799438
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000151",
+      "run_name": "run_005",
+      "source_run_id": "20251222_130219_phasea_train_recipe_causal_lstm_run_005",
+      "started_at": "2025-12-22T18:02:37",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_006/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_006/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_006",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_006"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_006/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_006/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_006/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_006/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_006/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_006/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_006/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_006/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_006/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_006/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_130219_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:02:47",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.5531914830207825,
+          "test_loss": 1.292212963104248,
+          "train_accuracy": 0.7962962962962963,
+          "val_accuracy": 0.6170212765957447
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.5531914830207825,
+        "test_loss": 1.292212963104248
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000152",
+      "run_name": "run_006",
+      "source_run_id": "20251222_130219_phasea_train_recipe_causal_lstm_run_006",
+      "started_at": "2025-12-22T18:02:42",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_007/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_007/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_007",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_007"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_007/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_007/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_007/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_007/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_007/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_007/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_007/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_007/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_007/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_007/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_130219_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:02:53",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.6595744490623474,
+          "test_loss": 1.1313587427139282,
+          "train_accuracy": 0.8379629629629629,
+          "val_accuracy": 0.6382978723404256
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.6595744490623474,
+        "test_loss": 1.1313587427139282
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000153",
+      "run_name": "run_007",
+      "source_run_id": "20251222_130219_phasea_train_recipe_causal_lstm_run_007",
+      "started_at": "2025-12-22T18:02:47",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_008/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_008/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_008",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_008"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_008/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_008/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_008/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_008/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_008/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_008/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_008/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_008/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_008/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_008/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_130219_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:02:57",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.6382978558540344,
+          "test_loss": 1.4040549993515015,
+          "train_accuracy": 0.5601851851851852,
+          "val_accuracy": 0.5319148936170213
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.6382978558540344,
+        "test_loss": 1.4040549993515015
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000154",
+      "run_name": "run_008",
+      "source_run_id": "20251222_130219_phasea_train_recipe_causal_lstm_run_008",
+      "started_at": "2025-12-22T18:02:53",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_009/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_009/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_009",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_009"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_009/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_009/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_009/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_009/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_009/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_009/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_009/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_009/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_009/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_009/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_130219_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:03:01",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.6170212626457214,
+          "test_loss": 1.397007703781128,
+          "train_accuracy": 0.5740740740740741,
+          "val_accuracy": 0.5319148936170213
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.6170212626457214,
+        "test_loss": 1.397007703781128
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000155",
+      "run_name": "run_009",
+      "source_run_id": "20251222_130219_phasea_train_recipe_causal_lstm_run_009",
+      "started_at": "2025-12-22T18:02:57",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_010/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_010/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_010",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_010"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_010/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_010/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_010/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_010/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_010/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_010/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_010/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_010/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_010/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_010/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_130219_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.4,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:03:06",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.5957446694374084,
+          "test_loss": 1.4069362878799438,
+          "train_accuracy": 0.5601851851851852,
+          "val_accuracy": 0.5319148936170213
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.5957446694374084,
+        "test_loss": 1.4069362878799438
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000156",
+      "run_name": "run_010",
+      "source_run_id": "20251222_130219_phasea_train_recipe_causal_lstm_run_010",
+      "started_at": "2025-12-22T18:03:02",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_011/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_011/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_011",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_011"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_011/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_011/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_011/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_011/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_011/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_011/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_011/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_011/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_011/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_011/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_130219_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:03:10",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.5531914830207825,
+          "test_loss": 1.2810018062591553,
+          "train_accuracy": 0.7916666666666666,
+          "val_accuracy": 0.6170212765957447
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.5531914830207825,
+        "test_loss": 1.2810018062591553
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000157",
+      "run_name": "run_011",
+      "source_run_id": "20251222_130219_phasea_train_recipe_causal_lstm_run_011",
+      "started_at": "2025-12-22T18:03:06",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_012/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_012/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_012",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_012"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_012/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_012/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_012/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_012/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_012/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_012/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_012/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_012/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_012/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_012/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_130219_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:03:14",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.6595744490623474,
+          "test_loss": 1.1359366178512573,
+          "train_accuracy": 0.8425925925925926,
+          "val_accuracy": 0.6382978723404256
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.6595744490623474,
+        "test_loss": 1.1359366178512573
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000158",
+      "run_name": "run_012",
+      "source_run_id": "20251222_130219_phasea_train_recipe_causal_lstm_run_012",
+      "started_at": "2025-12-22T18:03:10",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_013/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_013/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_013",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_013"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_013/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_013/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_013/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_013/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_013/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_013/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_013/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_013/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_013/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_013/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_130219_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:03:18",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.6595744490623474,
+          "test_loss": 1.1958001852035522,
+          "train_accuracy": 0.8009259259259259,
+          "val_accuracy": 0.6382978723404256
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.6595744490623474,
+        "test_loss": 1.1958001852035522
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000159",
+      "run_name": "run_013",
+      "source_run_id": "20251222_130219_phasea_train_recipe_causal_lstm_run_013",
+      "started_at": "2025-12-22T18:03:14",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_014/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_014/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_014",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_014"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_014/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_014/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_014/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_014/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_014/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_014/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_014/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_014/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_014/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_014/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_130219_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:03:22",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.6595744490623474,
+          "test_loss": 1.2070631980895996,
+          "train_accuracy": 0.8055555555555556,
+          "val_accuracy": 0.6595744680851063
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.6595744490623474,
+        "test_loss": 1.2070631980895996
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000160",
+      "run_name": "run_014",
+      "source_run_id": "20251222_130219_phasea_train_recipe_causal_lstm_run_014",
+      "started_at": "2025-12-22T18:03:18",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_015/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_015/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_015",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_015"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_015/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_015/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_015/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_015/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_015/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_015/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_015/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_015/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_015/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_015/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_130219_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.4,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:03:27",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.6382978558540344,
+          "test_loss": 1.2530794143676758,
+          "train_accuracy": 0.7916666666666666,
+          "val_accuracy": 0.6595744680851063
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.6382978558540344,
+        "test_loss": 1.2530794143676758
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000161",
+      "run_name": "run_015",
+      "source_run_id": "20251222_130219_phasea_train_recipe_causal_lstm_run_015",
+      "started_at": "2025-12-22T18:03:22",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_016/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_016/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_016",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_016"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_016/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_016/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_016/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_016/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_016/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_016/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_016/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_016/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_016/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_016/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_130219_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:03:31",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.5531914830207825,
+          "test_loss": 1.2810018062591553,
+          "train_accuracy": 0.7916666666666666,
+          "val_accuracy": 0.6170212765957447
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.5531914830207825,
+        "test_loss": 1.2810018062591553
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000162",
+      "run_name": "run_016",
+      "source_run_id": "20251222_130219_phasea_train_recipe_causal_lstm_run_016",
+      "started_at": "2025-12-22T18:03:27",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_017/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_017/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_017",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_017"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_017/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_017/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_017/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_017/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_017/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_017/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_017/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_017/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_017/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_017/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_130219_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:03:35",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.6595744490623474,
+          "test_loss": 1.1359366178512573,
+          "train_accuracy": 0.8425925925925926,
+          "val_accuracy": 0.6382978723404256
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.6595744490623474,
+        "test_loss": 1.1359366178512573
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000163",
+      "run_name": "run_017",
+      "source_run_id": "20251222_130219_phasea_train_recipe_causal_lstm_run_017",
+      "started_at": "2025-12-22T18:03:31",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_018/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_018/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_018",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_018"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_018/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_018/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_018/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_018/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_018/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_018/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_018/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_018/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_018/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_018/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_130219_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:03:39",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.6595744490623474,
+          "test_loss": 1.1958001852035522,
+          "train_accuracy": 0.8009259259259259,
+          "val_accuracy": 0.6382978723404256
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.6595744490623474,
+        "test_loss": 1.1958001852035522
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000164",
+      "run_name": "run_018",
+      "source_run_id": "20251222_130219_phasea_train_recipe_causal_lstm_run_018",
+      "started_at": "2025-12-22T18:03:35",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_019/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_019/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_019",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_019"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_019/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_019/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_019/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_019/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_019/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_019/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_019/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_019/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_019/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_019/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_130219_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:03:44",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.6595744490623474,
+          "test_loss": 1.2070631980895996,
+          "train_accuracy": 0.8055555555555556,
+          "val_accuracy": 0.6595744680851063
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.6595744490623474,
+        "test_loss": 1.2070631980895996
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000165",
+      "run_name": "run_019",
+      "source_run_id": "20251222_130219_phasea_train_recipe_causal_lstm_run_019",
+      "started_at": "2025-12-22T18:03:39",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_020/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_020/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_020",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_020"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_020/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_020/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_020/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_020/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_020/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_020/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_020/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_020/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_020/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_020/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_130219_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.4,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:03:49",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.6382978558540344,
+          "test_loss": 1.2530794143676758,
+          "train_accuracy": 0.7916666666666666,
+          "val_accuracy": 0.6595744680851063
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.6382978558540344,
+        "test_loss": 1.2530794143676758
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000166",
+      "run_name": "run_020",
+      "source_run_id": "20251222_130219_phasea_train_recipe_causal_lstm_run_020",
+      "started_at": "2025-12-22T18:03:44",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_021/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_021/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_021",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_021"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_021/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_021/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_021/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_021/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_021/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_021/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_021/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_021/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_021/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_021/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_130219_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:03:52",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7234042286872864,
+          "test_loss": 0.7583131194114685,
+          "train_accuracy": 0.9814814814814815,
+          "val_accuracy": 0.6808510638297872
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7234042286872864,
+        "test_loss": 0.7583131194114685
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000167",
+      "run_name": "run_021",
+      "source_run_id": "20251222_130219_phasea_train_recipe_causal_lstm_run_021",
+      "started_at": "2025-12-22T18:03:49",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_022/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_022/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_022",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_022"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_022/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_022/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_022/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_022/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_022/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_022/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_022/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_022/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_022/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_022/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_130219_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:03:57",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7659574747085571,
+          "test_loss": 0.6562426090240479,
+          "train_accuracy": 0.9814814814814815,
+          "val_accuracy": 0.6808510638297872
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7659574747085571,
+        "test_loss": 0.6562426090240479
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000168",
+      "run_name": "run_022",
+      "source_run_id": "20251222_130219_phasea_train_recipe_causal_lstm_run_022",
+      "started_at": "2025-12-22T18:03:52",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_023/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_023/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_023",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_023"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_023/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_023/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_023/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_023/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_023/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_023/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_023/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_023/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_023/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_023/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_130219_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:04:00",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.6382978558540344,
+          "test_loss": 1.1202610731124878,
+          "train_accuracy": 0.8703703703703703,
+          "val_accuracy": 0.6595744680851063
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.6382978558540344,
+        "test_loss": 1.1202610731124878
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000169",
+      "run_name": "run_023",
+      "source_run_id": "20251222_130219_phasea_train_recipe_causal_lstm_run_023",
+      "started_at": "2025-12-22T18:03:57",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_024/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_024/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_024",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_024"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_024/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_024/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_024/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_024/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_024/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_024/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_024/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_024/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_024/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_024/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_130219_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:04:04",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.6170212626457214,
+          "test_loss": 1.1457489728927612,
+          "train_accuracy": 0.8333333333333334,
+          "val_accuracy": 0.6382978723404256
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.6170212626457214,
+        "test_loss": 1.1457489728927612
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000170",
+      "run_name": "run_024",
+      "source_run_id": "20251222_130219_phasea_train_recipe_causal_lstm_run_024",
+      "started_at": "2025-12-22T18:04:01",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_025/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_025/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_025",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_025"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_025/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_025/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_025/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_025/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_025/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_025/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_025/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_025/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_025/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_025/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_130219_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.4,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:04:08",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7021276354789734,
+          "test_loss": 1.006375789642334,
+          "train_accuracy": 0.9120370370370371,
+          "val_accuracy": 0.6595744680851063
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7021276354789734,
+        "test_loss": 1.006375789642334
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000171",
+      "run_name": "run_025",
+      "source_run_id": "20251222_130219_phasea_train_recipe_causal_lstm_run_025",
+      "started_at": "2025-12-22T18:04:04",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_026/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_026/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_026",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_026"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_026/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_026/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_026/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_026/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_026/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_026/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_026/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_026/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_026/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_026/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_130219_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:04:11",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7234042286872864,
+          "test_loss": 0.7583131194114685,
+          "train_accuracy": 0.9814814814814815,
+          "val_accuracy": 0.6808510638297872
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7234042286872864,
+        "test_loss": 0.7583131194114685
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000172",
+      "run_name": "run_026",
+      "source_run_id": "20251222_130219_phasea_train_recipe_causal_lstm_run_026",
+      "started_at": "2025-12-22T18:04:08",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_027/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_027/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_027",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_027"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_027/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_027/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_027/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_027/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_027/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_027/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_027/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_027/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_027/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_027/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_130219_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:04:16",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7659574747085571,
+          "test_loss": 0.6562426090240479,
+          "train_accuracy": 0.9814814814814815,
+          "val_accuracy": 0.6808510638297872
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7659574747085571,
+        "test_loss": 0.6562426090240479
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000173",
+      "run_name": "run_027",
+      "source_run_id": "20251222_130219_phasea_train_recipe_causal_lstm_run_027",
+      "started_at": "2025-12-22T18:04:12",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_028/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_028/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_028",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_028"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_028/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_028/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_028/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_028/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_028/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_028/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_028/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_028/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_028/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_028/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_130219_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:04:19",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.6382978558540344,
+          "test_loss": 1.1202610731124878,
+          "train_accuracy": 0.8703703703703703,
+          "val_accuracy": 0.6595744680851063
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.6382978558540344,
+        "test_loss": 1.1202610731124878
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000174",
+      "run_name": "run_028",
+      "source_run_id": "20251222_130219_phasea_train_recipe_causal_lstm_run_028",
+      "started_at": "2025-12-22T18:04:16",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_029/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_029/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_029",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_029"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_029/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_029/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_029/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_029/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_029/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_029/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_029/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_029/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_029/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_029/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_130219_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:04:22",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.6170212626457214,
+          "test_loss": 1.1457489728927612,
+          "train_accuracy": 0.8333333333333334,
+          "val_accuracy": 0.6382978723404256
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.6170212626457214,
+        "test_loss": 1.1457489728927612
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000175",
+      "run_name": "run_029",
+      "source_run_id": "20251222_130219_phasea_train_recipe_causal_lstm_run_029",
+      "started_at": "2025-12-22T18:04:19",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_030/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_030/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_030",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_030"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_030/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_030/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_030/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_030/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_030/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_030/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_030/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_030/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_030/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_130219_phasea_train_recipe_causal_lstm/run_030/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_130219_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.4,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:04:27",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7021276354789734,
+          "test_loss": 1.006375789642334,
+          "train_accuracy": 0.9120370370370371,
+          "val_accuracy": 0.6595744680851063
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7021276354789734,
+        "test_loss": 1.006375789642334
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000176",
+      "run_name": "run_030",
+      "source_run_id": "20251222_130219_phasea_train_recipe_causal_lstm_run_030",
+      "started_at": "2025-12-22T18:04:23",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_001/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_001/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_001",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_001"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_001/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_001/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_001/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_001/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_001/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_001/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_001/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_001/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_001/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_001/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_131323_phaseb_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 64,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:13:27",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.5957446694374084,
+          "test_loss": 1.0301843881607056,
+          "train_accuracy": 0.9444444444444444,
+          "val_accuracy": 0.6595744680851063
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.5957446694374084,
+        "test_loss": 1.0301843881607056
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000177",
+      "run_name": "run_001",
+      "source_run_id": "20251222_131323_phaseb_train_recipe_causal_lstm_run_001",
+      "started_at": "2025-12-22T18:13:23",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_002/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_002/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_002",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_002"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_002/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_002/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_002/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_002/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_002/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_002/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_002/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_002/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_002/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_002/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_131323_phaseb_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 64,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:13:31",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7872340679168701,
+          "test_loss": 0.6466227769851685,
+          "train_accuracy": 0.9675925925925926,
+          "val_accuracy": 0.7446808510638298
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7872340679168701,
+        "test_loss": 0.6466227769851685
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000178",
+      "run_name": "run_002",
+      "source_run_id": "20251222_131323_phaseb_train_recipe_causal_lstm_run_002",
+      "started_at": "2025-12-22T18:13:27",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_003/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_003/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_003",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_003"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_003/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_003/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_003/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_003/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_003/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_003/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_003/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_003/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_003/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_003/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_131323_phaseb_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 64,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:13:36",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7659574747085571,
+          "test_loss": 0.6914288401603699,
+          "train_accuracy": 0.9768518518518519,
+          "val_accuracy": 0.723404255319149
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7659574747085571,
+        "test_loss": 0.6914288401603699
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000179",
+      "run_name": "run_003",
+      "source_run_id": "20251222_131323_phaseb_train_recipe_causal_lstm_run_003",
+      "started_at": "2025-12-22T18:13:31",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_004/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_004/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_004",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_004"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_004/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_004/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_004/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_004/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_004/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_004/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_004/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_004/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_004/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_004/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_131323_phaseb_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 64,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:13:42",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.8510638475418091,
+          "test_loss": 0.6707156300544739,
+          "train_accuracy": 0.9768518518518519,
+          "val_accuracy": 0.7021276595744681
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.8510638475418091,
+        "test_loss": 0.6707156300544739
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000180",
+      "run_name": "run_004",
+      "source_run_id": "20251222_131323_phaseb_train_recipe_causal_lstm_run_004",
+      "started_at": "2025-12-22T18:13:36",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_005/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_005/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_005",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_005"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_005/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_005/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_005/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_005/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_005/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_005/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_005/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_005/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_005/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_005/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_131323_phaseb_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 64,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 3,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:13:48",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7021276354789734,
+          "test_loss": 0.8612326979637146,
+          "train_accuracy": 0.9768518518518519,
+          "val_accuracy": 0.7021276595744681
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7021276354789734,
+        "test_loss": 0.8612326979637146
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000181",
+      "run_name": "run_005",
+      "source_run_id": "20251222_131323_phaseb_train_recipe_causal_lstm_run_005",
+      "started_at": "2025-12-22T18:13:42",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_006/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_006/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_006",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_006"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_006/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_006/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_006/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_006/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_006/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_006/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_006/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_006/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_006/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_006/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_131323_phaseb_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 64,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 3,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:13:57",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.8085106611251831,
+          "test_loss": 0.6560238599777222,
+          "train_accuracy": 0.9768518518518519,
+          "val_accuracy": 0.723404255319149
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.8085106611251831,
+        "test_loss": 0.6560238599777222
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000182",
+      "run_name": "run_006",
+      "source_run_id": "20251222_131323_phaseb_train_recipe_causal_lstm_run_006",
+      "started_at": "2025-12-22T18:13:49",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_007/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_007/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_007",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_007"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_007/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_007/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_007/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_007/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_007/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_007/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_007/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_007/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_007/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_007/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_131323_phaseb_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:14:01",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7659574747085571,
+          "test_loss": 0.6562426090240479,
+          "train_accuracy": 0.9814814814814815,
+          "val_accuracy": 0.6808510638297872
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7659574747085571,
+        "test_loss": 0.6562426090240479
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000183",
+      "run_name": "run_007",
+      "source_run_id": "20251222_131323_phaseb_train_recipe_causal_lstm_run_007",
+      "started_at": "2025-12-22T18:13:57",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_008/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_008/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_008",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_008"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_008/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_008/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_008/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_008/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_008/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_008/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_008/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_008/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_008/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_008/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_131323_phaseb_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:14:05",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.8297872543334961,
+          "test_loss": 0.6190508604049683,
+          "train_accuracy": 0.9722222222222222,
+          "val_accuracy": 0.723404255319149
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.8297872543334961,
+        "test_loss": 0.6190508604049683
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000184",
+      "run_name": "run_008",
+      "source_run_id": "20251222_131323_phaseb_train_recipe_causal_lstm_run_008",
+      "started_at": "2025-12-22T18:14:01",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_009/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_009/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_009",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_009"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_009/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_009/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_009/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_009/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_009/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_009/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_009/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_009/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_009/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_009/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_131323_phaseb_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:14:10",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7659574747085571,
+          "test_loss": 0.7775782942771912,
+          "train_accuracy": 0.9629629629629629,
+          "val_accuracy": 0.6808510638297872
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7659574747085571,
+        "test_loss": 0.7775782942771912
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000185",
+      "run_name": "run_009",
+      "source_run_id": "20251222_131323_phaseb_train_recipe_causal_lstm_run_009",
+      "started_at": "2025-12-22T18:14:05",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_010/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_010/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_010",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_010"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_010/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_010/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_010/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_010/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_010/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_010/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_010/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_010/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_010/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_010/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_131323_phaseb_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:14:17",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7659574747085571,
+          "test_loss": 0.7473808526992798,
+          "train_accuracy": 0.9768518518518519,
+          "val_accuracy": 0.7872340425531915
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7659574747085571,
+        "test_loss": 0.7473808526992798
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000186",
+      "run_name": "run_010",
+      "source_run_id": "20251222_131323_phaseb_train_recipe_causal_lstm_run_010",
+      "started_at": "2025-12-22T18:14:10",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_011/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_011/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_011",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_011"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_011/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_011/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_011/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_011/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_011/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_011/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_011/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_011/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_011/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_011/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_131323_phaseb_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 3,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:14:24",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7872340679168701,
+          "test_loss": 0.5636537671089172,
+          "train_accuracy": 0.9675925925925926,
+          "val_accuracy": 0.6808510638297872
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7872340679168701,
+        "test_loss": 0.5636537671089172
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000187",
+      "run_name": "run_011",
+      "source_run_id": "20251222_131323_phaseb_train_recipe_causal_lstm_run_011",
+      "started_at": "2025-12-22T18:14:17",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_012/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_012/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_012",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_012"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_012/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_012/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_012/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_012/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_012/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_012/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_012/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_012/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_012/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_012/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_131323_phaseb_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 3,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:14:32",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7872340679168701,
+          "test_loss": 0.6778815984725952,
+          "train_accuracy": 0.9722222222222222,
+          "val_accuracy": 0.723404255319149
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7872340679168701,
+        "test_loss": 0.6778815984725952
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000188",
+      "run_name": "run_012",
+      "source_run_id": "20251222_131323_phaseb_train_recipe_causal_lstm_run_012",
+      "started_at": "2025-12-22T18:14:24",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_013/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_013/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_013",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_013"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_013/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_013/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_013/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_013/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_013/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_013/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_013/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_013/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_013/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_013/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_131323_phaseb_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 256,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:14:36",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7234042286872864,
+          "test_loss": 0.8614318370819092,
+          "train_accuracy": 0.9629629629629629,
+          "val_accuracy": 0.723404255319149
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7234042286872864,
+        "test_loss": 0.8614318370819092
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000189",
+      "run_name": "run_013",
+      "source_run_id": "20251222_131323_phaseb_train_recipe_causal_lstm_run_013",
+      "started_at": "2025-12-22T18:14:32",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_014/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_014/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_014",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_014"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_014/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_014/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_014/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_014/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_014/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_014/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_014/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_014/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_014/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_014/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_131323_phaseb_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 256,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:14:42",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.8297872543334961,
+          "test_loss": 0.6628385186195374,
+          "train_accuracy": 0.9814814814814815,
+          "val_accuracy": 0.723404255319149
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.8297872543334961,
+        "test_loss": 0.6628385186195374
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000190",
+      "run_name": "run_014",
+      "source_run_id": "20251222_131323_phaseb_train_recipe_causal_lstm_run_014",
+      "started_at": "2025-12-22T18:14:36",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_015/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_015/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_015",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_015"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_015/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_015/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_015/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_015/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_015/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_015/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_015/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_015/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_015/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_015/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_131323_phaseb_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 256,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:14:49",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7872340679168701,
+          "test_loss": 0.6755763292312622,
+          "train_accuracy": 0.9768518518518519,
+          "val_accuracy": 0.6808510638297872
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7872340679168701,
+        "test_loss": 0.6755763292312622
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000191",
+      "run_name": "run_015",
+      "source_run_id": "20251222_131323_phaseb_train_recipe_causal_lstm_run_015",
+      "started_at": "2025-12-22T18:14:42",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_016/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_016/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_016",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_016"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_016/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_016/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_016/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_016/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_016/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_016/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_016/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_016/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_016/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_016/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_131323_phaseb_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 256,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:14:58",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.8297872543334961,
+          "test_loss": 0.7410680651664734,
+          "train_accuracy": 0.9768518518518519,
+          "val_accuracy": 0.723404255319149
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.8297872543334961,
+        "test_loss": 0.7410680651664734
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000192",
+      "run_name": "run_016",
+      "source_run_id": "20251222_131323_phaseb_train_recipe_causal_lstm_run_016",
+      "started_at": "2025-12-22T18:14:49",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_017/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_017/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_017",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_017"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_017/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_017/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_017/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_017/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_017/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_017/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_017/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_017/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_017/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_017/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_131323_phaseb_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 256,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 3,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:15:09",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.8297872543334961,
+          "test_loss": 0.6152550578117371,
+          "train_accuracy": 0.9490740740740741,
+          "val_accuracy": 0.723404255319149
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.8297872543334961,
+        "test_loss": 0.6152550578117371
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000193",
+      "run_name": "run_017",
+      "source_run_id": "20251222_131323_phaseb_train_recipe_causal_lstm_run_017",
+      "started_at": "2025-12-22T18:14:58",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_018/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_018/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_018",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_018"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_018/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_018/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_018/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_018/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_018/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_018/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_018/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_018/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_018/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_131323_phaseb_train_recipe_causal_lstm/run_018/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_131323_phaseb_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 256,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 3,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:15:21",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7659574747085571,
+          "test_loss": 0.8745986223220825,
+          "train_accuracy": 0.9629629629629629,
+          "val_accuracy": 0.7659574468085106
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7659574747085571,
+        "test_loss": 0.8745986223220825
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000194",
+      "run_name": "run_018",
+      "source_run_id": "20251222_131323_phaseb_train_recipe_causal_lstm_run_018",
+      "started_at": "2025-12-22T18:15:10",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_001/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_001/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_001",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_001"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_001/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_001/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_001/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_001/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_001/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_001/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_001/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_001/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_001/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_001/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 8,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_132031_phasec_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:20:39",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7659574747085571,
+          "test_loss": 0.7473808526992798,
+          "train_accuracy": 0.9768518518518519,
+          "val_accuracy": 0.7872340425531915
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7659574747085571,
+        "test_loss": 0.7473808526992798
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000195",
+      "run_name": "run_001",
+      "source_run_id": "20251222_132031_phasec_train_recipe_causal_lstm_run_001",
+      "started_at": "2025-12-22T18:20:31",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_002/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_002/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_002",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_002"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_002/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_002/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_002/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_002/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_002/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_002/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_002/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_002/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_002/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_002/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 8,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 43,
+          "seq_len": 30,
+          "sweep_id": "20251222_132031_phasec_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:20:47",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7872340679168701,
+          "test_loss": 0.5809310078620911,
+          "train_accuracy": 0.9768518518518519,
+          "val_accuracy": 0.7446808510638298
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7872340679168701,
+        "test_loss": 0.5809310078620911
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000196",
+      "run_name": "run_002",
+      "source_run_id": "20251222_132031_phasec_train_recipe_causal_lstm_run_002",
+      "started_at": "2025-12-22T18:20:39",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_003/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_003/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_003",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_003"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_003/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_003/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_003/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_003/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_003/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_003/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_003/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_003/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_003/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_003/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 8,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 44,
+          "seq_len": 30,
+          "sweep_id": "20251222_132031_phasec_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:20:53",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7872340679168701,
+          "test_loss": 0.4798610806465149,
+          "train_accuracy": 0.9814814814814815,
+          "val_accuracy": 0.8085106382978723
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7872340679168701,
+        "test_loss": 0.4798610806465149
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000197",
+      "run_name": "run_003",
+      "source_run_id": "20251222_132031_phasec_train_recipe_causal_lstm_run_003",
+      "started_at": "2025-12-22T18:20:47",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_004/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_004/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_004",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_004"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_004/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_004/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_004/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_004/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_004/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_004/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_004/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_004/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_004/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_004/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 8,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 45,
+          "seq_len": 30,
+          "sweep_id": "20251222_132031_phasec_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:20:59",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7659574747085571,
+          "test_loss": 0.6473563313484192,
+          "train_accuracy": 0.9444444444444444,
+          "val_accuracy": 0.7446808510638298
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7659574747085571,
+        "test_loss": 0.6473563313484192
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000198",
+      "run_name": "run_004",
+      "source_run_id": "20251222_132031_phasec_train_recipe_causal_lstm_run_004",
+      "started_at": "2025-12-22T18:20:53",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_005/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_005/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_005",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_005"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_005/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_005/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_005/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_005/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_005/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_005/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_005/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_005/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_005/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132031_phasec_train_recipe_causal_lstm/run_005/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 8,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 46,
+          "seq_len": 30,
+          "sweep_id": "20251222_132031_phasec_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:21:06",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7659574747085571,
+          "test_loss": 0.8610178232192993,
+          "train_accuracy": 0.9583333333333334,
+          "val_accuracy": 0.723404255319149
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7659574747085571,
+        "test_loss": 0.8610178232192993
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000199",
+      "run_name": "run_005",
+      "source_run_id": "20251222_132031_phasec_train_recipe_causal_lstm_run_005",
+      "started_at": "2025-12-22T18:20:59",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_001/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_001/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_001",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_001"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_001/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_001/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_001/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_001/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_001/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_001/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_001/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_001/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_001/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_001/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_132822_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.0,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:28:27",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7446808218955994,
+          "test_loss": 0.7836602330207825,
+          "train_accuracy": 0.9444444444444444,
+          "val_accuracy": 0.6808510638297872
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7446808218955994,
+        "test_loss": 0.7836602330207825
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000200",
+      "run_name": "run_001",
+      "source_run_id": "20251222_132822_phasea_train_recipe_causal_lstm_run_001",
+      "started_at": "2025-12-22T18:28:22",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    }
+  ],
+  "schema_version": 1,
+  "shard": 1
+}

--- a/docs/legacy/export/v1/runs/runs-002.json
+++ b/docs/legacy/export/v1/runs/runs-002.json
@@ -1,0 +1,14467 @@
+{
+  "kind": "signlab.legacy-run-index",
+  "records": [
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_002/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_002/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_002",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_002"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_002/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_002/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_002/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_002/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_002/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_002/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_002/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_002/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_002/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_002/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_132822_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.1,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:28:32",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.6808510422706604,
+          "test_loss": 0.7618635296821594,
+          "train_accuracy": 0.9351851851851852,
+          "val_accuracy": 0.723404255319149
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.6808510422706604,
+        "test_loss": 0.7618635296821594
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000201",
+      "run_name": "run_002",
+      "source_run_id": "20251222_132822_phasea_train_recipe_causal_lstm_run_002",
+      "started_at": "2025-12-22T18:28:27",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_003/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_003/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_003",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_003"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_003/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_003/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_003/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_003/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_003/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_003/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_003/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_003/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_003/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_003/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_132822_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.2,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:28:38",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7659574747085571,
+          "test_loss": 0.6943641901016235,
+          "train_accuracy": 0.9583333333333334,
+          "val_accuracy": 0.723404255319149
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7659574747085571,
+        "test_loss": 0.6943641901016235
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000202",
+      "run_name": "run_003",
+      "source_run_id": "20251222_132822_phasea_train_recipe_causal_lstm_run_003",
+      "started_at": "2025-12-22T18:28:32",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_004/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_004/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_004",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_004"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_004/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_004/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_004/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_004/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_004/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_004/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_004/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_004/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_004/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_004/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_132822_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.3,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:28:43",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7234042286872864,
+          "test_loss": 0.8241779804229736,
+          "train_accuracy": 0.8842592592592593,
+          "val_accuracy": 0.7021276595744681
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7234042286872864,
+        "test_loss": 0.8241779804229736
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000203",
+      "run_name": "run_004",
+      "source_run_id": "20251222_132822_phasea_train_recipe_causal_lstm_run_004",
+      "started_at": "2025-12-22T18:28:38",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_005/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_005/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_005",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_005"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_005/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_005/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_005/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_005/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_005/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_005/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_005/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_005/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_005/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_005/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_132822_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.4,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:28:49",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7021276354789734,
+          "test_loss": 0.7335032224655151,
+          "train_accuracy": 0.9259259259259259,
+          "val_accuracy": 0.723404255319149
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7021276354789734,
+        "test_loss": 0.7335032224655151
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000204",
+      "run_name": "run_005",
+      "source_run_id": "20251222_132822_phasea_train_recipe_causal_lstm_run_005",
+      "started_at": "2025-12-22T18:28:43",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_006/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_006/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_006",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_006"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_006/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_006/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_006/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_006/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_006/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_006/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_006/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_006/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_006/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_006/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_132822_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.0,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:28:54",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7446808218955994,
+          "test_loss": 0.7836602330207825,
+          "train_accuracy": 0.9444444444444444,
+          "val_accuracy": 0.6808510638297872
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7446808218955994,
+        "test_loss": 0.7836602330207825
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000205",
+      "run_name": "run_006",
+      "source_run_id": "20251222_132822_phasea_train_recipe_causal_lstm_run_006",
+      "started_at": "2025-12-22T18:28:49",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_007/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_007/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_007",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_007"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_007/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_007/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_007/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_007/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_007/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_007/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_007/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_007/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_007/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_007/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_132822_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.1,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:28:59",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.6808510422706604,
+          "test_loss": 0.7618635296821594,
+          "train_accuracy": 0.9351851851851852,
+          "val_accuracy": 0.723404255319149
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.6808510422706604,
+        "test_loss": 0.7618635296821594
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000206",
+      "run_name": "run_007",
+      "source_run_id": "20251222_132822_phasea_train_recipe_causal_lstm_run_007",
+      "started_at": "2025-12-22T18:28:54",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_008/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_008/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_008",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_008"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_008/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_008/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_008/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_008/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_008/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_008/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_008/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_008/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_008/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_008/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_132822_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.2,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:29:04",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7659574747085571,
+          "test_loss": 0.6943641901016235,
+          "train_accuracy": 0.9583333333333334,
+          "val_accuracy": 0.723404255319149
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7659574747085571,
+        "test_loss": 0.6943641901016235
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000207",
+      "run_name": "run_008",
+      "source_run_id": "20251222_132822_phasea_train_recipe_causal_lstm_run_008",
+      "started_at": "2025-12-22T18:28:59",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_009/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_009/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_009",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_009"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_009/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_009/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_009/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_009/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_009/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_009/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_009/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_009/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_009/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_009/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_132822_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.3,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:29:10",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7234042286872864,
+          "test_loss": 0.8241779804229736,
+          "train_accuracy": 0.8842592592592593,
+          "val_accuracy": 0.7021276595744681
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7234042286872864,
+        "test_loss": 0.8241779804229736
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000208",
+      "run_name": "run_009",
+      "source_run_id": "20251222_132822_phasea_train_recipe_causal_lstm_run_009",
+      "started_at": "2025-12-22T18:29:05",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_010/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_010/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_010",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_010"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_010/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_010/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_010/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_010/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_010/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_010/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_010/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_010/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_010/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_010/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_132822_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.4,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:29:16",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7021276354789734,
+          "test_loss": 0.7335032224655151,
+          "train_accuracy": 0.9259259259259259,
+          "val_accuracy": 0.723404255319149
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7021276354789734,
+        "test_loss": 0.7335032224655151
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000209",
+      "run_name": "run_010",
+      "source_run_id": "20251222_132822_phasea_train_recipe_causal_lstm_run_010",
+      "started_at": "2025-12-22T18:29:10",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_011/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_011/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_011",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_011"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_011/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_011/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_011/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_011/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_011/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_011/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_011/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_011/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_011/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_011/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_132822_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.0,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:29:20",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.8297872543334961,
+          "test_loss": 0.5621059536933899,
+          "train_accuracy": 0.9861111111111112,
+          "val_accuracy": 0.7021276595744681
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.8297872543334961,
+        "test_loss": 0.5621059536933899
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000210",
+      "run_name": "run_011",
+      "source_run_id": "20251222_132822_phasea_train_recipe_causal_lstm_run_011",
+      "started_at": "2025-12-22T18:29:16",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_012/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_012/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_012",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_012"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_012/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_012/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_012/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_012/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_012/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_012/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_012/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_012/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_012/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_012/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_132822_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.1,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:29:24",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7446808218955994,
+          "test_loss": 0.6971206665039062,
+          "train_accuracy": 0.9444444444444444,
+          "val_accuracy": 0.723404255319149
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7446808218955994,
+        "test_loss": 0.6971206665039062
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000211",
+      "run_name": "run_012",
+      "source_run_id": "20251222_132822_phasea_train_recipe_causal_lstm_run_012",
+      "started_at": "2025-12-22T18:29:20",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_013/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_013/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_013",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_013"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_013/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_013/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_013/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_013/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_013/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_013/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_013/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_013/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_013/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_013/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_132822_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.2,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:29:28",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7659574747085571,
+          "test_loss": 0.7367782592773438,
+          "train_accuracy": 0.9259259259259259,
+          "val_accuracy": 0.723404255319149
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7659574747085571,
+        "test_loss": 0.7367782592773438
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000212",
+      "run_name": "run_013",
+      "source_run_id": "20251222_132822_phasea_train_recipe_causal_lstm_run_013",
+      "started_at": "2025-12-22T18:29:24",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_014/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_014/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_014",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_014"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_014/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_014/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_014/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_014/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_014/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_014/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_014/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_014/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_014/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_014/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_132822_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.3,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:29:32",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7659574747085571,
+          "test_loss": 0.6955572962760925,
+          "train_accuracy": 0.9259259259259259,
+          "val_accuracy": 0.7021276595744681
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7659574747085571,
+        "test_loss": 0.6955572962760925
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000213",
+      "run_name": "run_014",
+      "source_run_id": "20251222_132822_phasea_train_recipe_causal_lstm_run_014",
+      "started_at": "2025-12-22T18:29:28",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_015/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_015/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_015",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_015"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_015/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_015/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_015/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_015/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_015/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_015/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_015/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_015/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_015/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_015/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_132822_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.4,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:29:37",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7234042286872864,
+          "test_loss": 0.6918260455131531,
+          "train_accuracy": 0.9212962962962963,
+          "val_accuracy": 0.723404255319149
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7234042286872864,
+        "test_loss": 0.6918260455131531
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000214",
+      "run_name": "run_015",
+      "source_run_id": "20251222_132822_phasea_train_recipe_causal_lstm_run_015",
+      "started_at": "2025-12-22T18:29:33",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_016/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_016/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_016",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_016"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_016/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_016/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_016/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_016/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_016/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_016/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_016/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_016/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_016/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_016/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_132822_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.0,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:29:41",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.8297872543334961,
+          "test_loss": 0.5621059536933899,
+          "train_accuracy": 0.9861111111111112,
+          "val_accuracy": 0.7021276595744681
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.8297872543334961,
+        "test_loss": 0.5621059536933899
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000215",
+      "run_name": "run_016",
+      "source_run_id": "20251222_132822_phasea_train_recipe_causal_lstm_run_016",
+      "started_at": "2025-12-22T18:29:37",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_017/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_017/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_017",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_017"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_017/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_017/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_017/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_017/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_017/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_017/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_017/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_017/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_017/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_017/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_132822_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.1,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:29:45",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7446808218955994,
+          "test_loss": 0.6971206665039062,
+          "train_accuracy": 0.9444444444444444,
+          "val_accuracy": 0.723404255319149
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7446808218955994,
+        "test_loss": 0.6971206665039062
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000216",
+      "run_name": "run_017",
+      "source_run_id": "20251222_132822_phasea_train_recipe_causal_lstm_run_017",
+      "started_at": "2025-12-22T18:29:41",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_018/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_018/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_018",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_018"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_018/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_018/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_018/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_018/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_018/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_018/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_018/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_018/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_018/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_018/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_132822_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.2,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:29:49",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7659574747085571,
+          "test_loss": 0.7367782592773438,
+          "train_accuracy": 0.9259259259259259,
+          "val_accuracy": 0.723404255319149
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7659574747085571,
+        "test_loss": 0.7367782592773438
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000217",
+      "run_name": "run_018",
+      "source_run_id": "20251222_132822_phasea_train_recipe_causal_lstm_run_018",
+      "started_at": "2025-12-22T18:29:45",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_019/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_019/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_019",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_019"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_019/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_019/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_019/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_019/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_019/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_019/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_019/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_019/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_019/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_019/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_132822_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.3,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:29:53",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7659574747085571,
+          "test_loss": 0.6955572962760925,
+          "train_accuracy": 0.9259259259259259,
+          "val_accuracy": 0.7021276595744681
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7659574747085571,
+        "test_loss": 0.6955572962760925
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000218",
+      "run_name": "run_019",
+      "source_run_id": "20251222_132822_phasea_train_recipe_causal_lstm_run_019",
+      "started_at": "2025-12-22T18:29:49",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_020/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_020/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_020",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_020"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_020/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_020/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_020/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_020/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_020/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_020/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_020/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_020/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_020/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_020/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_132822_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.4,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:29:59",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7234042286872864,
+          "test_loss": 0.6918260455131531,
+          "train_accuracy": 0.9212962962962963,
+          "val_accuracy": 0.723404255319149
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7234042286872864,
+        "test_loss": 0.6918260455131531
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000219",
+      "run_name": "run_020",
+      "source_run_id": "20251222_132822_phasea_train_recipe_causal_lstm_run_020",
+      "started_at": "2025-12-22T18:29:53",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_021/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_021/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_021",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_021"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_021/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_021/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_021/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_021/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_021/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_021/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_021/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_021/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_021/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_021/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_132822_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.0,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:30:03",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.8510638475418091,
+          "test_loss": 0.45683157444000244,
+          "train_accuracy": 0.9861111111111112,
+          "val_accuracy": 0.723404255319149
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.8510638475418091,
+        "test_loss": 0.45683157444000244
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000220",
+      "run_name": "run_021",
+      "source_run_id": "20251222_132822_phasea_train_recipe_causal_lstm_run_021",
+      "started_at": "2025-12-22T18:29:59",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_022/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_022/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_022",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_022"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_022/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_022/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_022/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_022/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_022/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_022/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_022/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_022/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_022/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_022/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_132822_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.1,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:30:07",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7659574747085571,
+          "test_loss": 0.8144330978393555,
+          "train_accuracy": 0.9120370370370371,
+          "val_accuracy": 0.7021276595744681
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7659574747085571,
+        "test_loss": 0.8144330978393555
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000221",
+      "run_name": "run_022",
+      "source_run_id": "20251222_132822_phasea_train_recipe_causal_lstm_run_022",
+      "started_at": "2025-12-22T18:30:03",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_023/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_023/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_023",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_023"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_023/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_023/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_023/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_023/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_023/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_023/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_023/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_023/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_023/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_023/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_132822_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.2,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:30:10",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7659574747085571,
+          "test_loss": 0.8199689984321594,
+          "train_accuracy": 0.8981481481481481,
+          "val_accuracy": 0.7021276595744681
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7659574747085571,
+        "test_loss": 0.8199689984321594
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000222",
+      "run_name": "run_023",
+      "source_run_id": "20251222_132822_phasea_train_recipe_causal_lstm_run_023",
+      "started_at": "2025-12-22T18:30:07",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_024/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_024/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_024",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_024"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_024/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_024/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_024/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_024/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_024/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_024/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_024/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_024/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_024/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_024/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_132822_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.3,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:30:14",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.8085106611251831,
+          "test_loss": 0.6563349962234497,
+          "train_accuracy": 0.9490740740740741,
+          "val_accuracy": 0.7446808510638298
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.8085106611251831,
+        "test_loss": 0.6563349962234497
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000223",
+      "run_name": "run_024",
+      "source_run_id": "20251222_132822_phasea_train_recipe_causal_lstm_run_024",
+      "started_at": "2025-12-22T18:30:10",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_025/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_025/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_025",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_025"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_025/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_025/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_025/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_025/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_025/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_025/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_025/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_025/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_025/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_025/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_132822_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.4,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:30:18",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.8510638475418091,
+          "test_loss": 0.4700283408164978,
+          "train_accuracy": 0.9675925925925926,
+          "val_accuracy": 0.7446808510638298
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.8510638475418091,
+        "test_loss": 0.4700283408164978
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000224",
+      "run_name": "run_025",
+      "source_run_id": "20251222_132822_phasea_train_recipe_causal_lstm_run_025",
+      "started_at": "2025-12-22T18:30:14",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_026/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_026/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_026",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_026"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_026/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_026/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_026/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_026/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_026/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_026/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_026/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_026/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_026/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_026/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_132822_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.0,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:30:22",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.8510638475418091,
+          "test_loss": 0.45683157444000244,
+          "train_accuracy": 0.9861111111111112,
+          "val_accuracy": 0.723404255319149
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.8510638475418091,
+        "test_loss": 0.45683157444000244
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000225",
+      "run_name": "run_026",
+      "source_run_id": "20251222_132822_phasea_train_recipe_causal_lstm_run_026",
+      "started_at": "2025-12-22T18:30:18",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_027/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_027/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_027",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_027"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_027/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_027/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_027/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_027/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_027/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_027/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_027/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_027/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_027/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_027/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_132822_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.1,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:30:25",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7659574747085571,
+          "test_loss": 0.8144330978393555,
+          "train_accuracy": 0.9120370370370371,
+          "val_accuracy": 0.7021276595744681
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7659574747085571,
+        "test_loss": 0.8144330978393555
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000226",
+      "run_name": "run_027",
+      "source_run_id": "20251222_132822_phasea_train_recipe_causal_lstm_run_027",
+      "started_at": "2025-12-22T18:30:22",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_028/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_028/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_028",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_028"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_028/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_028/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_028/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_028/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_028/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_028/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_028/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_028/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_028/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_028/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_132822_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.2,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:30:29",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7659574747085571,
+          "test_loss": 0.8199689984321594,
+          "train_accuracy": 0.8981481481481481,
+          "val_accuracy": 0.7021276595744681
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7659574747085571,
+        "test_loss": 0.8199689984321594
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000227",
+      "run_name": "run_028",
+      "source_run_id": "20251222_132822_phasea_train_recipe_causal_lstm_run_028",
+      "started_at": "2025-12-22T18:30:25",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_029/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_029/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_029",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_029"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_029/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_029/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_029/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_029/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_029/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_029/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_029/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_029/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_029/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_029/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_132822_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.3,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:30:32",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.8085106611251831,
+          "test_loss": 0.6563349962234497,
+          "train_accuracy": 0.9490740740740741,
+          "val_accuracy": 0.7446808510638298
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.8085106611251831,
+        "test_loss": 0.6563349962234497
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000228",
+      "run_name": "run_029",
+      "source_run_id": "20251222_132822_phasea_train_recipe_causal_lstm_run_029",
+      "started_at": "2025-12-22T18:30:29",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_030/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_030/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_030",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_030"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_030/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_030/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_030/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_030/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_030/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_030/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_030/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_030/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_030/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_132822_phasea_train_recipe_causal_lstm/run_030/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_132822_phasea_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.4,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:30:36",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.8510638475418091,
+          "test_loss": 0.4700283408164978,
+          "train_accuracy": 0.9675925925925926,
+          "val_accuracy": 0.7446808510638298
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.8510638475418091,
+        "test_loss": 0.4700283408164978
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000229",
+      "run_name": "run_030",
+      "source_run_id": "20251222_132822_phasea_train_recipe_causal_lstm_run_030",
+      "started_at": "2025-12-22T18:30:32",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_001/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_001/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_001",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_001"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_001/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_001/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_001/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_001/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_001/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_001/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_001/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_001/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_001/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_001/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_133907_phaseb_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 64,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.0,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:39:11",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.8085106611251831,
+          "test_loss": 0.47515350580215454,
+          "train_accuracy": 0.9861111111111112,
+          "val_accuracy": 0.723404255319149
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.8085106611251831,
+        "test_loss": 0.47515350580215454
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000230",
+      "run_name": "run_001",
+      "source_run_id": "20251222_133907_phaseb_train_recipe_causal_lstm_run_001",
+      "started_at": "2025-12-22T18:39:07",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_002/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_002/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_002",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_002"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_002/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_002/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_002/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_002/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_002/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_002/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_002/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_002/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_002/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_002/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_133907_phaseb_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 64,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.0,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 4,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:39:16",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.8085106611251831,
+          "test_loss": 0.5130367875099182,
+          "train_accuracy": 0.9814814814814815,
+          "val_accuracy": 0.7021276595744681
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.8085106611251831,
+        "test_loss": 0.5130367875099182
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000231",
+      "run_name": "run_002",
+      "source_run_id": "20251222_133907_phaseb_train_recipe_causal_lstm_run_002",
+      "started_at": "2025-12-22T18:39:11",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_003/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_003/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_003",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_003"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_003/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_003/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_003/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_003/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_003/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_003/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_003/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_003/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_003/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_003/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_133907_phaseb_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 64,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.0,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 5,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:39:20",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7872340679168701,
+          "test_loss": 0.5891804099082947,
+          "train_accuracy": 0.9814814814814815,
+          "val_accuracy": 0.6808510638297872
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7872340679168701,
+        "test_loss": 0.5891804099082947
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000232",
+      "run_name": "run_003",
+      "source_run_id": "20251222_133907_phaseb_train_recipe_causal_lstm_run_003",
+      "started_at": "2025-12-22T18:39:16",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_004/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_004/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_004",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_004"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_004/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_004/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_004/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_004/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_004/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_004/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_004/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_004/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_004/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_004/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_133907_phaseb_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.0,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:39:24",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.8510638475418091,
+          "test_loss": 0.45683157444000244,
+          "train_accuracy": 0.9861111111111112,
+          "val_accuracy": 0.723404255319149
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.8510638475418091,
+        "test_loss": 0.45683157444000244
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000233",
+      "run_name": "run_004",
+      "source_run_id": "20251222_133907_phaseb_train_recipe_causal_lstm_run_004",
+      "started_at": "2025-12-22T18:39:21",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_005/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_005/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_005",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_005"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_005/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_005/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_005/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_005/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_005/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_005/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_005/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_005/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_005/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_005/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_133907_phaseb_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.0,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 4,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:39:28",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.8510638475418091,
+          "test_loss": 0.39338845014572144,
+          "train_accuracy": 0.9814814814814815,
+          "val_accuracy": 0.7021276595744681
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.8510638475418091,
+        "test_loss": 0.39338845014572144
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000234",
+      "run_name": "run_005",
+      "source_run_id": "20251222_133907_phaseb_train_recipe_causal_lstm_run_005",
+      "started_at": "2025-12-22T18:39:24",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_006/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_006/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_006",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_006"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_006/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_006/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_006/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_006/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_006/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_006/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_006/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_006/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_006/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_006/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_133907_phaseb_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.0,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 5,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:39:33",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.8297872543334961,
+          "test_loss": 0.39914432168006897,
+          "train_accuracy": 0.9861111111111112,
+          "val_accuracy": 0.7659574468085106
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.8297872543334961,
+        "test_loss": 0.39914432168006897
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000235",
+      "run_name": "run_006",
+      "source_run_id": "20251222_133907_phaseb_train_recipe_causal_lstm_run_006",
+      "started_at": "2025-12-22T18:39:29",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_007/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_007/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_007",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_007"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_007/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_007/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_007/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_007/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_007/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_007/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_007/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_007/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_007/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_007/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_133907_phaseb_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 256,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.0,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:39:38",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.8297872543334961,
+          "test_loss": 0.48551276326179504,
+          "train_accuracy": 0.9861111111111112,
+          "val_accuracy": 0.6808510638297872
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.8297872543334961,
+        "test_loss": 0.48551276326179504
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000236",
+      "run_name": "run_007",
+      "source_run_id": "20251222_133907_phaseb_train_recipe_causal_lstm_run_007",
+      "started_at": "2025-12-22T18:39:34",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_008/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_008/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_008",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_008"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_008/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_008/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_008/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_008/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_008/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_008/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_008/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_008/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_008/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_008/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_133907_phaseb_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 256,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.0,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 4,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:39:44",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.8297872543334961,
+          "test_loss": 0.42719075083732605,
+          "train_accuracy": 0.9861111111111112,
+          "val_accuracy": 0.6808510638297872
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.8297872543334961,
+        "test_loss": 0.42719075083732605
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000237",
+      "run_name": "run_008",
+      "source_run_id": "20251222_133907_phaseb_train_recipe_causal_lstm_run_008",
+      "started_at": "2025-12-22T18:39:38",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_009/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_009/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_009",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_009"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_009/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_009/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_009/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_009/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_009/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_009/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_009/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_009/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_009/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_133907_phaseb_train_recipe_causal_lstm/run_009/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_133907_phaseb_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 256,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.0,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 5,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:39:51",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.8510638475418091,
+          "test_loss": 0.41553163528442383,
+          "train_accuracy": 0.9907407407407407,
+          "val_accuracy": 0.7021276595744681
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.8510638475418091,
+        "test_loss": 0.41553163528442383
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000238",
+      "run_name": "run_009",
+      "source_run_id": "20251222_133907_phaseb_train_recipe_causal_lstm_run_009",
+      "started_at": "2025-12-22T18:39:44",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_001/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_001/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_001",
+          "resolved_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_001"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_001/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_001/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_001/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_001/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_001/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_001/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_001/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_001/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_001/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_001/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 8,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_134646_phasec_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 256,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.0,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 5,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:46:54",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.8510638475418091,
+          "test_loss": 0.41553163528442383,
+          "train_accuracy": 0.9907407407407407,
+          "val_accuracy": 0.7021276595744681
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.8510638475418091,
+        "test_loss": 0.41553163528442383
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000239",
+      "run_name": "run_001",
+      "source_run_id": "20251222_134646_phasec_train_recipe_causal_lstm_run_001",
+      "started_at": "2025-12-22T18:46:46",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_002/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_002/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_002",
+          "resolved_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_002"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_002/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_002/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_002/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_002/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_002/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_002/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_002/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_002/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_002/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_002/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 8,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 43,
+          "seq_len": 30,
+          "sweep_id": "20251222_134646_phasec_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 256,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.0,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 5,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:47:02",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7659574747085571,
+          "test_loss": 0.5599273443222046,
+          "train_accuracy": 0.9907407407407407,
+          "val_accuracy": 0.723404255319149
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7659574747085571,
+        "test_loss": 0.5599273443222046
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000240",
+      "run_name": "run_002",
+      "source_run_id": "20251222_134646_phasec_train_recipe_causal_lstm_run_002",
+      "started_at": "2025-12-22T18:46:55",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_003/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_003/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_003",
+          "resolved_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_003"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_003/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_003/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_003/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_003/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_003/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_003/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_003/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_003/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_003/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_003/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 8,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 44,
+          "seq_len": 30,
+          "sweep_id": "20251222_134646_phasec_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 256,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.0,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 5,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:47:09",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.8723404407501221,
+          "test_loss": 0.49004992842674255,
+          "train_accuracy": 0.9768518518518519,
+          "val_accuracy": 0.7021276595744681
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.8723404407501221,
+        "test_loss": 0.49004992842674255
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000241",
+      "run_name": "run_003",
+      "source_run_id": "20251222_134646_phasec_train_recipe_causal_lstm_run_003",
+      "started_at": "2025-12-22T18:47:03",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_004/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_004/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_004",
+          "resolved_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_004"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_004/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_004/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_004/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_004/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_004/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_004/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_004/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_004/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_004/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_004/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 8,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 45,
+          "seq_len": 30,
+          "sweep_id": "20251222_134646_phasec_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 256,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.0,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 5,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:47:16",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.8085106611251831,
+          "test_loss": 0.6635878682136536,
+          "train_accuracy": 0.9490740740740741,
+          "val_accuracy": 0.7021276595744681
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.8085106611251831,
+        "test_loss": 0.6635878682136536
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000242",
+      "run_name": "run_004",
+      "source_run_id": "20251222_134646_phasec_train_recipe_causal_lstm_run_004",
+      "started_at": "2025-12-22T18:47:10",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_005/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_005/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_005",
+          "resolved_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_005"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_005/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_005/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_005/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_005/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_005/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_005/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_005/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_005/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_005/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_134646_phasec_train_recipe_causal_lstm/run_005/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 8,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 46,
+          "seq_len": 30,
+          "sweep_id": "20251222_134646_phasec_train_recipe_causal_lstm",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 256,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.0,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 5,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T18:47:24",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.8085106611251831,
+          "test_loss": 0.5900981426239014,
+          "train_accuracy": 0.9861111111111112,
+          "val_accuracy": 0.723404255319149
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.8085106611251831,
+        "test_loss": 0.5900981426239014
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000243",
+      "run_name": "run_005",
+      "source_run_id": "20251222_134646_phasec_train_recipe_causal_lstm_run_005",
+      "started_at": "2025-12-22T18:47:16",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_001/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_001/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_001",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_001"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_001/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_001/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_001/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_001/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_001/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_001/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_001/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_001/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_001/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_001/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_140204_phasea_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 5,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:02:10",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7446808218955994,
+          "test_loss": 0.9935258030891418,
+          "train_accuracy": 0.8564814814814815,
+          "val_accuracy": 0.6170212765957447
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7446808218955994,
+        "test_loss": 0.9935258030891418
+      },
+      "model_key": "mamba",
+      "record_id": "run-000244",
+      "run_name": "run_001",
+      "source_run_id": "20251222_140204_phasea_train_recipe_memba_run_001",
+      "started_at": "2025-12-22T19:02:04",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_002/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_002/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_002",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_002"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_002/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_002/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_002/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_002/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_002/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_002/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_002/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_002/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_002/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_002/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_140204_phasea_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 5,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:02:16",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7446808218955994,
+          "test_loss": 0.9935258030891418,
+          "train_accuracy": 0.8564814814814815,
+          "val_accuracy": 0.6170212765957447
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7446808218955994,
+        "test_loss": 0.9935258030891418
+      },
+      "model_key": "mamba",
+      "record_id": "run-000245",
+      "run_name": "run_002",
+      "source_run_id": "20251222_140204_phasea_train_recipe_memba_run_002",
+      "started_at": "2025-12-22T19:02:10",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_003/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_003/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_003",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_003"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_003/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_003/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_003/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_003/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_003/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_003/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_003/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_003/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_003/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_003/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_140204_phasea_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 5,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:02:21",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7234042286872864,
+          "test_loss": 0.9613981246948242,
+          "train_accuracy": 0.8425925925925926,
+          "val_accuracy": 0.5957446808510638
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7234042286872864,
+        "test_loss": 0.9613981246948242
+      },
+      "model_key": "mamba",
+      "record_id": "run-000246",
+      "run_name": "run_003",
+      "source_run_id": "20251222_140204_phasea_train_recipe_memba_run_003",
+      "started_at": "2025-12-22T19:02:16",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_004/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_004/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_004",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_004"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_004/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_004/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_004/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_004/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_004/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_004/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_004/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_004/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_004/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_004/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_140204_phasea_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 5,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:02:25",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7234042286872864,
+          "test_loss": 0.9613981246948242,
+          "train_accuracy": 0.8425925925925926,
+          "val_accuracy": 0.5957446808510638
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7234042286872864,
+        "test_loss": 0.9613981246948242
+      },
+      "model_key": "mamba",
+      "record_id": "run-000247",
+      "run_name": "run_004",
+      "source_run_id": "20251222_140204_phasea_train_recipe_memba_run_004",
+      "started_at": "2025-12-22T19:02:21",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_005/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_005/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_005",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_005"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_005/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_005/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_005/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_005/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_005/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_005/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_005/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_005/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_005/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_005/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_140204_phasea_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 5,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:02:31",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.8297872543334961,
+          "test_loss": 0.6027488112449646,
+          "train_accuracy": 0.9861111111111112,
+          "val_accuracy": 0.7021276595744681
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.8297872543334961,
+        "test_loss": 0.6027488112449646
+      },
+      "model_key": "mamba",
+      "record_id": "run-000248",
+      "run_name": "run_005",
+      "source_run_id": "20251222_140204_phasea_train_recipe_memba_run_005",
+      "started_at": "2025-12-22T19:02:26",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_006/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_006/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_006",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_006"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_006/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_006/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_006/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_006/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_006/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_006/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_006/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_006/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_006/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_006/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_140204_phasea_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 5,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:02:37",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.8297872543334961,
+          "test_loss": 0.6027488112449646,
+          "train_accuracy": 0.9861111111111112,
+          "val_accuracy": 0.7021276595744681
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.8297872543334961,
+        "test_loss": 0.6027488112449646
+      },
+      "model_key": "mamba",
+      "record_id": "run-000249",
+      "run_name": "run_006",
+      "source_run_id": "20251222_140204_phasea_train_recipe_memba_run_006",
+      "started_at": "2025-12-22T19:02:31",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_007/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_007/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_007",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_007"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_007/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_007/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_007/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_007/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_007/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_007/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_007/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_007/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_007/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_007/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_140204_phasea_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.1,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 5,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:02:44",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.5957446694374084,
+          "test_loss": 1.2643651962280273,
+          "train_accuracy": 0.8425925925925926,
+          "val_accuracy": 0.5957446808510638
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.5957446694374084,
+        "test_loss": 1.2643651962280273
+      },
+      "model_key": "mamba",
+      "record_id": "run-000250",
+      "run_name": "run_007",
+      "source_run_id": "20251222_140204_phasea_train_recipe_memba_run_007",
+      "started_at": "2025-12-22T19:02:37",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_008/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_008/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_008",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_008"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_008/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_008/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_008/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_008/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_008/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_008/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_008/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_008/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_008/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_008/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_140204_phasea_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.1,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 5,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:02:51",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.5957446694374084,
+          "test_loss": 1.2643651962280273,
+          "train_accuracy": 0.8425925925925926,
+          "val_accuracy": 0.5957446808510638
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.5957446694374084,
+        "test_loss": 1.2643651962280273
+      },
+      "model_key": "mamba",
+      "record_id": "run-000251",
+      "run_name": "run_008",
+      "source_run_id": "20251222_140204_phasea_train_recipe_memba_run_008",
+      "started_at": "2025-12-22T19:02:44",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_009/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_009/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_009",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_009"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_009/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_009/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_009/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_009/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_009/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_009/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_009/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_009/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_009/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_009/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_140204_phasea_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.1,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 5,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:02:56",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.6808510422706604,
+          "test_loss": 1.0409201383590698,
+          "train_accuracy": 0.9027777777777778,
+          "val_accuracy": 0.6382978723404256
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.6808510422706604,
+        "test_loss": 1.0409201383590698
+      },
+      "model_key": "mamba",
+      "record_id": "run-000252",
+      "run_name": "run_009",
+      "source_run_id": "20251222_140204_phasea_train_recipe_memba_run_009",
+      "started_at": "2025-12-22T19:02:51",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_010/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_010/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_010",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_010"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_010/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_010/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_010/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_010/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_010/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_010/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_010/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_010/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_010/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_010/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_140204_phasea_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.1,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 5,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:03:02",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.6808510422706604,
+          "test_loss": 1.0409201383590698,
+          "train_accuracy": 0.9027777777777778,
+          "val_accuracy": 0.6382978723404256
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.6808510422706604,
+        "test_loss": 1.0409201383590698
+      },
+      "model_key": "mamba",
+      "record_id": "run-000253",
+      "run_name": "run_010",
+      "source_run_id": "20251222_140204_phasea_train_recipe_memba_run_010",
+      "started_at": "2025-12-22T19:02:57",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_011/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_011/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_011",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_011"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_011/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_011/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_011/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_011/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_011/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_011/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_011/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_011/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_011/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_011/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_140204_phasea_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.1,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 5,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:03:08",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7021276354789734,
+          "test_loss": 0.9217679500579834,
+          "train_accuracy": 0.9675925925925926,
+          "val_accuracy": 0.6595744680851063
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7021276354789734,
+        "test_loss": 0.9217679500579834
+      },
+      "model_key": "mamba",
+      "record_id": "run-000254",
+      "run_name": "run_011",
+      "source_run_id": "20251222_140204_phasea_train_recipe_memba_run_011",
+      "started_at": "2025-12-22T19:03:03",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_012/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_012/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_012",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_012"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_012/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_012/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_012/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_012/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_012/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_012/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_012/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_012/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_012/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_012/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_140204_phasea_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.1,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 5,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:03:13",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7021276354789734,
+          "test_loss": 0.9217679500579834,
+          "train_accuracy": 0.9675925925925926,
+          "val_accuracy": 0.6595744680851063
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7021276354789734,
+        "test_loss": 0.9217679500579834
+      },
+      "model_key": "mamba",
+      "record_id": "run-000255",
+      "run_name": "run_012",
+      "source_run_id": "20251222_140204_phasea_train_recipe_memba_run_012",
+      "started_at": "2025-12-22T19:03:08",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_013/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_013/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_013",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_013"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_013/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_013/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_013/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_013/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_013/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_013/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_013/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_013/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_013/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_013/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_140204_phasea_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 5,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:03:22",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.5744680762290955,
+          "test_loss": 1.1677720546722412,
+          "train_accuracy": 0.8379629629629629,
+          "val_accuracy": 0.5957446808510638
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.5744680762290955,
+        "test_loss": 1.1677720546722412
+      },
+      "model_key": "mamba",
+      "record_id": "run-000256",
+      "run_name": "run_013",
+      "source_run_id": "20251222_140204_phasea_train_recipe_memba_run_013",
+      "started_at": "2025-12-22T19:03:13",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_014/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_014/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_014",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_014"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_014/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_014/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_014/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_014/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_014/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_014/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_014/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_014/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_014/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_014/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_140204_phasea_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 5,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:03:30",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.5744680762290955,
+          "test_loss": 1.1677720546722412,
+          "train_accuracy": 0.8379629629629629,
+          "val_accuracy": 0.5957446808510638
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.5744680762290955,
+        "test_loss": 1.1677720546722412
+      },
+      "model_key": "mamba",
+      "record_id": "run-000257",
+      "run_name": "run_014",
+      "source_run_id": "20251222_140204_phasea_train_recipe_memba_run_014",
+      "started_at": "2025-12-22T19:03:22",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_015/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_015/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_015",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_015"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_015/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_015/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_015/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_015/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_015/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_015/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_015/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_015/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_015/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_015/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_140204_phasea_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 5,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:03:40",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7234042286872864,
+          "test_loss": 0.9196138381958008,
+          "train_accuracy": 0.9675925925925926,
+          "val_accuracy": 0.7021276595744681
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7234042286872864,
+        "test_loss": 0.9196138381958008
+      },
+      "model_key": "mamba",
+      "record_id": "run-000258",
+      "run_name": "run_015",
+      "source_run_id": "20251222_140204_phasea_train_recipe_memba_run_015",
+      "started_at": "2025-12-22T19:03:31",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_016/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_016/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_016",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_016"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_016/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_016/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_016/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_016/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_016/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_016/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_016/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_016/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_016/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_016/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_140204_phasea_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 5,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:03:50",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7234042286872864,
+          "test_loss": 0.9196138381958008,
+          "train_accuracy": 0.9675925925925926,
+          "val_accuracy": 0.7021276595744681
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7234042286872864,
+        "test_loss": 0.9196138381958008
+      },
+      "model_key": "mamba",
+      "record_id": "run-000259",
+      "run_name": "run_016",
+      "source_run_id": "20251222_140204_phasea_train_recipe_memba_run_016",
+      "started_at": "2025-12-22T19:03:41",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_017/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_017/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_017",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_017"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_017/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_017/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_017/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_017/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_017/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_017/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_017/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_017/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_017/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_017/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_140204_phasea_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 5,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:03:56",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7446808218955994,
+          "test_loss": 0.9250391721725464,
+          "train_accuracy": 0.9629629629629629,
+          "val_accuracy": 0.6808510638297872
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7446808218955994,
+        "test_loss": 0.9250391721725464
+      },
+      "model_key": "mamba",
+      "record_id": "run-000260",
+      "run_name": "run_017",
+      "source_run_id": "20251222_140204_phasea_train_recipe_memba_run_017",
+      "started_at": "2025-12-22T19:03:50",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_018/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_018/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_018",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_018"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_018/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_018/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_018/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_018/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_018/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_018/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_018/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_018/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_018/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_018/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_140204_phasea_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 5,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:04:05",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7446808218955994,
+          "test_loss": 0.9250391721725464,
+          "train_accuracy": 0.9629629629629629,
+          "val_accuracy": 0.6808510638297872
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7446808218955994,
+        "test_loss": 0.9250391721725464
+      },
+      "model_key": "mamba",
+      "record_id": "run-000261",
+      "run_name": "run_018",
+      "source_run_id": "20251222_140204_phasea_train_recipe_memba_run_018",
+      "started_at": "2025-12-22T19:03:56",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_019/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_019/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_019",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_019"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_019/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_019/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_019/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_019/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_019/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_019/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_019/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_019/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_019/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_019/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_140204_phasea_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.3,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 5,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:04:12",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.38297873735427856,
+          "test_loss": 1.5329049825668335,
+          "train_accuracy": 0.5972222222222222,
+          "val_accuracy": 0.5106382978723404
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.38297873735427856,
+        "test_loss": 1.5329049825668335
+      },
+      "model_key": "mamba",
+      "record_id": "run-000262",
+      "run_name": "run_019",
+      "source_run_id": "20251222_140204_phasea_train_recipe_memba_run_019",
+      "started_at": "2025-12-22T19:04:05",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_020/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_020/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_020",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_020"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_020/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_020/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_020/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_020/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_020/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_020/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_020/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_020/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_020/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_020/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_140204_phasea_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.3,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 5,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:04:19",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.38297873735427856,
+          "test_loss": 1.5329049825668335,
+          "train_accuracy": 0.5972222222222222,
+          "val_accuracy": 0.5106382978723404
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.38297873735427856,
+        "test_loss": 1.5329049825668335
+      },
+      "model_key": "mamba",
+      "record_id": "run-000263",
+      "run_name": "run_020",
+      "source_run_id": "20251222_140204_phasea_train_recipe_memba_run_020",
+      "started_at": "2025-12-22T19:04:12",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_021/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_021/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_021",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_021"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_021/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_021/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_021/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_021/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_021/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_021/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_021/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_021/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_021/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_021/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_140204_phasea_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.3,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 5,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:04:28",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.6382978558540344,
+          "test_loss": 1.0443642139434814,
+          "train_accuracy": 0.8657407407407407,
+          "val_accuracy": 0.6808510638297872
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.6382978558540344,
+        "test_loss": 1.0443642139434814
+      },
+      "model_key": "mamba",
+      "record_id": "run-000264",
+      "run_name": "run_021",
+      "source_run_id": "20251222_140204_phasea_train_recipe_memba_run_021",
+      "started_at": "2025-12-22T19:04:19",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_022/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_022/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_022",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_022"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_022/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_022/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_022/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_022/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_022/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_022/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_022/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_022/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_022/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_022/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_140204_phasea_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.3,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 5,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:04:37",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.6382978558540344,
+          "test_loss": 1.0443642139434814,
+          "train_accuracy": 0.8657407407407407,
+          "val_accuracy": 0.6808510638297872
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.6382978558540344,
+        "test_loss": 1.0443642139434814
+      },
+      "model_key": "mamba",
+      "record_id": "run-000265",
+      "run_name": "run_022",
+      "source_run_id": "20251222_140204_phasea_train_recipe_memba_run_022",
+      "started_at": "2025-12-22T19:04:28",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_023/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_023/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_023",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_023"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_023/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_023/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_023/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_023/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_023/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_023/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_023/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_023/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_023/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_023/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_140204_phasea_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.3,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 5,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:04:43",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7021276354789734,
+          "test_loss": 0.9398750066757202,
+          "train_accuracy": 0.9305555555555556,
+          "val_accuracy": 0.7021276595744681
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7021276354789734,
+        "test_loss": 0.9398750066757202
+      },
+      "model_key": "mamba",
+      "record_id": "run-000266",
+      "run_name": "run_023",
+      "source_run_id": "20251222_140204_phasea_train_recipe_memba_run_023",
+      "started_at": "2025-12-22T19:04:37",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_024/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_024/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_024",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_024"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_024/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_024/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_024/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_024/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_024/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_024/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_024/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_024/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_024/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_024/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_140204_phasea_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.3,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 5,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:04:50",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7021276354789734,
+          "test_loss": 0.9398750066757202,
+          "train_accuracy": 0.9305555555555556,
+          "val_accuracy": 0.7021276595744681
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7021276354789734,
+        "test_loss": 0.9398750066757202
+      },
+      "model_key": "mamba",
+      "record_id": "run-000267",
+      "run_name": "run_024",
+      "source_run_id": "20251222_140204_phasea_train_recipe_memba_run_024",
+      "started_at": "2025-12-22T19:04:43",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_025/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_025/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_025",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_025"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_025/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_025/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_025/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_025/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_025/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_025/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_025/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_025/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_025/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_025/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_140204_phasea_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.4,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 5,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:05:00",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.4893617033958435,
+          "test_loss": 1.4689278602600098,
+          "train_accuracy": 0.6481481481481481,
+          "val_accuracy": 0.48936170212765956
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.4893617033958435,
+        "test_loss": 1.4689278602600098
+      },
+      "model_key": "mamba",
+      "record_id": "run-000268",
+      "run_name": "run_025",
+      "source_run_id": "20251222_140204_phasea_train_recipe_memba_run_025",
+      "started_at": "2025-12-22T19:04:50",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_026/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_026/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_026",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_026"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_026/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_026/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_026/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_026/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_026/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_026/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_026/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_026/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_026/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_026/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_140204_phasea_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.4,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 5,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:05:10",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.4893617033958435,
+          "test_loss": 1.4689278602600098,
+          "train_accuracy": 0.6481481481481481,
+          "val_accuracy": 0.48936170212765956
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.4893617033958435,
+        "test_loss": 1.4689278602600098
+      },
+      "model_key": "mamba",
+      "record_id": "run-000269",
+      "run_name": "run_026",
+      "source_run_id": "20251222_140204_phasea_train_recipe_memba_run_026",
+      "started_at": "2025-12-22T19:05:00",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_027/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_027/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_027",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_027"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_027/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_027/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_027/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_027/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_027/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_027/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_027/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_027/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_027/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_027/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_140204_phasea_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.4,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 5,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:05:18",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.5319148898124695,
+          "test_loss": 1.3681559562683105,
+          "train_accuracy": 0.6898148148148148,
+          "val_accuracy": 0.5531914893617021
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.5319148898124695,
+        "test_loss": 1.3681559562683105
+      },
+      "model_key": "mamba",
+      "record_id": "run-000270",
+      "run_name": "run_027",
+      "source_run_id": "20251222_140204_phasea_train_recipe_memba_run_027",
+      "started_at": "2025-12-22T19:05:11",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_028/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_028/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_028",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_028"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_028/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_028/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_028/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_028/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_028/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_028/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_028/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_028/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_028/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_028/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_140204_phasea_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.4,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 5,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:05:25",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.5319148898124695,
+          "test_loss": 1.3681559562683105,
+          "train_accuracy": 0.6898148148148148,
+          "val_accuracy": 0.5531914893617021
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.5319148898124695,
+        "test_loss": 1.3681559562683105
+      },
+      "model_key": "mamba",
+      "record_id": "run-000271",
+      "run_name": "run_028",
+      "source_run_id": "20251222_140204_phasea_train_recipe_memba_run_028",
+      "started_at": "2025-12-22T19:05:18",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_029/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_029/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_029",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_029"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_029/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_029/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_029/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_029/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_029/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_029/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_029/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_029/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_029/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_029/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_140204_phasea_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.4,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 5,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:05:31",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.5957446694374084,
+          "test_loss": 1.1746914386749268,
+          "train_accuracy": 0.7777777777777778,
+          "val_accuracy": 0.6595744680851063
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.5957446694374084,
+        "test_loss": 1.1746914386749268
+      },
+      "model_key": "mamba",
+      "record_id": "run-000272",
+      "run_name": "run_029",
+      "source_run_id": "20251222_140204_phasea_train_recipe_memba_run_029",
+      "started_at": "2025-12-22T19:05:25",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_030/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_030/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_030",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_030"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_030/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_030/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_030/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_030/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_030/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_030/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_030/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_030/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_030/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_140204_phasea_train_recipe_memba/run_030/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_140204_phasea_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.4,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 5,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:05:36",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.5957446694374084,
+          "test_loss": 1.1746914386749268,
+          "train_accuracy": 0.7777777777777778,
+          "val_accuracy": 0.6595744680851063
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.5957446694374084,
+        "test_loss": 1.1746914386749268
+      },
+      "model_key": "mamba",
+      "record_id": "run-000273",
+      "run_name": "run_030",
+      "source_run_id": "20251222_140204_phasea_train_recipe_memba_run_030",
+      "started_at": "2025-12-22T19:05:31",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_001/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_001/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_001",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_001"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_001/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_001/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_001/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_001/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_001/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_001/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_001/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_001/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_001/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_001/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_141251_phaseb_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "d_model": 64,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:13:01",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7446808218955994,
+          "test_loss": 0.8064327836036682,
+          "train_accuracy": 0.9351851851851852,
+          "val_accuracy": 0.6595744680851063
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7446808218955994,
+        "test_loss": 0.8064327836036682
+      },
+      "model_key": "mamba",
+      "record_id": "run-000274",
+      "run_name": "run_001",
+      "source_run_id": "20251222_141251_phaseb_train_recipe_memba_run_001",
+      "started_at": "2025-12-22T19:12:51",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_002/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_002/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_002",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_002"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_002/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_002/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_002/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_002/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_002/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_002/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_002/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_002/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_002/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_002/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_141251_phaseb_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "d_model": 64,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:13:13",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7659574747085571,
+          "test_loss": 0.6991755962371826,
+          "train_accuracy": 0.9444444444444444,
+          "val_accuracy": 0.7446808510638298
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7659574747085571,
+        "test_loss": 0.6991755962371826
+      },
+      "model_key": "mamba",
+      "record_id": "run-000275",
+      "run_name": "run_002",
+      "source_run_id": "20251222_141251_phaseb_train_recipe_memba_run_002",
+      "started_at": "2025-12-22T19:13:02",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_003/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_003/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_003",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_003"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_003/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_003/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_003/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_003/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_003/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_003/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_003/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_003/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_003/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_003/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_141251_phaseb_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "d_model": 64,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 4,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:13:31",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7234042286872864,
+          "test_loss": 0.7272530198097229,
+          "train_accuracy": 0.9907407407407407,
+          "val_accuracy": 0.7021276595744681
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7234042286872864,
+        "test_loss": 0.7272530198097229
+      },
+      "model_key": "mamba",
+      "record_id": "run-000276",
+      "run_name": "run_003",
+      "source_run_id": "20251222_141251_phaseb_train_recipe_memba_run_003",
+      "started_at": "2025-12-22T19:13:13",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_004/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_004/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_004",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_004"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_004/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_004/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_004/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_004/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_004/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_004/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_004/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_004/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_004/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_004/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_141251_phaseb_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "d_model": 64,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 4,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:13:49",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7446808218955994,
+          "test_loss": 0.6253052353858948,
+          "train_accuracy": 0.9814814814814815,
+          "val_accuracy": 0.723404255319149
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7446808218955994,
+        "test_loss": 0.6253052353858948
+      },
+      "model_key": "mamba",
+      "record_id": "run-000277",
+      "run_name": "run_004",
+      "source_run_id": "20251222_141251_phaseb_train_recipe_memba_run_004",
+      "started_at": "2025-12-22T19:13:32",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_005/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_005/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_005",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_005"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_005/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_005/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_005/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_005/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_005/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_005/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_005/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_005/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_005/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_005/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_141251_phaseb_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "d_model": 64,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 6,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:14:11",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7234042286872864,
+          "test_loss": 0.7112394571304321,
+          "train_accuracy": 0.9907407407407407,
+          "val_accuracy": 0.7021276595744681
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7234042286872864,
+        "test_loss": 0.7112394571304321
+      },
+      "model_key": "mamba",
+      "record_id": "run-000278",
+      "run_name": "run_005",
+      "source_run_id": "20251222_141251_phaseb_train_recipe_memba_run_005",
+      "started_at": "2025-12-22T19:13:50",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_006/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_006/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_006",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_006"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_006/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_006/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_006/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_006/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_006/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_006/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_006/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_006/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_006/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_006/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_141251_phaseb_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "d_model": 64,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 6,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:14:25",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.8085106611251831,
+          "test_loss": 0.7379732131958008,
+          "train_accuracy": 0.9814814814814815,
+          "val_accuracy": 0.6382978723404256
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.8085106611251831,
+        "test_loss": 0.7379732131958008
+      },
+      "model_key": "mamba",
+      "record_id": "run-000279",
+      "run_name": "run_006",
+      "source_run_id": "20251222_141251_phaseb_train_recipe_memba_run_006",
+      "started_at": "2025-12-22T19:14:11",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_007/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_007/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_007",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_007"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_007/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_007/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_007/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_007/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_007/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_007/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_007/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_007/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_007/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_007/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_141251_phaseb_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:14:42",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.8510638475418091,
+          "test_loss": 0.5026400089263916,
+          "train_accuracy": 0.9814814814814815,
+          "val_accuracy": 0.7659574468085106
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.8510638475418091,
+        "test_loss": 0.5026400089263916
+      },
+      "model_key": "mamba",
+      "record_id": "run-000280",
+      "run_name": "run_007",
+      "source_run_id": "20251222_141251_phaseb_train_recipe_memba_run_007",
+      "started_at": "2025-12-22T19:14:26",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_008/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_008/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_008",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_008"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_008/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_008/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_008/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_008/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_008/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_008/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_008/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_008/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_008/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_008/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_141251_phaseb_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:14:53",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7872340679168701,
+          "test_loss": 0.6854156851768494,
+          "train_accuracy": 0.9537037037037037,
+          "val_accuracy": 0.7021276595744681
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7872340679168701,
+        "test_loss": 0.6854156851768494
+      },
+      "model_key": "mamba",
+      "record_id": "run-000281",
+      "run_name": "run_008",
+      "source_run_id": "20251222_141251_phaseb_train_recipe_memba_run_008",
+      "started_at": "2025-12-22T19:14:42",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_009/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_009/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_009",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_009"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_009/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_009/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_009/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_009/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_009/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_009/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_009/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_009/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_009/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_009/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_141251_phaseb_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 4,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:15:07",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7659574747085571,
+          "test_loss": 0.5560439825057983,
+          "train_accuracy": 0.9861111111111112,
+          "val_accuracy": 0.7446808510638298
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7659574747085571,
+        "test_loss": 0.5560439825057983
+      },
+      "model_key": "mamba",
+      "record_id": "run-000282",
+      "run_name": "run_009",
+      "source_run_id": "20251222_141251_phaseb_train_recipe_memba_run_009",
+      "started_at": "2025-12-22T19:14:54",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_010/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_010/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_010",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_010"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_010/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_010/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_010/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_010/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_010/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_010/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_010/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_010/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_010/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_010/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_141251_phaseb_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 4,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:15:21",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7446808218955994,
+          "test_loss": 0.6025915145874023,
+          "train_accuracy": 0.9814814814814815,
+          "val_accuracy": 0.723404255319149
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7446808218955994,
+        "test_loss": 0.6025915145874023
+      },
+      "model_key": "mamba",
+      "record_id": "run-000283",
+      "run_name": "run_010",
+      "source_run_id": "20251222_141251_phaseb_train_recipe_memba_run_010",
+      "started_at": "2025-12-22T19:15:08",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_011/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_011/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_011",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_011"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_011/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_011/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_011/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_011/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_011/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_011/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_011/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_011/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_011/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_011/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_141251_phaseb_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 6,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:15:42",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7872340679168701,
+          "test_loss": 0.6515741348266602,
+          "train_accuracy": 0.9861111111111112,
+          "val_accuracy": 0.7659574468085106
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7872340679168701,
+        "test_loss": 0.6515741348266602
+      },
+      "model_key": "mamba",
+      "record_id": "run-000284",
+      "run_name": "run_011",
+      "source_run_id": "20251222_141251_phaseb_train_recipe_memba_run_011",
+      "started_at": "2025-12-22T19:15:21",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_012/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_012/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_012",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_012"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_012/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_012/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_012/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_012/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_012/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_012/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_012/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_012/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_012/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_012/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_141251_phaseb_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 6,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:15:57",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7234042286872864,
+          "test_loss": 0.7352174520492554,
+          "train_accuracy": 0.9675925925925926,
+          "val_accuracy": 0.7872340425531915
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7234042286872864,
+        "test_loss": 0.7352174520492554
+      },
+      "model_key": "mamba",
+      "record_id": "run-000285",
+      "run_name": "run_012",
+      "source_run_id": "20251222_141251_phaseb_train_recipe_memba_run_012",
+      "started_at": "2025-12-22T19:15:43",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_013/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_013/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_013",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_013"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_013/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_013/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_013/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_013/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_013/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_013/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_013/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_013/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_013/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_013/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_141251_phaseb_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "d_model": 256,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:16:10",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7659574747085571,
+          "test_loss": 0.6128727793693542,
+          "train_accuracy": 0.9768518518518519,
+          "val_accuracy": 0.7446808510638298
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7659574747085571,
+        "test_loss": 0.6128727793693542
+      },
+      "model_key": "mamba",
+      "record_id": "run-000286",
+      "run_name": "run_013",
+      "source_run_id": "20251222_141251_phaseb_train_recipe_memba_run_013",
+      "started_at": "2025-12-22T19:15:58",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_014/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_014/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_014",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_014"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_014/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_014/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_014/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_014/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_014/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_014/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_014/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_014/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_014/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_014/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_141251_phaseb_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "d_model": 256,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:16:20",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.8085106611251831,
+          "test_loss": 0.5411496758460999,
+          "train_accuracy": 0.9768518518518519,
+          "val_accuracy": 0.723404255319149
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.8085106611251831,
+        "test_loss": 0.5411496758460999
+      },
+      "model_key": "mamba",
+      "record_id": "run-000287",
+      "run_name": "run_014",
+      "source_run_id": "20251222_141251_phaseb_train_recipe_memba_run_014",
+      "started_at": "2025-12-22T19:16:10",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_015/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_015/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_015",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_015"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_015/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_015/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_015/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_015/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_015/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_015/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_015/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_015/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_015/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_015/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_141251_phaseb_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "d_model": 256,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 4,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:16:40",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7872340679168701,
+          "test_loss": 0.7304054498672485,
+          "train_accuracy": 0.9814814814814815,
+          "val_accuracy": 0.7659574468085106
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7872340679168701,
+        "test_loss": 0.7304054498672485
+      },
+      "model_key": "mamba",
+      "record_id": "run-000288",
+      "run_name": "run_015",
+      "source_run_id": "20251222_141251_phaseb_train_recipe_memba_run_015",
+      "started_at": "2025-12-22T19:16:21",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_016/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_016/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_016",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_016"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_016/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_016/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_016/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_016/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_016/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_016/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_016/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_016/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_016/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_016/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_141251_phaseb_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "d_model": 256,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 4,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:16:55",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.8085106611251831,
+          "test_loss": 0.6548391580581665,
+          "train_accuracy": 0.9861111111111112,
+          "val_accuracy": 0.7659574468085106
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.8085106611251831,
+        "test_loss": 0.6548391580581665
+      },
+      "model_key": "mamba",
+      "record_id": "run-000289",
+      "run_name": "run_016",
+      "source_run_id": "20251222_141251_phaseb_train_recipe_memba_run_016",
+      "started_at": "2025-12-22T19:16:41",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_017/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_017/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_017",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_017"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_017/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_017/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_017/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_017/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_017/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_017/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_017/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_017/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_017/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_017/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_141251_phaseb_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "d_model": 256,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 6,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:17:27",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.8085106611251831,
+          "test_loss": 0.5603275895118713,
+          "train_accuracy": 0.9861111111111112,
+          "val_accuracy": 0.7446808510638298
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.8085106611251831,
+        "test_loss": 0.5603275895118713
+      },
+      "model_key": "mamba",
+      "record_id": "run-000290",
+      "run_name": "run_017",
+      "source_run_id": "20251222_141251_phaseb_train_recipe_memba_run_017",
+      "started_at": "2025-12-22T19:16:56",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_018/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_018/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_018",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_018"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_018/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_018/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_018/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_018/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_018/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_018/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_018/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_018/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_018/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_141251_phaseb_train_recipe_memba/run_018/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_141251_phaseb_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "d_model": 256,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 6,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:17:51",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.8297872543334961,
+          "test_loss": 0.49456438422203064,
+          "train_accuracy": 0.9861111111111112,
+          "val_accuracy": 0.7872340425531915
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.8297872543334961,
+        "test_loss": 0.49456438422203064
+      },
+      "model_key": "mamba",
+      "record_id": "run-000291",
+      "run_name": "run_018",
+      "source_run_id": "20251222_141251_phaseb_train_recipe_memba_run_018",
+      "started_at": "2025-12-22T19:17:28",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_001/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_001/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_001",
+          "resolved_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_001"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_001/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_001/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_001/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_001/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_001/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_001/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_001/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_001/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_001/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_001/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 8,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_142231_phasec_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:22:35",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.8510638475418091,
+          "test_loss": 0.5026400089263916,
+          "train_accuracy": 0.9814814814814815,
+          "val_accuracy": 0.7659574468085106
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.8510638475418091,
+        "test_loss": 0.5026400089263916
+      },
+      "model_key": "mamba",
+      "record_id": "run-000292",
+      "run_name": "run_001",
+      "source_run_id": "20251222_142231_phasec_train_recipe_memba_run_001",
+      "started_at": "2025-12-22T19:22:31",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_002/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_002/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_002",
+          "resolved_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_002"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_002/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_002/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_002/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_002/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_002/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_002/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_002/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_002/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_002/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_002/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 8,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 43,
+          "seq_len": 30,
+          "sweep_id": "20251222_142231_phasec_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:22:39",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7659574747085571,
+          "test_loss": 0.6834836006164551,
+          "train_accuracy": 0.9814814814814815,
+          "val_accuracy": 0.7021276595744681
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7659574747085571,
+        "test_loss": 0.6834836006164551
+      },
+      "model_key": "mamba",
+      "record_id": "run-000293",
+      "run_name": "run_002",
+      "source_run_id": "20251222_142231_phasec_train_recipe_memba_run_002",
+      "started_at": "2025-12-22T19:22:35",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_003/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_003/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_003",
+          "resolved_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_003"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_003/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_003/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_003/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_003/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_003/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_003/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_003/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_003/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_003/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_003/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 8,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 44,
+          "seq_len": 30,
+          "sweep_id": "20251222_142231_phasec_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:22:43",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.8723404407501221,
+          "test_loss": 0.5244731307029724,
+          "train_accuracy": 0.9814814814814815,
+          "val_accuracy": 0.723404255319149
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.8723404407501221,
+        "test_loss": 0.5244731307029724
+      },
+      "model_key": "mamba",
+      "record_id": "run-000294",
+      "run_name": "run_003",
+      "source_run_id": "20251222_142231_phasec_train_recipe_memba_run_003",
+      "started_at": "2025-12-22T19:22:39",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_004/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_004/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_004",
+          "resolved_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_004"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_004/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_004/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_004/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_004/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_004/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_004/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_004/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_004/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_004/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_004/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 8,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 45,
+          "seq_len": 30,
+          "sweep_id": "20251222_142231_phasec_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:22:48",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.8085106611251831,
+          "test_loss": 0.4911457598209381,
+          "train_accuracy": 0.9861111111111112,
+          "val_accuracy": 0.6808510638297872
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.8085106611251831,
+        "test_loss": 0.4911457598209381
+      },
+      "model_key": "mamba",
+      "record_id": "run-000295",
+      "run_name": "run_004",
+      "source_run_id": "20251222_142231_phasec_train_recipe_memba_run_004",
+      "started_at": "2025-12-22T19:22:44",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_005/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_005/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_005",
+          "resolved_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_005"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_005/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_005/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_005/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_005/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_005/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_005/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_005/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_005/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_005/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_142231_phasec_train_recipe_memba/run_005/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 8,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 46,
+          "seq_len": 30,
+          "sweep_id": "20251222_142231_phasec_train_recipe_memba",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T19:22:52",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7021276354789734,
+          "test_loss": 0.7140020728111267,
+          "train_accuracy": 0.9629629629629629,
+          "val_accuracy": 0.7659574468085106
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7021276354789734,
+        "test_loss": 0.7140020728111267
+      },
+      "model_key": "mamba",
+      "record_id": "run-000296",
+      "run_name": "run_005",
+      "source_run_id": "20251222_142231_phasec_train_recipe_memba_run_005",
+      "started_at": "2025-12-22T19:22:48",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150231_preprocess_sweep_1/run_001/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150231_preprocess_sweep_1/run_001/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150231_preprocess_sweep_1/run_001",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150231_preprocess_sweep_1/run_001"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150231_preprocess_sweep_1/run_001/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150231_preprocess_sweep_1/run_001/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150231_preprocess_sweep_1/run_001/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150231_preprocess_sweep_1/run_001/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150231_preprocess_sweep_1/run_001/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150231_preprocess_sweep_1/run_001/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150231_preprocess_sweep_1/run_001/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150231_preprocess_sweep_1/run_001/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150231_preprocess_sweep_1/run_001/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150231_preprocess_sweep_1/run_001/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/baseline_pos_handscale_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/baseline_pos_handscale_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.01,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_150231_preprocess_sweep_1",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T20:02:37",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7234042286872864,
+          "test_loss": 0.910670816898346,
+          "train_accuracy": 0.9351851851851852,
+          "val_accuracy": 0.6382978723404256
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7234042286872864,
+        "test_loss": 0.910670816898346
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000297",
+      "run_name": "run_001",
+      "source_run_id": "20251222_150231_preprocess_sweep_1_run_001",
+      "started_at": "2025-12-22T20:02:33",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150231_preprocess_sweep_1/run_002/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150231_preprocess_sweep_1/run_002/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150231_preprocess_sweep_1/run_002",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150231_preprocess_sweep_1/run_002"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150231_preprocess_sweep_1/run_002/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150231_preprocess_sweep_1/run_002/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150231_preprocess_sweep_1/run_002/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150231_preprocess_sweep_1/run_002/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150231_preprocess_sweep_1/run_002/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150231_preprocess_sweep_1/run_002/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150231_preprocess_sweep_1/run_002/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150231_preprocess_sweep_1/run_002/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150231_preprocess_sweep_1/run_002/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150231_preprocess_sweep_1/run_002/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/baseline_pos_handscale_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/baseline_pos_handscale_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.01,
+          "optimizer_type": "adam",
+          "seed": 43,
+          "seq_len": 30,
+          "sweep_id": "20251222_150231_preprocess_sweep_1",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T20:02:40",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.6170212626457214,
+          "test_loss": 0.9801743626594543,
+          "train_accuracy": 0.8055555555555556,
+          "val_accuracy": 0.6382978723404256
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.6170212626457214,
+        "test_loss": 0.9801743626594543
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000298",
+      "run_name": "run_002",
+      "source_run_id": "20251222_150231_preprocess_sweep_1_run_002",
+      "started_at": "2025-12-22T20:02:37",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150231_preprocess_sweep_1/run_003/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150231_preprocess_sweep_1/run_003/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150231_preprocess_sweep_1/run_003",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150231_preprocess_sweep_1/run_003"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150231_preprocess_sweep_1/run_003/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150231_preprocess_sweep_1/run_003/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150231_preprocess_sweep_1/run_003/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150231_preprocess_sweep_1/run_003/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150231_preprocess_sweep_1/run_003/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150231_preprocess_sweep_1/run_003/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150231_preprocess_sweep_1/run_003/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150231_preprocess_sweep_1/run_003/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150231_preprocess_sweep_1/run_003/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150231_preprocess_sweep_1/run_003/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/baseline_pos_handscale_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/baseline_pos_handscale_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.01,
+          "optimizer_type": "adam",
+          "seed": 44,
+          "seq_len": 30,
+          "sweep_id": "20251222_150231_preprocess_sweep_1",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T20:02:43",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.6808510422706604,
+          "test_loss": 0.9957749247550964,
+          "train_accuracy": 0.9305555555555556,
+          "val_accuracy": 0.6382978723404256
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.6808510422706604,
+        "test_loss": 0.9957749247550964
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000299",
+      "run_name": "run_003",
+      "source_run_id": "20251222_150231_preprocess_sweep_1_run_003",
+      "started_at": "2025-12-22T20:02:40",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150337_preprocess_sweep_2/run_001/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150337_preprocess_sweep_2/run_001/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150337_preprocess_sweep_2/run_001",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150337_preprocess_sweep_2/run_001"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150337_preprocess_sweep_2/run_001/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150337_preprocess_sweep_2/run_001/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150337_preprocess_sweep_2/run_001/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150337_preprocess_sweep_2/run_001/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150337_preprocess_sweep_2/run_001/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150337_preprocess_sweep_2/run_001/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150337_preprocess_sweep_2/run_001/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150337_preprocess_sweep_2/run_001/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150337_preprocess_sweep_2/run_001/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150337_preprocess_sweep_2/run_001/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.01,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_150337_preprocess_sweep_2",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T20:03:44",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.6808510422706604,
+          "test_loss": 1.1338908672332764,
+          "train_accuracy": 0.9814814814814815,
+          "val_accuracy": 0.7446808510638298
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.6808510422706604,
+        "test_loss": 1.1338908672332764
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000300",
+      "run_name": "run_001",
+      "source_run_id": "20251222_150337_preprocess_sweep_2_run_001",
+      "started_at": "2025-12-22T20:03:40",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    }
+  ],
+  "schema_version": 1,
+  "shard": 2
+}

--- a/docs/legacy/export/v1/runs/runs-003.json
+++ b/docs/legacy/export/v1/runs/runs-003.json
@@ -1,0 +1,14007 @@
+{
+  "kind": "signlab.legacy-run-index",
+  "records": [
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150337_preprocess_sweep_2/run_002/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150337_preprocess_sweep_2/run_002/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150337_preprocess_sweep_2/run_002",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150337_preprocess_sweep_2/run_002"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150337_preprocess_sweep_2/run_002/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150337_preprocess_sweep_2/run_002/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150337_preprocess_sweep_2/run_002/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150337_preprocess_sweep_2/run_002/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150337_preprocess_sweep_2/run_002/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150337_preprocess_sweep_2/run_002/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150337_preprocess_sweep_2/run_002/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150337_preprocess_sweep_2/run_002/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150337_preprocess_sweep_2/run_002/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150337_preprocess_sweep_2/run_002/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.01,
+          "optimizer_type": "adam",
+          "seed": 43,
+          "seq_len": 30,
+          "sweep_id": "20251222_150337_preprocess_sweep_2",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T20:03:47",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7446808218955994,
+          "test_loss": 0.8591005802154541,
+          "train_accuracy": 0.9305555555555556,
+          "val_accuracy": 0.7021276595744681
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7446808218955994,
+        "test_loss": 0.8591005802154541
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000301",
+      "run_name": "run_002",
+      "source_run_id": "20251222_150337_preprocess_sweep_2_run_002",
+      "started_at": "2025-12-22T20:03:44",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150337_preprocess_sweep_2/run_003/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150337_preprocess_sweep_2/run_003/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150337_preprocess_sweep_2/run_003",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150337_preprocess_sweep_2/run_003"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150337_preprocess_sweep_2/run_003/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150337_preprocess_sweep_2/run_003/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150337_preprocess_sweep_2/run_003/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150337_preprocess_sweep_2/run_003/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150337_preprocess_sweep_2/run_003/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150337_preprocess_sweep_2/run_003/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150337_preprocess_sweep_2/run_003/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150337_preprocess_sweep_2/run_003/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150337_preprocess_sweep_2/run_003/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150337_preprocess_sweep_2/run_003/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.01,
+          "optimizer_type": "adam",
+          "seed": 44,
+          "seq_len": 30,
+          "sweep_id": "20251222_150337_preprocess_sweep_2",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T20:03:52",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.7659574747085571,
+          "test_loss": 0.8441765904426575,
+          "train_accuracy": 0.9814814814814815,
+          "val_accuracy": 0.7446808510638298
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.7659574747085571,
+        "test_loss": 0.8441765904426575
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000302",
+      "run_name": "run_003",
+      "source_run_id": "20251222_150337_preprocess_sweep_2_run_003",
+      "started_at": "2025-12-22T20:03:48",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150503_preprocess_sweep_3/run_001/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150503_preprocess_sweep_3/run_001/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150503_preprocess_sweep_3/run_001",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150503_preprocess_sweep_3/run_001"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150503_preprocess_sweep_3/run_001/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150503_preprocess_sweep_3/run_001/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150503_preprocess_sweep_3/run_001/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150503_preprocess_sweep_3/run_001/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150503_preprocess_sweep_3/run_001/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150503_preprocess_sweep_3/run_001/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150503_preprocess_sweep_3/run_001/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150503_preprocess_sweep_3/run_001/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150503_preprocess_sweep_3/run_001/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150503_preprocess_sweep_3/run_001/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.01,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_150503_preprocess_sweep_3",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T20:05:13",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.6595744490623474,
+          "test_loss": 1.1579501628875732,
+          "train_accuracy": 0.8981481481481481,
+          "val_accuracy": 0.6382978723404256
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.6595744490623474,
+        "test_loss": 1.1579501628875732
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000303",
+      "run_name": "run_001",
+      "source_run_id": "20251222_150503_preprocess_sweep_3_run_001",
+      "started_at": "2025-12-22T20:05:10",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150503_preprocess_sweep_3/run_002/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150503_preprocess_sweep_3/run_002/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150503_preprocess_sweep_3/run_002",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150503_preprocess_sweep_3/run_002"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150503_preprocess_sweep_3/run_002/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150503_preprocess_sweep_3/run_002/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150503_preprocess_sweep_3/run_002/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150503_preprocess_sweep_3/run_002/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150503_preprocess_sweep_3/run_002/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150503_preprocess_sweep_3/run_002/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150503_preprocess_sweep_3/run_002/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150503_preprocess_sweep_3/run_002/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150503_preprocess_sweep_3/run_002/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150503_preprocess_sweep_3/run_002/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.01,
+          "optimizer_type": "adam",
+          "seed": 43,
+          "seq_len": 30,
+          "sweep_id": "20251222_150503_preprocess_sweep_3",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T20:05:16",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.6382978558540344,
+          "test_loss": 1.148180603981018,
+          "train_accuracy": 0.8981481481481481,
+          "val_accuracy": 0.6808510638297872
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.6382978558540344,
+        "test_loss": 1.148180603981018
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000304",
+      "run_name": "run_002",
+      "source_run_id": "20251222_150503_preprocess_sweep_3_run_002",
+      "started_at": "2025-12-22T20:05:13",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150503_preprocess_sweep_3/run_003/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150503_preprocess_sweep_3/run_003/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150503_preprocess_sweep_3/run_003",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150503_preprocess_sweep_3/run_003"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150503_preprocess_sweep_3/run_003/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150503_preprocess_sweep_3/run_003/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150503_preprocess_sweep_3/run_003/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150503_preprocess_sweep_3/run_003/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150503_preprocess_sweep_3/run_003/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150503_preprocess_sweep_3/run_003/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150503_preprocess_sweep_3/run_003/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150503_preprocess_sweep_3/run_003/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_150503_preprocess_sweep_3/run_003/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_150503_preprocess_sweep_3/run_003/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/shape_motion_angles_robust_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.01,
+          "optimizer_type": "adam",
+          "seed": 44,
+          "seq_len": 30,
+          "sweep_id": "20251222_150503_preprocess_sweep_3",
+          "test_frac": 0.15,
+          "val_frac": 0.15,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.15,
+        "validation_fraction": 0.15
+      },
+      "finished_at": "2025-12-22T20:05:20",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "label_counts_train": {
+            "hello": 42,
+            "no": 49,
+            "please": 40,
+            "thank you": 37,
+            "yes": 48
+          },
+          "label_counts_val": {
+            "hello": 9,
+            "no": 11,
+            "please": 9,
+            "thank you": 8,
+            "yes": 10
+          },
+          "num_classes": 5,
+          "samples_test": 47,
+          "samples_train": 216,
+          "samples_val": 47,
+          "test_accuracy": 0.6595744490623474,
+          "test_loss": 1.1211609840393066,
+          "train_accuracy": 0.9814814814814815,
+          "val_accuracy": 0.7021276595744681
+        },
+        "samples_test": 47,
+        "samples_train": 216,
+        "samples_validation": 47,
+        "test_accuracy": 0.6595744490623474,
+        "test_loss": 1.1211609840393066
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000305",
+      "run_name": "run_003",
+      "source_run_id": "20251222_150503_preprocess_sweep_3_run_003",
+      "started_at": "2025-12-22T20:05:16",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_001/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_001/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_001",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_001"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_001/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_001/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_001/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_001/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_001/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_001/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_001/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_001/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_001/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_001/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_152528_gru_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:25:33",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.5161290168762207,
+          "test_loss": 1.5084818601608276,
+          "train_accuracy": 0.5967741935483871,
+          "val_accuracy": 0.5967741935483871
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.5161290168762207,
+        "test_loss": 1.5084818601608276
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000306",
+      "run_name": "run_001",
+      "source_run_id": "20251222_152528_gru_phase_a_run_001",
+      "started_at": "2025-12-22T20:25:28",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_002/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_002/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_002",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_002"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_002/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_002/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_002/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_002/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_002/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_002/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_002/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_002/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_002/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_002/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_152528_gru_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:25:43",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8225806355476379,
+          "test_loss": 0.7930776476860046,
+          "train_accuracy": 0.7903225806451613,
+          "val_accuracy": 0.7258064516129032
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8225806355476379,
+        "test_loss": 0.7930776476860046
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000307",
+      "run_name": "run_002",
+      "source_run_id": "20251222_152528_gru_phase_a_run_002",
+      "started_at": "2025-12-22T20:25:33",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_003/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_003/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_003",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_003"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_003/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_003/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_003/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_003/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_003/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_003/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_003/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_003/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_003/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_003/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_152528_gru_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:25:48",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.4838709533214569,
+          "test_loss": 1.4908645153045654,
+          "train_accuracy": 0.5,
+          "val_accuracy": 0.45161290322580644
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.4838709533214569,
+        "test_loss": 1.4908645153045654
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000308",
+      "run_name": "run_003",
+      "source_run_id": "20251222_152528_gru_phase_a_run_003",
+      "started_at": "2025-12-22T20:25:43",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_004/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_004/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_004",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_004"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_004/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_004/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_004/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_004/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_004/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_004/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_004/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_004/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_004/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_004/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_152528_gru_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:25:56",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.5967742204666138,
+          "test_loss": 1.3345009088516235,
+          "train_accuracy": 0.5806451612903226,
+          "val_accuracy": 0.532258064516129
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.5967742204666138,
+        "test_loss": 1.3345009088516235
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000309",
+      "run_name": "run_004",
+      "source_run_id": "20251222_152528_gru_phase_a_run_004",
+      "started_at": "2025-12-22T20:25:48",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_005/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_005/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_005",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_005"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_005/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_005/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_005/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_005/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_005/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_005/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_005/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_005/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_005/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_005/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_152528_gru_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.4,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:26:02",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.5483871102333069,
+          "test_loss": 1.4817427396774292,
+          "train_accuracy": 0.5645161290322581,
+          "val_accuracy": 0.4838709677419355
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.5483871102333069,
+        "test_loss": 1.4817427396774292
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000310",
+      "run_name": "run_005",
+      "source_run_id": "20251222_152528_gru_phase_a_run_005",
+      "started_at": "2025-12-22T20:25:56",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_006/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_006/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_006",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_006"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_006/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_006/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_006/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_006/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_006/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_006/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_006/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_006/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_006/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_006/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_152528_gru_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:26:07",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.5161290168762207,
+          "test_loss": 1.5084818601608276,
+          "train_accuracy": 0.5967741935483871,
+          "val_accuracy": 0.5967741935483871
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.5161290168762207,
+        "test_loss": 1.5084818601608276
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000311",
+      "run_name": "run_006",
+      "source_run_id": "20251222_152528_gru_phase_a_run_006",
+      "started_at": "2025-12-22T20:26:02",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_007/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_007/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_007",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_007"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_007/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_007/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_007/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_007/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_007/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_007/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_007/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_007/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_007/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_007/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_152528_gru_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:26:17",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8225806355476379,
+          "test_loss": 0.7930776476860046,
+          "train_accuracy": 0.7903225806451613,
+          "val_accuracy": 0.7258064516129032
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8225806355476379,
+        "test_loss": 0.7930776476860046
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000312",
+      "run_name": "run_007",
+      "source_run_id": "20251222_152528_gru_phase_a_run_007",
+      "started_at": "2025-12-22T20:26:08",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_008/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_008/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_008",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_008"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_008/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_008/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_008/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_008/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_008/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_008/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_008/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_008/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_008/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_008/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_152528_gru_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:26:23",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.4838709533214569,
+          "test_loss": 1.4908645153045654,
+          "train_accuracy": 0.5,
+          "val_accuracy": 0.45161290322580644
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.4838709533214569,
+        "test_loss": 1.4908645153045654
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000313",
+      "run_name": "run_008",
+      "source_run_id": "20251222_152528_gru_phase_a_run_008",
+      "started_at": "2025-12-22T20:26:17",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_009/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_009/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_009",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_009"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_009/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_009/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_009/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_009/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_009/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_009/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_009/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_009/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_009/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_009/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_152528_gru_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:26:30",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.5967742204666138,
+          "test_loss": 1.3345009088516235,
+          "train_accuracy": 0.5806451612903226,
+          "val_accuracy": 0.532258064516129
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.5967742204666138,
+        "test_loss": 1.3345009088516235
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000314",
+      "run_name": "run_009",
+      "source_run_id": "20251222_152528_gru_phase_a_run_009",
+      "started_at": "2025-12-22T20:26:23",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_010/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_010/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_010",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_010"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_010/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_010/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_010/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_010/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_010/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_010/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_010/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_010/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_010/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_010/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_152528_gru_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.4,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:26:36",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.5483871102333069,
+          "test_loss": 1.4817427396774292,
+          "train_accuracy": 0.5645161290322581,
+          "val_accuracy": 0.4838709677419355
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.5483871102333069,
+        "test_loss": 1.4817427396774292
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000315",
+      "run_name": "run_010",
+      "source_run_id": "20251222_152528_gru_phase_a_run_010",
+      "started_at": "2025-12-22T20:26:30",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_011/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_011/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_011",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_011"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_011/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_011/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_011/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_011/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_011/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_011/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_011/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_011/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_011/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_011/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_152528_gru_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:26:41",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.5645161271095276,
+          "test_loss": 1.4597281217575073,
+          "train_accuracy": 0.6505376344086021,
+          "val_accuracy": 0.6290322580645161
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.5645161271095276,
+        "test_loss": 1.4597281217575073
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000316",
+      "run_name": "run_011",
+      "source_run_id": "20251222_152528_gru_phase_a_run_011",
+      "started_at": "2025-12-22T20:26:36",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_012/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_012/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_012",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_012"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_012/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_012/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_012/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_012/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_012/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_012/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_012/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_012/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_012/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_012/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_152528_gru_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:26:49",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8225806355476379,
+          "test_loss": 0.626359760761261,
+          "train_accuracy": 0.8978494623655914,
+          "val_accuracy": 0.7580645161290323
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8225806355476379,
+        "test_loss": 0.626359760761261
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000317",
+      "run_name": "run_012",
+      "source_run_id": "20251222_152528_gru_phase_a_run_012",
+      "started_at": "2025-12-22T20:26:41",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_013/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_013/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_013",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_013"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_013/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_013/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_013/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_013/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_013/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_013/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_013/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_013/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_013/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_013/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_152528_gru_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:26:59",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8387096524238586,
+          "test_loss": 0.5606422424316406,
+          "train_accuracy": 0.9301075268817204,
+          "val_accuracy": 0.7741935483870968
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8387096524238586,
+        "test_loss": 0.5606422424316406
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000318",
+      "run_name": "run_013",
+      "source_run_id": "20251222_152528_gru_phase_a_run_013",
+      "started_at": "2025-12-22T20:26:49",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_014/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_014/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_014",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_014"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_014/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_014/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_014/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_014/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_014/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_014/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_014/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_014/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_014/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_014/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_152528_gru_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:27:08",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.7903226017951965,
+          "test_loss": 0.7632730007171631,
+          "train_accuracy": 0.8387096774193549,
+          "val_accuracy": 0.7741935483870968
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.7903226017951965,
+        "test_loss": 0.7632730007171631
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000319",
+      "run_name": "run_014",
+      "source_run_id": "20251222_152528_gru_phase_a_run_014",
+      "started_at": "2025-12-22T20:26:59",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_015/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_015/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_015",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_015"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_015/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_015/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_015/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_015/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_015/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_015/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_015/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_015/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_015/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_015/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_152528_gru_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.4,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:27:13",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.6290322542190552,
+          "test_loss": 1.3726654052734375,
+          "train_accuracy": 0.5967741935483871,
+          "val_accuracy": 0.46774193548387094
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.6290322542190552,
+        "test_loss": 1.3726654052734375
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000320",
+      "run_name": "run_015",
+      "source_run_id": "20251222_152528_gru_phase_a_run_015",
+      "started_at": "2025-12-22T20:27:08",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_016/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_016/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_016",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_016"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_016/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_016/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_016/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_016/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_016/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_016/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_016/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_016/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_016/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_016/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_152528_gru_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:27:18",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.5645161271095276,
+          "test_loss": 1.4597281217575073,
+          "train_accuracy": 0.6505376344086021,
+          "val_accuracy": 0.6290322580645161
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.5645161271095276,
+        "test_loss": 1.4597281217575073
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000321",
+      "run_name": "run_016",
+      "source_run_id": "20251222_152528_gru_phase_a_run_016",
+      "started_at": "2025-12-22T20:27:14",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_017/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_017/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_017",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_017"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_017/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_017/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_017/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_017/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_017/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_017/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_017/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_017/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_017/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_017/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_152528_gru_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:27:26",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8225806355476379,
+          "test_loss": 0.626359760761261,
+          "train_accuracy": 0.8978494623655914,
+          "val_accuracy": 0.7580645161290323
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8225806355476379,
+        "test_loss": 0.626359760761261
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000322",
+      "run_name": "run_017",
+      "source_run_id": "20251222_152528_gru_phase_a_run_017",
+      "started_at": "2025-12-22T20:27:18",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_018/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_018/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_018",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_018"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_018/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_018/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_018/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_018/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_018/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_018/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_018/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_018/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_018/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_018/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_152528_gru_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:27:36",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8387096524238586,
+          "test_loss": 0.5606422424316406,
+          "train_accuracy": 0.9301075268817204,
+          "val_accuracy": 0.7741935483870968
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8387096524238586,
+        "test_loss": 0.5606422424316406
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000323",
+      "run_name": "run_018",
+      "source_run_id": "20251222_152528_gru_phase_a_run_018",
+      "started_at": "2025-12-22T20:27:27",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_019/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_019/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_019",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_019"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_019/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_019/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_019/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_019/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_019/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_019/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_019/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_019/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_019/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_019/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_152528_gru_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:27:46",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.7903226017951965,
+          "test_loss": 0.7632730007171631,
+          "train_accuracy": 0.8387096774193549,
+          "val_accuracy": 0.7741935483870968
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.7903226017951965,
+        "test_loss": 0.7632730007171631
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000324",
+      "run_name": "run_019",
+      "source_run_id": "20251222_152528_gru_phase_a_run_019",
+      "started_at": "2025-12-22T20:27:36",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_020/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_020/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_020",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_020"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_020/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_020/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_020/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_020/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_020/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_020/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_020/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_020/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_020/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_020/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_152528_gru_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.4,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:27:51",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.6290322542190552,
+          "test_loss": 1.3726654052734375,
+          "train_accuracy": 0.5967741935483871,
+          "val_accuracy": 0.46774193548387094
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.6290322542190552,
+        "test_loss": 1.3726654052734375
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000325",
+      "run_name": "run_020",
+      "source_run_id": "20251222_152528_gru_phase_a_run_020",
+      "started_at": "2025-12-22T20:27:46",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_021/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_021/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_021",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_021"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_021/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_021/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_021/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_021/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_021/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_021/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_021/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_021/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_021/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_021/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_152528_gru_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:27:58",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8548387289047241,
+          "test_loss": 0.6965636014938354,
+          "train_accuracy": 0.9838709677419355,
+          "val_accuracy": 0.8064516129032258
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8548387289047241,
+        "test_loss": 0.6965636014938354
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000326",
+      "run_name": "run_021",
+      "source_run_id": "20251222_152528_gru_phase_a_run_021",
+      "started_at": "2025-12-22T20:27:51",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_022/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_022/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_022",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_022"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_022/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_022/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_022/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_022/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_022/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_022/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_022/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_022/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_022/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_022/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_152528_gru_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:28:05",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.7903226017951965,
+          "test_loss": 0.5315257906913757,
+          "train_accuracy": 0.978494623655914,
+          "val_accuracy": 0.8064516129032258
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.7903226017951965,
+        "test_loss": 0.5315257906913757
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000327",
+      "run_name": "run_022",
+      "source_run_id": "20251222_152528_gru_phase_a_run_022",
+      "started_at": "2025-12-22T20:27:59",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_023/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_023/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_023",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_023"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_023/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_023/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_023/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_023/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_023/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_023/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_023/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_023/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_023/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_023/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_152528_gru_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:28:12",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8064516186714172,
+          "test_loss": 0.7304223775863647,
+          "train_accuracy": 0.8655913978494624,
+          "val_accuracy": 0.7741935483870968
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8064516186714172,
+        "test_loss": 0.7304223775863647
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000328",
+      "run_name": "run_023",
+      "source_run_id": "20251222_152528_gru_phase_a_run_023",
+      "started_at": "2025-12-22T20:28:06",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_024/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_024/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_024",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_024"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_024/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_024/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_024/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_024/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_024/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_024/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_024/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_024/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_024/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_024/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_152528_gru_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:28:19",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8225806355476379,
+          "test_loss": 0.5956308841705322,
+          "train_accuracy": 0.9301075268817204,
+          "val_accuracy": 0.7741935483870968
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8225806355476379,
+        "test_loss": 0.5956308841705322
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000329",
+      "run_name": "run_024",
+      "source_run_id": "20251222_152528_gru_phase_a_run_024",
+      "started_at": "2025-12-22T20:28:12",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_025/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_025/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_025",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_025"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_025/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_025/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_025/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_025/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_025/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_025/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_025/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_025/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_025/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_025/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_152528_gru_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.4,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:28:26",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.7580645084381104,
+          "test_loss": 0.773429274559021,
+          "train_accuracy": 0.8172043010752689,
+          "val_accuracy": 0.7580645161290323
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.7580645084381104,
+        "test_loss": 0.773429274559021
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000330",
+      "run_name": "run_025",
+      "source_run_id": "20251222_152528_gru_phase_a_run_025",
+      "started_at": "2025-12-22T20:28:19",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_026/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_026/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_026",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_026"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_026/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_026/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_026/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_026/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_026/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_026/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_026/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_026/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_026/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_026/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_152528_gru_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:28:33",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8548387289047241,
+          "test_loss": 0.6965636014938354,
+          "train_accuracy": 0.9838709677419355,
+          "val_accuracy": 0.8064516129032258
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8548387289047241,
+        "test_loss": 0.6965636014938354
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000331",
+      "run_name": "run_026",
+      "source_run_id": "20251222_152528_gru_phase_a_run_026",
+      "started_at": "2025-12-22T20:28:26",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_027/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_027/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_027",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_027"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_027/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_027/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_027/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_027/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_027/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_027/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_027/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_027/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_027/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_027/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_152528_gru_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:28:43",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.7903226017951965,
+          "test_loss": 0.5315257906913757,
+          "train_accuracy": 0.978494623655914,
+          "val_accuracy": 0.8064516129032258
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.7903226017951965,
+        "test_loss": 0.5315257906913757
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000332",
+      "run_name": "run_027",
+      "source_run_id": "20251222_152528_gru_phase_a_run_027",
+      "started_at": "2025-12-22T20:28:33",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_028/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_028/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_028",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_028"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_028/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_028/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_028/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_028/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_028/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_028/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_028/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_028/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_028/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_028/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_152528_gru_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:28:50",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8064516186714172,
+          "test_loss": 0.7304223775863647,
+          "train_accuracy": 0.8655913978494624,
+          "val_accuracy": 0.7741935483870968
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8064516186714172,
+        "test_loss": 0.7304223775863647
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000333",
+      "run_name": "run_028",
+      "source_run_id": "20251222_152528_gru_phase_a_run_028",
+      "started_at": "2025-12-22T20:28:44",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_029/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_029/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_029",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_029"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_029/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_029/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_029/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_029/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_029/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_029/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_029/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_029/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_029/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_029/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_152528_gru_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:28:57",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8225806355476379,
+          "test_loss": 0.5956308841705322,
+          "train_accuracy": 0.9301075268817204,
+          "val_accuracy": 0.7741935483870968
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8225806355476379,
+        "test_loss": 0.5956308841705322
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000334",
+      "run_name": "run_029",
+      "source_run_id": "20251222_152528_gru_phase_a_run_029",
+      "started_at": "2025-12-22T20:28:50",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_030/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_030/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_030",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_030"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_030/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_030/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_030/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_030/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_030/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_030/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_030/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_030/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_030/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_152528_gru_phase_a/run_030/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_152528_gru_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.4,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:29:04",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.7580645084381104,
+          "test_loss": 0.773429274559021,
+          "train_accuracy": 0.8172043010752689,
+          "val_accuracy": 0.7580645161290323
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.7580645084381104,
+        "test_loss": 0.773429274559021
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000335",
+      "run_name": "run_030",
+      "source_run_id": "20251222_152528_gru_phase_a_run_030",
+      "started_at": "2025-12-22T20:28:58",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_001/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_001/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_001",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_001"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_001/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_001/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_001/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_001/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_001/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_001/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_001/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_001/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_001/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_001/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_153505_gru_phase_2",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 64,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:35:11",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.6935483813285828,
+          "test_loss": 0.9371265172958374,
+          "train_accuracy": 0.9838709677419355,
+          "val_accuracy": 0.6935483870967742
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.6935483813285828,
+        "test_loss": 0.9371265172958374
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000336",
+      "run_name": "run_001",
+      "source_run_id": "20251222_153505_gru_phase_2_run_001",
+      "started_at": "2025-12-22T20:35:05",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_002/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_002/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_002",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_002"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_002/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_002/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_002/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_002/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_002/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_002/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_002/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_002/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_002/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_002/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_153505_gru_phase_2",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 64,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:35:15",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8064516186714172,
+          "test_loss": 0.6548428535461426,
+          "train_accuracy": 0.9032258064516129,
+          "val_accuracy": 0.7903225806451613
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8064516186714172,
+        "test_loss": 0.6548428535461426
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000337",
+      "run_name": "run_002",
+      "source_run_id": "20251222_153505_gru_phase_2_run_002",
+      "started_at": "2025-12-22T20:35:11",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_003/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_003/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_003",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_003"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_003/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_003/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_003/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_003/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_003/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_003/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_003/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_003/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_003/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_003/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_153505_gru_phase_2",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 64,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:35:21",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.7419354915618896,
+          "test_loss": 1.0644491910934448,
+          "train_accuracy": 0.9731182795698925,
+          "val_accuracy": 0.7096774193548387
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.7419354915618896,
+        "test_loss": 1.0644491910934448
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000338",
+      "run_name": "run_003",
+      "source_run_id": "20251222_153505_gru_phase_2_run_003",
+      "started_at": "2025-12-22T20:35:16",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_004/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_004/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_004",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_004"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_004/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_004/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_004/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_004/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_004/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_004/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_004/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_004/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_004/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_004/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_153505_gru_phase_2",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 64,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:35:26",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.725806474685669,
+          "test_loss": 1.0285872220993042,
+          "train_accuracy": 0.7096774193548387,
+          "val_accuracy": 0.7096774193548387
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.725806474685669,
+        "test_loss": 1.0285872220993042
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000339",
+      "run_name": "run_004",
+      "source_run_id": "20251222_153505_gru_phase_2_run_004",
+      "started_at": "2025-12-22T20:35:22",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_005/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_005/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_005",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_005"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_005/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_005/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_005/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_005/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_005/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_005/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_005/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_005/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_005/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_005/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_153505_gru_phase_2",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 64,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 3,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:35:34",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.6935483813285828,
+          "test_loss": 0.9814016222953796,
+          "train_accuracy": 0.978494623655914,
+          "val_accuracy": 0.6935483870967742
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.6935483813285828,
+        "test_loss": 0.9814016222953796
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000340",
+      "run_name": "run_005",
+      "source_run_id": "20251222_153505_gru_phase_2_run_005",
+      "started_at": "2025-12-22T20:35:26",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_006/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_006/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_006",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_006"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_006/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_006/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_006/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_006/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_006/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_006/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_006/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_006/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_006/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_006/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_153505_gru_phase_2",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 64,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 3,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:35:42",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8387096524238586,
+          "test_loss": 0.6561028361320496,
+          "train_accuracy": 0.9838709677419355,
+          "val_accuracy": 0.8225806451612904
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8387096524238586,
+        "test_loss": 0.6561028361320496
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000341",
+      "run_name": "run_006",
+      "source_run_id": "20251222_153505_gru_phase_2_run_006",
+      "started_at": "2025-12-22T20:35:34",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_007/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_007/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_007",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_007"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_007/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_007/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_007/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_007/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_007/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_007/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_007/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_007/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_007/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_007/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_153505_gru_phase_2",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:35:46",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.6612903475761414,
+          "test_loss": 1.1039750576019287,
+          "train_accuracy": 0.9838709677419355,
+          "val_accuracy": 0.7258064516129032
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.6612903475761414,
+        "test_loss": 1.1039750576019287
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000342",
+      "run_name": "run_007",
+      "source_run_id": "20251222_153505_gru_phase_2_run_007",
+      "started_at": "2025-12-22T20:35:42",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_008/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_008/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_008",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_008"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_008/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_008/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_008/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_008/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_008/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_008/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_008/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_008/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_008/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_008/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_153505_gru_phase_2",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:35:52",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.7903226017951965,
+          "test_loss": 0.7290655970573425,
+          "train_accuracy": 0.989247311827957,
+          "val_accuracy": 0.8387096774193549
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.7903226017951965,
+        "test_loss": 0.7290655970573425
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000343",
+      "run_name": "run_008",
+      "source_run_id": "20251222_153505_gru_phase_2_run_008",
+      "started_at": "2025-12-22T20:35:46",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_009/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_009/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_009",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_009"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_009/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_009/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_009/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_009/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_009/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_009/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_009/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_009/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_009/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_009/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_153505_gru_phase_2",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:35:58",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.7096773982048035,
+          "test_loss": 0.9208729863166809,
+          "train_accuracy": 0.956989247311828,
+          "val_accuracy": 0.7258064516129032
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.7096773982048035,
+        "test_loss": 0.9208729863166809
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000344",
+      "run_name": "run_009",
+      "source_run_id": "20251222_153505_gru_phase_2_run_009",
+      "started_at": "2025-12-22T20:35:52",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_010/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_010/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_010",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_010"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_010/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_010/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_010/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_010/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_010/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_010/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_010/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_010/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_010/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_010/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_153505_gru_phase_2",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:36:04",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8548387289047241,
+          "test_loss": 0.6965636014938354,
+          "train_accuracy": 0.9838709677419355,
+          "val_accuracy": 0.8064516129032258
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8548387289047241,
+        "test_loss": 0.6965636014938354
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000345",
+      "run_name": "run_010",
+      "source_run_id": "20251222_153505_gru_phase_2_run_010",
+      "started_at": "2025-12-22T20:35:58",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_011/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_011/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_011",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_011"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_011/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_011/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_011/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_011/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_011/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_011/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_011/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_011/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_011/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_011/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_153505_gru_phase_2",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 3,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:36:12",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.6774193644523621,
+          "test_loss": 0.9475324153900146,
+          "train_accuracy": 0.978494623655914,
+          "val_accuracy": 0.7419354838709677
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.6774193644523621,
+        "test_loss": 0.9475324153900146
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000346",
+      "run_name": "run_011",
+      "source_run_id": "20251222_153505_gru_phase_2_run_011",
+      "started_at": "2025-12-22T20:36:05",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_012/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_012/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_012",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_012"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_012/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_012/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_012/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_012/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_012/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_012/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_012/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_012/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_012/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_012/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_153505_gru_phase_2",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 3,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:36:19",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8064516186714172,
+          "test_loss": 0.8118860721588135,
+          "train_accuracy": 0.9838709677419355,
+          "val_accuracy": 0.8225806451612904
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8064516186714172,
+        "test_loss": 0.8118860721588135
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000347",
+      "run_name": "run_012",
+      "source_run_id": "20251222_153505_gru_phase_2_run_012",
+      "started_at": "2025-12-22T20:36:12",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_013/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_013/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_013",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_013"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_013/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_013/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_013/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_013/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_013/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_013/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_013/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_013/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_013/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_013/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_153505_gru_phase_2",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 256,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:36:23",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.6935483813285828,
+          "test_loss": 1.0031639337539673,
+          "train_accuracy": 0.9408602150537635,
+          "val_accuracy": 0.6935483870967742
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.6935483813285828,
+        "test_loss": 1.0031639337539673
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000348",
+      "run_name": "run_013",
+      "source_run_id": "20251222_153505_gru_phase_2_run_013",
+      "started_at": "2025-12-22T20:36:19",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_014/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_014/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_014",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_014"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_014/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_014/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_014/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_014/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_014/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_014/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_014/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_014/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_014/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_014/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_153505_gru_phase_2",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 256,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:36:29",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8387096524238586,
+          "test_loss": 0.4837423264980316,
+          "train_accuracy": 0.978494623655914,
+          "val_accuracy": 0.8225806451612904
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8387096524238586,
+        "test_loss": 0.4837423264980316
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000349",
+      "run_name": "run_014",
+      "source_run_id": "20251222_153505_gru_phase_2_run_014",
+      "started_at": "2025-12-22T20:36:23",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_015/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_015/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_015",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_015"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_015/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_015/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_015/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_015/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_015/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_015/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_015/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_015/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_015/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_015/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_153505_gru_phase_2",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 256,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:36:37",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.7096773982048035,
+          "test_loss": 1.2679836750030518,
+          "train_accuracy": 0.9731182795698925,
+          "val_accuracy": 0.7258064516129032
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.7096773982048035,
+        "test_loss": 1.2679836750030518
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000350",
+      "run_name": "run_015",
+      "source_run_id": "20251222_153505_gru_phase_2_run_015",
+      "started_at": "2025-12-22T20:36:29",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_016/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_016/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_016",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_016"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_016/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_016/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_016/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_016/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_016/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_016/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_016/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_016/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_016/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_016/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_153505_gru_phase_2",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 256,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:36:46",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8225806355476379,
+          "test_loss": 0.6613001823425293,
+          "train_accuracy": 0.978494623655914,
+          "val_accuracy": 0.8225806451612904
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8225806355476379,
+        "test_loss": 0.6613001823425293
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000351",
+      "run_name": "run_016",
+      "source_run_id": "20251222_153505_gru_phase_2_run_016",
+      "started_at": "2025-12-22T20:36:38",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_017/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_017/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_017",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_017"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_017/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_017/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_017/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_017/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_017/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_017/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_017/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_017/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_017/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_017/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_153505_gru_phase_2",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 256,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 3,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:36:54",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.6935483813285828,
+          "test_loss": 0.9832486510276794,
+          "train_accuracy": 0.8924731182795699,
+          "val_accuracy": 0.6774193548387096
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.6935483813285828,
+        "test_loss": 0.9832486510276794
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000352",
+      "run_name": "run_017",
+      "source_run_id": "20251222_153505_gru_phase_2_run_017",
+      "started_at": "2025-12-22T20:36:46",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_018/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_018/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_018",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_018"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_018/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_018/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_018/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_018/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_018/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_018/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_018/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_018/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_018/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_153505_gru_phase_2/run_018/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_153505_gru_phase_2",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 256,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 3,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:37:07",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.7903226017951965,
+          "test_loss": 0.7470638155937195,
+          "train_accuracy": 0.9838709677419355,
+          "val_accuracy": 0.8064516129032258
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.7903226017951965,
+        "test_loss": 0.7470638155937195
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000353",
+      "run_name": "run_018",
+      "source_run_id": "20251222_153505_gru_phase_2_run_018",
+      "started_at": "2025-12-22T20:36:54",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_001/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_001/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_001",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_001"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_001/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_001/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_001/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_001/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_001/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_001/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_001/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_001/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_001/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_001/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 8,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_154233_gru_phase_3",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:42:40",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8548387289047241,
+          "test_loss": 0.6965636014938354,
+          "train_accuracy": 0.9838709677419355,
+          "val_accuracy": 0.8064516129032258
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8548387289047241,
+        "test_loss": 0.6965636014938354
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000354",
+      "run_name": "run_001",
+      "source_run_id": "20251222_154233_gru_phase_3_run_001",
+      "started_at": "2025-12-22T20:42:33",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_002/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_002/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_002",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_002"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_002/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_002/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_002/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_002/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_002/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_002/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_002/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_002/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_002/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_002/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 8,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 43,
+          "seq_len": 30,
+          "sweep_id": "20251222_154233_gru_phase_3",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:42:48",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8064516186714172,
+          "test_loss": 0.9257904291152954,
+          "train_accuracy": 0.989247311827957,
+          "val_accuracy": 0.8225806451612904
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8064516186714172,
+        "test_loss": 0.9257904291152954
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000355",
+      "run_name": "run_002",
+      "source_run_id": "20251222_154233_gru_phase_3_run_002",
+      "started_at": "2025-12-22T20:42:40",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_003/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_003/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_003",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_003"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_003/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_003/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_003/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_003/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_003/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_003/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_003/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_003/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_003/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_003/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 8,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 44,
+          "seq_len": 30,
+          "sweep_id": "20251222_154233_gru_phase_3",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:42:54",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8225806355476379,
+          "test_loss": 0.61654132604599,
+          "train_accuracy": 0.9838709677419355,
+          "val_accuracy": 0.7903225806451613
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8225806355476379,
+        "test_loss": 0.61654132604599
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000356",
+      "run_name": "run_003",
+      "source_run_id": "20251222_154233_gru_phase_3_run_003",
+      "started_at": "2025-12-22T20:42:48",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_004/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_004/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_004",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_004"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_004/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_004/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_004/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_004/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_004/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_004/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_004/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_004/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_004/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_004/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 8,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 45,
+          "seq_len": 30,
+          "sweep_id": "20251222_154233_gru_phase_3",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:43:01",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.7580645084381104,
+          "test_loss": 0.8411555886268616,
+          "train_accuracy": 0.9838709677419355,
+          "val_accuracy": 0.8548387096774194
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.7580645084381104,
+        "test_loss": 0.8411555886268616
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000357",
+      "run_name": "run_004",
+      "source_run_id": "20251222_154233_gru_phase_3_run_004",
+      "started_at": "2025-12-22T20:42:54",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_005/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_005/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_005",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_005"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_005/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_005/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_005/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_005/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_005/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_005/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_005/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_005/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_005/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154233_gru_phase_3/run_005/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 8,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 46,
+          "seq_len": 30,
+          "sweep_id": "20251222_154233_gru_phase_3",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:43:10",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8225806355476379,
+          "test_loss": 0.7379844188690186,
+          "train_accuracy": 0.9838709677419355,
+          "val_accuracy": 0.7903225806451613
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8225806355476379,
+        "test_loss": 0.7379844188690186
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000358",
+      "run_name": "run_005",
+      "source_run_id": "20251222_154233_gru_phase_3_run_005",
+      "started_at": "2025-12-22T20:43:01",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_001/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_001/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_001",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_001"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_001/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_001/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_001/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_001/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_001/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_001/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_001/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_001/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_001/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_001/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_154800_lstm_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:48:05",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.7903226017951965,
+          "test_loss": 1.4624971151351929,
+          "train_accuracy": 0.6989247311827957,
+          "val_accuracy": 0.6774193548387096
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.7903226017951965,
+        "test_loss": 1.4624971151351929
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000359",
+      "run_name": "run_001",
+      "source_run_id": "20251222_154800_lstm_phase_a_run_001",
+      "started_at": "2025-12-22T20:48:00",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_002/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_002/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_002",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_002"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_002/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_002/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_002/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_002/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_002/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_002/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_002/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_002/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_002/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_002/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_154800_lstm_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:48:12",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.6774193644523621,
+          "test_loss": 1.2829546928405762,
+          "train_accuracy": 0.6612903225806451,
+          "val_accuracy": 0.6612903225806451
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.6774193644523621,
+        "test_loss": 1.2829546928405762
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000360",
+      "run_name": "run_002",
+      "source_run_id": "20251222_154800_lstm_phase_a_run_002",
+      "started_at": "2025-12-22T20:48:05",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_003/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_003/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_003",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_003"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_003/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_003/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_003/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_003/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_003/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_003/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_003/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_003/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_003/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_003/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_154800_lstm_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:48:20",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.6774193644523621,
+          "test_loss": 1.2396491765975952,
+          "train_accuracy": 0.6559139784946236,
+          "val_accuracy": 0.6451612903225806
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.6774193644523621,
+        "test_loss": 1.2396491765975952
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000361",
+      "run_name": "run_003",
+      "source_run_id": "20251222_154800_lstm_phase_a_run_003",
+      "started_at": "2025-12-22T20:48:12",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_004/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_004/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_004",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_004"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_004/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_004/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_004/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_004/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_004/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_004/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_004/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_004/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_004/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_004/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_154800_lstm_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:48:33",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.6774193644523621,
+          "test_loss": 1.2343508005142212,
+          "train_accuracy": 0.6559139784946236,
+          "val_accuracy": 0.6129032258064516
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.6774193644523621,
+        "test_loss": 1.2343508005142212
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000362",
+      "run_name": "run_004",
+      "source_run_id": "20251222_154800_lstm_phase_a_run_004",
+      "started_at": "2025-12-22T20:48:20",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_005/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_005/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_005",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_005"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_005/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_005/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_005/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_005/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_005/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_005/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_005/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_005/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_005/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_005/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_154800_lstm_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.4,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:49:00",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.6612903475761414,
+          "test_loss": 1.247578501701355,
+          "train_accuracy": 0.6397849462365591,
+          "val_accuracy": 0.5967741935483871
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.6612903475761414,
+        "test_loss": 1.247578501701355
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000363",
+      "run_name": "run_005",
+      "source_run_id": "20251222_154800_lstm_phase_a_run_005",
+      "started_at": "2025-12-22T20:48:33",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_006/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_006/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_006",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_006"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_006/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_006/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_006/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_006/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_006/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_006/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_006/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_006/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_006/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_006/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_154800_lstm_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:49:18",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.7903226017951965,
+          "test_loss": 1.4624971151351929,
+          "train_accuracy": 0.6989247311827957,
+          "val_accuracy": 0.6774193548387096
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.7903226017951965,
+        "test_loss": 1.4624971151351929
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000364",
+      "run_name": "run_006",
+      "source_run_id": "20251222_154800_lstm_phase_a_run_006",
+      "started_at": "2025-12-22T20:49:00",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_007/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_007/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_007",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_007"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_007/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_007/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_007/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_007/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_007/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_007/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_007/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_007/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_007/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_007/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_154800_lstm_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:49:39",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.6774193644523621,
+          "test_loss": 1.2829546928405762,
+          "train_accuracy": 0.6612903225806451,
+          "val_accuracy": 0.6612903225806451
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.6774193644523621,
+        "test_loss": 1.2829546928405762
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000365",
+      "run_name": "run_007",
+      "source_run_id": "20251222_154800_lstm_phase_a_run_007",
+      "started_at": "2025-12-22T20:49:18",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_008/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_008/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_008",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_008"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_008/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_008/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_008/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_008/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_008/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_008/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_008/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_008/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_008/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_008/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_154800_lstm_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:50:05",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.6774193644523621,
+          "test_loss": 1.2396491765975952,
+          "train_accuracy": 0.6559139784946236,
+          "val_accuracy": 0.6451612903225806
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.6774193644523621,
+        "test_loss": 1.2396491765975952
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000366",
+      "run_name": "run_008",
+      "source_run_id": "20251222_154800_lstm_phase_a_run_008",
+      "started_at": "2025-12-22T20:49:39",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_009/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_009/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_009",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_009"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_009/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_009/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_009/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_009/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_009/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_009/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_009/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_009/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_009/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_009/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_154800_lstm_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:50:34",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.6774193644523621,
+          "test_loss": 1.2343508005142212,
+          "train_accuracy": 0.6559139784946236,
+          "val_accuracy": 0.6129032258064516
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.6774193644523621,
+        "test_loss": 1.2343508005142212
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000367",
+      "run_name": "run_009",
+      "source_run_id": "20251222_154800_lstm_phase_a_run_009",
+      "started_at": "2025-12-22T20:50:05",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_010/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_010/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_010",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_010"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_010/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_010/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_010/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_010/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_010/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_010/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_010/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_010/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_010/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_010/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_154800_lstm_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.4,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:51:03",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.6612903475761414,
+          "test_loss": 1.247578501701355,
+          "train_accuracy": 0.6397849462365591,
+          "val_accuracy": 0.5967741935483871
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.6612903475761414,
+        "test_loss": 1.247578501701355
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000368",
+      "run_name": "run_010",
+      "source_run_id": "20251222_154800_lstm_phase_a_run_010",
+      "started_at": "2025-12-22T20:50:34",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_011/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_011/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_011",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_011"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_011/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_011/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_011/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_011/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_011/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_011/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_011/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_011/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_011/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_011/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_154800_lstm_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:51:15",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.7419354915618896,
+          "test_loss": 1.4726885557174683,
+          "train_accuracy": 0.7043010752688172,
+          "val_accuracy": 0.6774193548387096
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.7419354915618896,
+        "test_loss": 1.4726885557174683
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000369",
+      "run_name": "run_011",
+      "source_run_id": "20251222_154800_lstm_phase_a_run_011",
+      "started_at": "2025-12-22T20:51:03",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_012/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_012/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_012",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_012"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_012/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_012/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_012/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_012/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_012/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_012/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_012/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_012/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_012/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_012/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_154800_lstm_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:51:41",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8064516186714172,
+          "test_loss": 0.7361927032470703,
+          "train_accuracy": 0.9623655913978495,
+          "val_accuracy": 0.7903225806451613
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8064516186714172,
+        "test_loss": 0.7361927032470703
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000370",
+      "run_name": "run_012",
+      "source_run_id": "20251222_154800_lstm_phase_a_run_012",
+      "started_at": "2025-12-22T20:51:16",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_013/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_013/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_013",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_013"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_013/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_013/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_013/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_013/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_013/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_013/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_013/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_013/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_013/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_013/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_154800_lstm_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:52:06",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8225806355476379,
+          "test_loss": 0.7497807741165161,
+          "train_accuracy": 0.8817204301075269,
+          "val_accuracy": 0.7419354838709677
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8225806355476379,
+        "test_loss": 0.7497807741165161
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000371",
+      "run_name": "run_013",
+      "source_run_id": "20251222_154800_lstm_phase_a_run_013",
+      "started_at": "2025-12-22T20:51:42",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_014/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_014/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_014",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_014"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_014/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_014/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_014/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_014/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_014/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_014/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_014/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_014/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_014/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_014/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_154800_lstm_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:52:24",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.6935483813285828,
+          "test_loss": 1.2591948509216309,
+          "train_accuracy": 0.6559139784946236,
+          "val_accuracy": 0.6129032258064516
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.6935483813285828,
+        "test_loss": 1.2591948509216309
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000372",
+      "run_name": "run_014",
+      "source_run_id": "20251222_154800_lstm_phase_a_run_014",
+      "started_at": "2025-12-22T20:52:06",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_015/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_015/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_015",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_015"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_015/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_015/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_015/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_015/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_015/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_015/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_015/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_015/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_015/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_015/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_154800_lstm_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.4,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:52:44",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.6612903475761414,
+          "test_loss": 1.1661278009414673,
+          "train_accuracy": 0.6559139784946236,
+          "val_accuracy": 0.6290322580645161
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.6612903475761414,
+        "test_loss": 1.1661278009414673
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000373",
+      "run_name": "run_015",
+      "source_run_id": "20251222_154800_lstm_phase_a_run_015",
+      "started_at": "2025-12-22T20:52:25",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_016/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_016/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_016",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_016"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_016/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_016/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_016/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_016/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_016/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_016/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_016/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_016/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_016/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_016/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_154800_lstm_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:52:57",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.7419354915618896,
+          "test_loss": 1.4726885557174683,
+          "train_accuracy": 0.7043010752688172,
+          "val_accuracy": 0.6774193548387096
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.7419354915618896,
+        "test_loss": 1.4726885557174683
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000374",
+      "run_name": "run_016",
+      "source_run_id": "20251222_154800_lstm_phase_a_run_016",
+      "started_at": "2025-12-22T20:52:44",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_017/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_017/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_017",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_017"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_017/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_017/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_017/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_017/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_017/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_017/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_017/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_017/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_017/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_017/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_154800_lstm_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:53:21",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8064516186714172,
+          "test_loss": 0.7361927032470703,
+          "train_accuracy": 0.9623655913978495,
+          "val_accuracy": 0.7903225806451613
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8064516186714172,
+        "test_loss": 0.7361927032470703
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000375",
+      "run_name": "run_017",
+      "source_run_id": "20251222_154800_lstm_phase_a_run_017",
+      "started_at": "2025-12-22T20:52:57",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_018/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_018/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_018",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_018"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_018/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_018/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_018/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_018/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_018/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_018/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_018/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_018/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_018/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_018/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_154800_lstm_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:53:45",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8225806355476379,
+          "test_loss": 0.7497807741165161,
+          "train_accuracy": 0.8817204301075269,
+          "val_accuracy": 0.7419354838709677
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8225806355476379,
+        "test_loss": 0.7497807741165161
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000376",
+      "run_name": "run_018",
+      "source_run_id": "20251222_154800_lstm_phase_a_run_018",
+      "started_at": "2025-12-22T20:53:22",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_019/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_019/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_019",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_019"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_019/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_019/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_019/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_019/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_019/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_019/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_019/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_019/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_019/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_019/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_154800_lstm_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:54:01",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.6935483813285828,
+          "test_loss": 1.2591948509216309,
+          "train_accuracy": 0.6559139784946236,
+          "val_accuracy": 0.6129032258064516
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.6935483813285828,
+        "test_loss": 1.2591948509216309
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000377",
+      "run_name": "run_019",
+      "source_run_id": "20251222_154800_lstm_phase_a_run_019",
+      "started_at": "2025-12-22T20:53:46",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_020/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_020/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_020",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_020"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_020/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_020/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_020/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_020/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_020/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_020/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_020/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_020/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_020/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_020/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_154800_lstm_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.4,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:54:22",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.6612903475761414,
+          "test_loss": 1.1661278009414673,
+          "train_accuracy": 0.6559139784946236,
+          "val_accuracy": 0.6290322580645161
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.6612903475761414,
+        "test_loss": 1.1661278009414673
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000378",
+      "run_name": "run_020",
+      "source_run_id": "20251222_154800_lstm_phase_a_run_020",
+      "started_at": "2025-12-22T20:54:01",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_021/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_021/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_021",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_021"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_021/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_021/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_021/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_021/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_021/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_021/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_021/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_021/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_021/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_021/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_154800_lstm_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:54:36",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8064516186714172,
+          "test_loss": 0.7008318901062012,
+          "train_accuracy": 0.8763440860215054,
+          "val_accuracy": 0.7419354838709677
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8064516186714172,
+        "test_loss": 0.7008318901062012
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000379",
+      "run_name": "run_021",
+      "source_run_id": "20251222_154800_lstm_phase_a_run_021",
+      "started_at": "2025-12-22T20:54:23",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_022/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_022/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_022",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_022"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_022/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_022/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_022/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_022/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_022/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_022/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_022/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_022/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_022/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_022/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_154800_lstm_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:55:01",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8064516186714172,
+          "test_loss": 0.7305488586425781,
+          "train_accuracy": 0.978494623655914,
+          "val_accuracy": 0.8548387096774194
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8064516186714172,
+        "test_loss": 0.7305488586425781
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000380",
+      "run_name": "run_022",
+      "source_run_id": "20251222_154800_lstm_phase_a_run_022",
+      "started_at": "2025-12-22T20:54:36",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_023/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_023/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_023",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_023"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_023/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_023/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_023/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_023/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_023/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_023/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_023/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_023/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_023/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_023/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_154800_lstm_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:55:20",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8064516186714172,
+          "test_loss": 0.6612731218338013,
+          "train_accuracy": 0.9516129032258065,
+          "val_accuracy": 0.7580645161290323
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8064516186714172,
+        "test_loss": 0.6612731218338013
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000381",
+      "run_name": "run_023",
+      "source_run_id": "20251222_154800_lstm_phase_a_run_023",
+      "started_at": "2025-12-22T20:55:02",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_024/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_024/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_024",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_024"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_024/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_024/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_024/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_024/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_024/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_024/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_024/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_024/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_024/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_024/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_154800_lstm_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:55:48",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8225806355476379,
+          "test_loss": 0.7203039526939392,
+          "train_accuracy": 0.978494623655914,
+          "val_accuracy": 0.7903225806451613
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8225806355476379,
+        "test_loss": 0.7203039526939392
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000382",
+      "run_name": "run_024",
+      "source_run_id": "20251222_154800_lstm_phase_a_run_024",
+      "started_at": "2025-12-22T20:55:21",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_025/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_025/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_025",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_025"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_025/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_025/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_025/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_025/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_025/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_025/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_025/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_025/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_025/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_025/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_154800_lstm_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.4,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:56:20",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8064516186714172,
+          "test_loss": 0.7755718231201172,
+          "train_accuracy": 0.9623655913978495,
+          "val_accuracy": 0.8064516129032258
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8064516186714172,
+        "test_loss": 0.7755718231201172
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000383",
+      "run_name": "run_025",
+      "source_run_id": "20251222_154800_lstm_phase_a_run_025",
+      "started_at": "2025-12-22T20:55:49",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_026/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_026/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_026",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_026"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_026/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_026/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_026/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_026/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_026/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_026/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_026/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_026/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_026/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_026/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_154800_lstm_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:56:34",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8064516186714172,
+          "test_loss": 0.7008318901062012,
+          "train_accuracy": 0.8763440860215054,
+          "val_accuracy": 0.7419354838709677
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8064516186714172,
+        "test_loss": 0.7008318901062012
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000384",
+      "run_name": "run_026",
+      "source_run_id": "20251222_154800_lstm_phase_a_run_026",
+      "started_at": "2025-12-22T20:56:20",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_027/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_027/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_027",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_027"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_027/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_027/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_027/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_027/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_027/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_027/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_027/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_027/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_027/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_027/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_154800_lstm_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.1,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:56:59",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8064516186714172,
+          "test_loss": 0.7305488586425781,
+          "train_accuracy": 0.978494623655914,
+          "val_accuracy": 0.8548387096774194
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8064516186714172,
+        "test_loss": 0.7305488586425781
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000385",
+      "run_name": "run_027",
+      "source_run_id": "20251222_154800_lstm_phase_a_run_027",
+      "started_at": "2025-12-22T20:56:34",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_028/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_028/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_028",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_028"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_028/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_028/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_028/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_028/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_028/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_028/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_028/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_028/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_028/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_028/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_154800_lstm_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:57:22",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8064516186714172,
+          "test_loss": 0.6612731218338013,
+          "train_accuracy": 0.9516129032258065,
+          "val_accuracy": 0.7580645161290323
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8064516186714172,
+        "test_loss": 0.6612731218338013
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000386",
+      "run_name": "run_028",
+      "source_run_id": "20251222_154800_lstm_phase_a_run_028",
+      "started_at": "2025-12-22T20:57:00",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_029/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_029/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_029",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_029"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_029/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_029/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_029/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_029/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_029/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_029/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_029/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_029/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_029/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_029/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_154800_lstm_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:57:49",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8225806355476379,
+          "test_loss": 0.7203039526939392,
+          "train_accuracy": 0.978494623655914,
+          "val_accuracy": 0.7903225806451613
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8225806355476379,
+        "test_loss": 0.7203039526939392
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000387",
+      "run_name": "run_029",
+      "source_run_id": "20251222_154800_lstm_phase_a_run_029",
+      "started_at": "2025-12-22T20:57:22",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_030/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_030/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_030",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_030"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_030/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_030/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_030/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_030/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_030/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_030/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_030/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_030/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_030/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_154800_lstm_phase_a/run_030/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_154800_lstm_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.4,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T20:58:21",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8064516186714172,
+          "test_loss": 0.7755718231201172,
+          "train_accuracy": 0.9623655913978495,
+          "val_accuracy": 0.8064516129032258
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8064516186714172,
+        "test_loss": 0.7755718231201172
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000388",
+      "run_name": "run_030",
+      "source_run_id": "20251222_154800_lstm_phase_a_run_030",
+      "started_at": "2025-12-22T20:57:50",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_001/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_001/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_001",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_001"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_001/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_001/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_001/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_001/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_001/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_001/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_001/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_001/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_001/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_001/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_160202_lstm_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:02:07",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.7419354915618896,
+          "test_loss": 1.4726884365081787,
+          "train_accuracy": 0.7043010752688172,
+          "val_accuracy": 0.6774193548387096
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.7419354915618896,
+        "test_loss": 1.4726884365081787
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000389",
+      "run_name": "run_001",
+      "source_run_id": "20251222_160202_lstm_phase_a_run_001",
+      "started_at": "2025-12-22T21:02:02",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_002/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_002/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_002",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_002"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_002/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_002/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_002/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_002/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_002/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_002/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_002/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_002/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_002/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_002/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_160202_lstm_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:02:11",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.7419354915618896,
+          "test_loss": 1.4726884365081787,
+          "train_accuracy": 0.7043010752688172,
+          "val_accuracy": 0.6774193548387096
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.7419354915618896,
+        "test_loss": 1.4726884365081787
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000390",
+      "run_name": "run_002",
+      "source_run_id": "20251222_160202_lstm_phase_a_run_002",
+      "started_at": "2025-12-22T21:02:07",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_003/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_003/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_003",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_003"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_003/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_003/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_003/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_003/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_003/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_003/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_003/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_003/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_003/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_003/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_160202_lstm_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:02:19",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8225806355476379,
+          "test_loss": 0.7497808337211609,
+          "train_accuracy": 0.8817204301075269,
+          "val_accuracy": 0.7419354838709677
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8225806355476379,
+        "test_loss": 0.7497808337211609
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000391",
+      "run_name": "run_003",
+      "source_run_id": "20251222_160202_lstm_phase_a_run_003",
+      "started_at": "2025-12-22T21:02:11",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_004/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_004/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_004",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_004"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_004/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_004/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_004/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_004/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_004/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_004/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_004/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_004/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_004/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_004/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_160202_lstm_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:02:26",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8225806355476379,
+          "test_loss": 0.7497808337211609,
+          "train_accuracy": 0.8817204301075269,
+          "val_accuracy": 0.7419354838709677
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8225806355476379,
+        "test_loss": 0.7497808337211609
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000392",
+      "run_name": "run_004",
+      "source_run_id": "20251222_160202_lstm_phase_a_run_004",
+      "started_at": "2025-12-22T21:02:19",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_005/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_005/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_005",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_005"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_005/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_005/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_005/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_005/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_005/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_005/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_005/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_005/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_005/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_005/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_160202_lstm_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:02:31",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8064516186714172,
+          "test_loss": 0.7008318305015564,
+          "train_accuracy": 0.8763440860215054,
+          "val_accuracy": 0.7419354838709677
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8064516186714172,
+        "test_loss": 0.7008318305015564
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000393",
+      "run_name": "run_005",
+      "source_run_id": "20251222_160202_lstm_phase_a_run_005",
+      "started_at": "2025-12-22T21:02:26",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_006/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_006/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_006",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_006"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_006/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_006/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_006/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_006/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_006/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_006/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_006/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_006/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_006/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_006/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_160202_lstm_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.0,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:02:35",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8064516186714172,
+          "test_loss": 0.7008318305015564,
+          "train_accuracy": 0.8763440860215054,
+          "val_accuracy": 0.7419354838709677
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8064516186714172,
+        "test_loss": 0.7008318305015564
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000394",
+      "run_name": "run_006",
+      "source_run_id": "20251222_160202_lstm_phase_a_run_006",
+      "started_at": "2025-12-22T21:02:31",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_007/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_007/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_007",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_007"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_007/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_007/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_007/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_007/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_007/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_007/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_007/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_007/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_007/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_007/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_160202_lstm_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:02:41",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8064516186714172,
+          "test_loss": 0.6612732410430908,
+          "train_accuracy": 0.9516129032258065,
+          "val_accuracy": 0.7580645161290323
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8064516186714172,
+        "test_loss": 0.6612732410430908
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000395",
+      "run_name": "run_007",
+      "source_run_id": "20251222_160202_lstm_phase_a_run_007",
+      "started_at": "2025-12-22T21:02:36",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_008/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_008/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_008",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_008"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_008/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_008/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_008/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_008/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_008/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_008/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_008/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_008/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_008/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160202_lstm_phase_a/run_008/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_160202_lstm_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:02:47",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8064516186714172,
+          "test_loss": 0.6612732410430908,
+          "train_accuracy": 0.9516129032258065,
+          "val_accuracy": 0.7580645161290323
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8064516186714172,
+        "test_loss": 0.6612732410430908
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000396",
+      "run_name": "run_008",
+      "source_run_id": "20251222_160202_lstm_phase_a_run_008",
+      "started_at": "2025-12-22T21:02:42",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_001/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_001/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_001",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_001"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_001/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_001/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_001/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_001/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_001/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_001/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_001/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_001/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_001/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_001/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_160558_lstm_phase_b",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 64,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:06:03",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.6290322542190552,
+          "test_loss": 1.1353611946105957,
+          "train_accuracy": 0.8064516129032258,
+          "val_accuracy": 0.5806451612903226
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.6290322542190552,
+        "test_loss": 1.1353611946105957
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000397",
+      "run_name": "run_001",
+      "source_run_id": "20251222_160558_lstm_phase_b_run_001",
+      "started_at": "2025-12-22T21:05:58",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_002/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_002/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_002",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_002"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_002/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_002/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_002/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_002/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_002/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_002/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_002/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_002/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_002/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_002/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_160558_lstm_phase_b",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 64,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:06:08",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.7580645084381104,
+          "test_loss": 0.9617251753807068,
+          "train_accuracy": 0.7526881720430108,
+          "val_accuracy": 0.6774193548387096
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.7580645084381104,
+        "test_loss": 0.9617251753807068
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000398",
+      "run_name": "run_002",
+      "source_run_id": "20251222_160558_lstm_phase_b_run_002",
+      "started_at": "2025-12-22T21:06:03",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_003/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_003/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_003",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_003"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_003/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_003/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_003/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_003/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_003/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_003/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_003/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_003/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_003/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_003/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_160558_lstm_phase_b",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 64,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:06:13",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.5483871102333069,
+          "test_loss": 1.3535935878753662,
+          "train_accuracy": 0.5806451612903226,
+          "val_accuracy": 0.5967741935483871
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.5483871102333069,
+        "test_loss": 1.3535935878753662
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000399",
+      "run_name": "run_003",
+      "source_run_id": "20251222_160558_lstm_phase_b_run_003",
+      "started_at": "2025-12-22T21:06:08",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_004/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_004/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_004",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_004"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_004/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_004/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_004/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_004/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_004/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_004/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_004/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_004/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_004/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_004/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_160558_lstm_phase_b",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 64,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:06:18",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.7419354915618896,
+          "test_loss": 1.1941245794296265,
+          "train_accuracy": 0.6451612903225806,
+          "val_accuracy": 0.6451612903225806
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.7419354915618896,
+        "test_loss": 1.1941245794296265
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000400",
+      "run_name": "run_004",
+      "source_run_id": "20251222_160558_lstm_phase_b_run_004",
+      "started_at": "2025-12-22T21:06:13",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    }
+  ],
+  "schema_version": 1,
+  "shard": 3
+}

--- a/docs/legacy/export/v1/runs/runs-004.json
+++ b/docs/legacy/export/v1/runs/runs-004.json
@@ -1,0 +1,9185 @@
+{
+  "kind": "signlab.legacy-run-index",
+  "records": [
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_005/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_005/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_005",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_005"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_005/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_005/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_005/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_005/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_005/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_005/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_005/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_005/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_005/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_005/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_160558_lstm_phase_b",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 64,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 3,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:06:24",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.5806451439857483,
+          "test_loss": 1.4327843189239502,
+          "train_accuracy": 0.5752688172043011,
+          "val_accuracy": 0.5161290322580645
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.5806451439857483,
+        "test_loss": 1.4327843189239502
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000401",
+      "run_name": "run_005",
+      "source_run_id": "20251222_160558_lstm_phase_b_run_005",
+      "started_at": "2025-12-22T21:06:19",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_006/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_006/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_006",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_006"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_006/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_006/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_006/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_006/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_006/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_006/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_006/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_006/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_006/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_006/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_160558_lstm_phase_b",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 64,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 3,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:06:31",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.725806474685669,
+          "test_loss": 1.4091064929962158,
+          "train_accuracy": 0.6182795698924731,
+          "val_accuracy": 0.6774193548387096
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.725806474685669,
+        "test_loss": 1.4091064929962158
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000402",
+      "run_name": "run_006",
+      "source_run_id": "20251222_160558_lstm_phase_b_run_006",
+      "started_at": "2025-12-22T21:06:25",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_007/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_007/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_007",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_007"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_007/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_007/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_007/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_007/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_007/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_007/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_007/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_007/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_007/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_007/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_160558_lstm_phase_b",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:06:34",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.5645161271095276,
+          "test_loss": 1.2846404314041138,
+          "train_accuracy": 0.6451612903225806,
+          "val_accuracy": 0.5483870967741935
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.5645161271095276,
+        "test_loss": 1.2846404314041138
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000403",
+      "run_name": "run_007",
+      "source_run_id": "20251222_160558_lstm_phase_b_run_007",
+      "started_at": "2025-12-22T21:06:31",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_008/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_008/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_008",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_008"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_008/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_008/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_008/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_008/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_008/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_008/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_008/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_008/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_008/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_008/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_160558_lstm_phase_b",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:06:38",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.725806474685669,
+          "test_loss": 1.0629034042358398,
+          "train_accuracy": 0.7365591397849462,
+          "val_accuracy": 0.7096774193548387
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.725806474685669,
+        "test_loss": 1.0629034042358398
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000404",
+      "run_name": "run_008",
+      "source_run_id": "20251222_160558_lstm_phase_b_run_008",
+      "started_at": "2025-12-22T21:06:34",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_009/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_009/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_009",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_009"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_009/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_009/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_009/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_009/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_009/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_009/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_009/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_009/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_009/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_009/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_160558_lstm_phase_b",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:06:45",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.774193525314331,
+          "test_loss": 0.7876697778701782,
+          "train_accuracy": 0.8763440860215054,
+          "val_accuracy": 0.7580645161290323
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.774193525314331,
+        "test_loss": 0.7876697778701782
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000405",
+      "run_name": "run_009",
+      "source_run_id": "20251222_160558_lstm_phase_b_run_009",
+      "started_at": "2025-12-22T21:06:39",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_010/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_010/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_010",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_010"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_010/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_010/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_010/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_010/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_010/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_010/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_010/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_010/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_010/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_010/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_160558_lstm_phase_b",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:06:52",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8225806355476379,
+          "test_loss": 0.7497808337211609,
+          "train_accuracy": 0.8817204301075269,
+          "val_accuracy": 0.7419354838709677
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8225806355476379,
+        "test_loss": 0.7497808337211609
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000406",
+      "run_name": "run_010",
+      "source_run_id": "20251222_160558_lstm_phase_b_run_010",
+      "started_at": "2025-12-22T21:06:45",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_011/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_011/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_011",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_011"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_011/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_011/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_011/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_011/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_011/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_011/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_011/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_011/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_011/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_011/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_160558_lstm_phase_b",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 3,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:07:01",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.774193525314331,
+          "test_loss": 0.708502471446991,
+          "train_accuracy": 0.9032258064516129,
+          "val_accuracy": 0.7419354838709677
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.774193525314331,
+        "test_loss": 0.708502471446991
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000407",
+      "run_name": "run_011",
+      "source_run_id": "20251222_160558_lstm_phase_b_run_011",
+      "started_at": "2025-12-22T21:06:53",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_012/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_012/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_012",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_012"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_012/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_012/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_012/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_012/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_012/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_012/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_012/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_012/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_012/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_012/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_160558_lstm_phase_b",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 3,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:07:07",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.6774193644523621,
+          "test_loss": 1.5086418390274048,
+          "train_accuracy": 0.6774193548387096,
+          "val_accuracy": 0.6612903225806451
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.6774193644523621,
+        "test_loss": 1.5086418390274048
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000408",
+      "run_name": "run_012",
+      "source_run_id": "20251222_160558_lstm_phase_b_run_012",
+      "started_at": "2025-12-22T21:07:01",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_013/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_013/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_013",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_013"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_013/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_013/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_013/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_013/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_013/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_013/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_013/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_013/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_013/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_013/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_160558_lstm_phase_b",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 256,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:07:14",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.7096773982048035,
+          "test_loss": 0.9560372233390808,
+          "train_accuracy": 0.9516129032258065,
+          "val_accuracy": 0.7580645161290323
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.7096773982048035,
+        "test_loss": 0.9560372233390808
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000409",
+      "run_name": "run_013",
+      "source_run_id": "20251222_160558_lstm_phase_b_run_013",
+      "started_at": "2025-12-22T21:07:07",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_014/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_014/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_014",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_014"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_014/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_014/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_014/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_014/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_014/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_014/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_014/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_014/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_014/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_014/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_160558_lstm_phase_b",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 256,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:07:21",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.7903226017951965,
+          "test_loss": 0.7475726008415222,
+          "train_accuracy": 0.9193548387096774,
+          "val_accuracy": 0.7903225806451613
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.7903226017951965,
+        "test_loss": 0.7475726008415222
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000410",
+      "run_name": "run_014",
+      "source_run_id": "20251222_160558_lstm_phase_b_run_014",
+      "started_at": "2025-12-22T21:07:14",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_015/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_015/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_015",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_015"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_015/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_015/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_015/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_015/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_015/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_015/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_015/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_015/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_015/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_015/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_160558_lstm_phase_b",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 256,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:07:31",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8064516186714172,
+          "test_loss": 0.7874071598052979,
+          "train_accuracy": 0.9623655913978495,
+          "val_accuracy": 0.7903225806451613
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8064516186714172,
+        "test_loss": 0.7874071598052979
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000411",
+      "run_name": "run_015",
+      "source_run_id": "20251222_160558_lstm_phase_b_run_015",
+      "started_at": "2025-12-22T21:07:21",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_016/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_016/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_016",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_016"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_016/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_016/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_016/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_016/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_016/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_016/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_016/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_016/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_016/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_016/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_160558_lstm_phase_b",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 256,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:07:39",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.7419354915618896,
+          "test_loss": 0.8297929167747498,
+          "train_accuracy": 0.7688172043010753,
+          "val_accuracy": 0.7419354838709677
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.7419354915618896,
+        "test_loss": 0.8297929167747498
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000412",
+      "run_name": "run_016",
+      "source_run_id": "20251222_160558_lstm_phase_b_run_016",
+      "started_at": "2025-12-22T21:07:32",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_017/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_017/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_017",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_017"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_017/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_017/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_017/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_017/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_017/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_017/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_017/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_017/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_017/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_017/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_160558_lstm_phase_b",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 256,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 3,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:07:53",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.7903226017951965,
+          "test_loss": 0.8467907905578613,
+          "train_accuracy": 0.9623655913978495,
+          "val_accuracy": 0.7580645161290323
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.7903226017951965,
+        "test_loss": 0.8467907905578613
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000413",
+      "run_name": "run_017",
+      "source_run_id": "20251222_160558_lstm_phase_b_run_017",
+      "started_at": "2025-12-22T21:07:39",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_018/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_018/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_018",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_018"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_018/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_018/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_018/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_018/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_018/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_018/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_018/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_018/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_018/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_160558_lstm_phase_b/run_018/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_160558_lstm_phase_b",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 256,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 3,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:08:13",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.7903226017951965,
+          "test_loss": 0.8006089925765991,
+          "train_accuracy": 0.9838709677419355,
+          "val_accuracy": 0.7903225806451613
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.7903226017951965,
+        "test_loss": 0.8006089925765991
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000414",
+      "run_name": "run_018",
+      "source_run_id": "20251222_160558_lstm_phase_b_run_018",
+      "started_at": "2025-12-22T21:07:54",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_001/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_001/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_001",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_001"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_001/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_001/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_001/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_001/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_001/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_001/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_001/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_001/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_001/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_001/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 8,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_161016_lstm_phase_c",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:10:25",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.7903226017951965,
+          "test_loss": 0.6272757053375244,
+          "train_accuracy": 0.9623655913978495,
+          "val_accuracy": 0.7741935483870968
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.7903226017951965,
+        "test_loss": 0.6272757053375244
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000415",
+      "run_name": "run_001",
+      "source_run_id": "20251222_161016_lstm_phase_c_run_001",
+      "started_at": "2025-12-22T21:10:16",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_002/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_002/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_002",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_002"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_002/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_002/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_002/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_002/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_002/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_002/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_002/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_002/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_002/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_002/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 8,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 43,
+          "seq_len": 30,
+          "sweep_id": "20251222_161016_lstm_phase_c",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:10:34",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.7903226017951965,
+          "test_loss": 0.6793283820152283,
+          "train_accuracy": 0.956989247311828,
+          "val_accuracy": 0.8064516129032258
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.7903226017951965,
+        "test_loss": 0.6793283820152283
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000416",
+      "run_name": "run_002",
+      "source_run_id": "20251222_161016_lstm_phase_c_run_002",
+      "started_at": "2025-12-22T21:10:25",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_003/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_003/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_003",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_003"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_003/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_003/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_003/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_003/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_003/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_003/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_003/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_003/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_003/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_003/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 8,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 44,
+          "seq_len": 30,
+          "sweep_id": "20251222_161016_lstm_phase_c",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:10:43",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8225806355476379,
+          "test_loss": 0.6356301307678223,
+          "train_accuracy": 0.9408602150537635,
+          "val_accuracy": 0.7741935483870968
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8225806355476379,
+        "test_loss": 0.6356301307678223
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000417",
+      "run_name": "run_003",
+      "source_run_id": "20251222_161016_lstm_phase_c_run_003",
+      "started_at": "2025-12-22T21:10:35",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_004/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_004/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_004",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_004"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_004/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_004/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_004/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_004/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_004/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_004/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_004/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_004/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_004/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_004/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 8,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 45,
+          "seq_len": 30,
+          "sweep_id": "20251222_161016_lstm_phase_c",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:10:49",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.725806474685669,
+          "test_loss": 1.4201408624649048,
+          "train_accuracy": 0.6989247311827957,
+          "val_accuracy": 0.6774193548387096
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.725806474685669,
+        "test_loss": 1.4201408624649048
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000418",
+      "run_name": "run_004",
+      "source_run_id": "20251222_161016_lstm_phase_c_run_004",
+      "started_at": "2025-12-22T21:10:44",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_005/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_005/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_005",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_005"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_005/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_005/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_005/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_005/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_005/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_005/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_005/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_005/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_005/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161016_lstm_phase_c/run_005/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 8,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 46,
+          "seq_len": 30,
+          "sweep_id": "20251222_161016_lstm_phase_c",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.2,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_lstm",
+          "name": "Causal LSTM",
+          "num_layers": 2,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:10:58",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8064516186714172,
+          "test_loss": 0.69565749168396,
+          "train_accuracy": 0.967741935483871,
+          "val_accuracy": 0.7741935483870968
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8064516186714172,
+        "test_loss": 0.69565749168396
+      },
+      "model_key": "causal_lstm",
+      "record_id": "run-000419",
+      "run_name": "run_005",
+      "source_run_id": "20251222_161016_lstm_phase_c_run_005",
+      "started_at": "2025-12-22T21:10:49",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_001/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_001/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_001",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_001"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_001/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_001/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_001/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_001/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_001/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_001/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_001/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_001/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_001/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_001/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_161451_tcn_sweep_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.0,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 4,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:14:56",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8387096524238586,
+          "test_loss": 0.6023600101470947,
+          "train_accuracy": 0.9838709677419355,
+          "val_accuracy": 0.7903225806451613
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8387096524238586,
+        "test_loss": 0.6023600101470947
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000420",
+      "run_name": "run_001",
+      "source_run_id": "20251222_161451_tcn_sweep_a_run_001",
+      "started_at": "2025-12-22T21:14:51",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_002/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_002/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_002",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_002"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_002/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_002/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_002/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_002/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_002/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_002/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_002/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_002/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_002/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_002/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_161451_tcn_sweep_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.0,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 4,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:15:02",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8387096524238586,
+          "test_loss": 0.6023600101470947,
+          "train_accuracy": 0.9838709677419355,
+          "val_accuracy": 0.7903225806451613
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8387096524238586,
+        "test_loss": 0.6023600101470947
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000421",
+      "run_name": "run_002",
+      "source_run_id": "20251222_161451_tcn_sweep_a_run_002",
+      "started_at": "2025-12-22T21:14:56",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_003/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_003/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_003",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_003"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_003/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_003/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_003/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_003/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_003/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_003/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_003/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_003/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_003/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_003/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_161451_tcn_sweep_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.2,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 4,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:15:07",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.7903226017951965,
+          "test_loss": 0.6402608752250671,
+          "train_accuracy": 0.967741935483871,
+          "val_accuracy": 0.8064516129032258
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.7903226017951965,
+        "test_loss": 0.6402608752250671
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000422",
+      "run_name": "run_003",
+      "source_run_id": "20251222_161451_tcn_sweep_a_run_003",
+      "started_at": "2025-12-22T21:15:02",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_004/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_004/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_004",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_004"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_004/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_004/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_004/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_004/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_004/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_004/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_004/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_004/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_004/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_004/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_161451_tcn_sweep_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.2,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 4,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:15:13",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.7903226017951965,
+          "test_loss": 0.6402608752250671,
+          "train_accuracy": 0.967741935483871,
+          "val_accuracy": 0.8064516129032258
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.7903226017951965,
+        "test_loss": 0.6402608752250671
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000423",
+      "run_name": "run_004",
+      "source_run_id": "20251222_161451_tcn_sweep_a_run_004",
+      "started_at": "2025-12-22T21:15:07",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_005/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_005/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_005",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_005"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_005/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_005/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_005/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_005/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_005/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_005/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_005/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_005/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_005/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_005/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_161451_tcn_sweep_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.0,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 4,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:15:17",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.7903226017951965,
+          "test_loss": 0.6320786476135254,
+          "train_accuracy": 0.9838709677419355,
+          "val_accuracy": 0.7903225806451613
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.7903226017951965,
+        "test_loss": 0.6320786476135254
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000424",
+      "run_name": "run_005",
+      "source_run_id": "20251222_161451_tcn_sweep_a_run_005",
+      "started_at": "2025-12-22T21:15:13",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_006/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_006/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_006",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_006"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_006/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_006/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_006/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_006/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_006/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_006/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_006/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_006/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_006/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_006/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_161451_tcn_sweep_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.0,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 4,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:15:23",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.7903226017951965,
+          "test_loss": 0.6320786476135254,
+          "train_accuracy": 0.9838709677419355,
+          "val_accuracy": 0.7903225806451613
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.7903226017951965,
+        "test_loss": 0.6320786476135254
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000425",
+      "run_name": "run_006",
+      "source_run_id": "20251222_161451_tcn_sweep_a_run_006",
+      "started_at": "2025-12-22T21:15:18",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_007/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_007/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_007",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_007"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_007/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_007/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_007/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_007/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_007/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_007/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_007/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_007/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_007/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_007/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_161451_tcn_sweep_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.2,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 4,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:15:28",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8225806355476379,
+          "test_loss": 0.6287501454353333,
+          "train_accuracy": 0.978494623655914,
+          "val_accuracy": 0.8064516129032258
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8225806355476379,
+        "test_loss": 0.6287501454353333
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000426",
+      "run_name": "run_007",
+      "source_run_id": "20251222_161451_tcn_sweep_a_run_007",
+      "started_at": "2025-12-22T21:15:23",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_008/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_008/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_008",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_008"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_008/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_008/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_008/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_008/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_008/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_008/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_008/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_008/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_008/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_161451_tcn_sweep_a/run_008/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_161451_tcn_sweep_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.2,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 4,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:15:32",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8225806355476379,
+          "test_loss": 0.6287501454353333,
+          "train_accuracy": 0.978494623655914,
+          "val_accuracy": 0.8064516129032258
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8225806355476379,
+        "test_loss": 0.6287501454353333
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000427",
+      "run_name": "run_008",
+      "source_run_id": "20251222_161451_tcn_sweep_a_run_008",
+      "started_at": "2025-12-22T21:15:28",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_001/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_001/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_001",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_001"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_001/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_001/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_001/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_001/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_001/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_001/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_001/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_001/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_001/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_001/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_162034_tcn_phase_b",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.001
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 64,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.0,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:20:38",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8387096524238586,
+          "test_loss": 0.6626717448234558,
+          "train_accuracy": 0.9516129032258065,
+          "val_accuracy": 0.7580645161290323
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8387096524238586,
+        "test_loss": 0.6626717448234558
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000428",
+      "run_name": "run_001",
+      "source_run_id": "20251222_162034_tcn_phase_b_run_001",
+      "started_at": "2025-12-22T21:20:34",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_002/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_002/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_002",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_002"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_002/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_002/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_002/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_002/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_002/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_002/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_002/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_002/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_002/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_002/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_162034_tcn_phase_b",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.001
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 64,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.0,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 4,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:20:44",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.7903226017951965,
+          "test_loss": 0.6385617256164551,
+          "train_accuracy": 0.9838709677419355,
+          "val_accuracy": 0.8064516129032258
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.7903226017951965,
+        "test_loss": 0.6385617256164551
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000429",
+      "run_name": "run_002",
+      "source_run_id": "20251222_162034_tcn_phase_b_run_002",
+      "started_at": "2025-12-22T21:20:38",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_003/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_003/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_003",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_003"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_003/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_003/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_003/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_003/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_003/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_003/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_003/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_003/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_003/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_003/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_162034_tcn_phase_b",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.001
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 64,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.0,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 5,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:20:50",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8064516186714172,
+          "test_loss": 0.7379993200302124,
+          "train_accuracy": 0.967741935483871,
+          "val_accuracy": 0.7258064516129032
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8064516186714172,
+        "test_loss": 0.7379993200302124
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000430",
+      "run_name": "run_003",
+      "source_run_id": "20251222_162034_tcn_phase_b_run_003",
+      "started_at": "2025-12-22T21:20:44",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_004/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_004/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_004",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_004"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_004/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_004/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_004/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_004/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_004/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_004/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_004/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_004/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_004/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_004/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_162034_tcn_phase_b",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.001
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.0,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:20:55",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8225806355476379,
+          "test_loss": 0.6301278471946716,
+          "train_accuracy": 0.9838709677419355,
+          "val_accuracy": 0.8387096774193549
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8225806355476379,
+        "test_loss": 0.6301278471946716
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000431",
+      "run_name": "run_004",
+      "source_run_id": "20251222_162034_tcn_phase_b_run_004",
+      "started_at": "2025-12-22T21:20:50",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_005/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_005/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_005",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_005"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_005/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_005/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_005/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_005/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_005/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_005/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_005/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_005/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_005/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_005/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_162034_tcn_phase_b",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.001
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.0,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 4,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:21:00",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8387096524238586,
+          "test_loss": 0.6023600101470947,
+          "train_accuracy": 0.9838709677419355,
+          "val_accuracy": 0.7903225806451613
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8387096524238586,
+        "test_loss": 0.6023600101470947
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000432",
+      "run_name": "run_005",
+      "source_run_id": "20251222_162034_tcn_phase_b_run_005",
+      "started_at": "2025-12-22T21:20:55",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_006/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_006/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_006",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_006"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_006/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_006/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_006/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_006/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_006/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_006/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_006/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_006/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_006/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_006/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_162034_tcn_phase_b",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.001
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.0,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 5,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:21:06",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8064516186714172,
+          "test_loss": 0.558768093585968,
+          "train_accuracy": 0.9838709677419355,
+          "val_accuracy": 0.7903225806451613
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8064516186714172,
+        "test_loss": 0.558768093585968
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000433",
+      "run_name": "run_006",
+      "source_run_id": "20251222_162034_tcn_phase_b_run_006",
+      "started_at": "2025-12-22T21:21:01",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_007/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_007/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_007",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_007"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_007/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_007/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_007/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_007/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_007/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_007/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_007/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_007/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_007/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_007/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_162034_tcn_phase_b",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.001
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 256,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.0,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 3,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:21:12",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8064516186714172,
+          "test_loss": 0.7051780223846436,
+          "train_accuracy": 0.989247311827957,
+          "val_accuracy": 0.8064516129032258
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8064516186714172,
+        "test_loss": 0.7051780223846436
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000434",
+      "run_name": "run_007",
+      "source_run_id": "20251222_162034_tcn_phase_b_run_007",
+      "started_at": "2025-12-22T21:21:07",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_008/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_008/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_008",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_008"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_008/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_008/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_008/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_008/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_008/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_008/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_008/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_008/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_008/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_008/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_162034_tcn_phase_b",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.001
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 256,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.0,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 4,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:21:18",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8548387289047241,
+          "test_loss": 0.6134661436080933,
+          "train_accuracy": 0.9838709677419355,
+          "val_accuracy": 0.7903225806451613
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8548387289047241,
+        "test_loss": 0.6134661436080933
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000435",
+      "run_name": "run_008",
+      "source_run_id": "20251222_162034_tcn_phase_b_run_008",
+      "started_at": "2025-12-22T21:21:12",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_009/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_009/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_009",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_009"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_009/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_009/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_009/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_009/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_009/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_009/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_009/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_009/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_009/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162034_tcn_phase_b/run_009/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_162034_tcn_phase_b",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.001
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 256,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.0,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 5,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:21:25",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8387096524238586,
+          "test_loss": 0.5976829528808594,
+          "train_accuracy": 0.989247311827957,
+          "val_accuracy": 0.7741935483870968
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8387096524238586,
+        "test_loss": 0.5976829528808594
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000436",
+      "run_name": "run_009",
+      "source_run_id": "20251222_162034_tcn_phase_b_run_009",
+      "started_at": "2025-12-22T21:21:18",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_001/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_001/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_001",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_001"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_001/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_001/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_001/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_001/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_001/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_001/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_001/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_001/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_001/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_001/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 8,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_162425_tcn_phase_c",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.0,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 4,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:24:31",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8387096524238586,
+          "test_loss": 0.6023600101470947,
+          "train_accuracy": 0.9838709677419355,
+          "val_accuracy": 0.7903225806451613
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8387096524238586,
+        "test_loss": 0.6023600101470947
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000437",
+      "run_name": "run_001",
+      "source_run_id": "20251222_162425_tcn_phase_c_run_001",
+      "started_at": "2025-12-22T21:24:25",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_002/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_002/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_002",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_002"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_002/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_002/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_002/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_002/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_002/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_002/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_002/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_002/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_002/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_002/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 8,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 43,
+          "seq_len": 30,
+          "sweep_id": "20251222_162425_tcn_phase_c",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.0,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 4,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:24:38",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8387096524238586,
+          "test_loss": 0.6383557319641113,
+          "train_accuracy": 0.989247311827957,
+          "val_accuracy": 0.7741935483870968
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8387096524238586,
+        "test_loss": 0.6383557319641113
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000438",
+      "run_name": "run_002",
+      "source_run_id": "20251222_162425_tcn_phase_c_run_002",
+      "started_at": "2025-12-22T21:24:32",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_003/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_003/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_003",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_003"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_003/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_003/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_003/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_003/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_003/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_003/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_003/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_003/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_003/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_003/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 8,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 44,
+          "seq_len": 30,
+          "sweep_id": "20251222_162425_tcn_phase_c",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.0,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 4,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:24:43",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8709677457809448,
+          "test_loss": 0.5304130911827087,
+          "train_accuracy": 0.9838709677419355,
+          "val_accuracy": 0.8387096774193549
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8709677457809448,
+        "test_loss": 0.5304130911827087
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000439",
+      "run_name": "run_003",
+      "source_run_id": "20251222_162425_tcn_phase_c_run_003",
+      "started_at": "2025-12-22T21:24:38",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_004/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_004/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_004",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_004"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_004/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_004/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_004/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_004/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_004/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_004/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_004/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_004/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_004/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_004/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 8,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 45,
+          "seq_len": 30,
+          "sweep_id": "20251222_162425_tcn_phase_c",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.0,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 4,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:24:50",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8709677457809448,
+          "test_loss": 0.5971089005470276,
+          "train_accuracy": 0.989247311827957,
+          "val_accuracy": 0.7903225806451613
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8709677457809448,
+        "test_loss": 0.5971089005470276
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000440",
+      "run_name": "run_004",
+      "source_run_id": "20251222_162425_tcn_phase_c_run_004",
+      "started_at": "2025-12-22T21:24:44",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_005/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_005/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_005",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_005"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_005/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_005/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_005/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_005/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_005/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_005/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_005/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_005/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_005/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162425_tcn_phase_c/run_005/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 8,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 46,
+          "seq_len": 30,
+          "sweep_id": "20251222_162425_tcn_phase_c",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "activation": "relu",
+          "causal": true,
+          "channels": 128,
+          "dilations": [
+            1,
+            2,
+            4
+          ],
+          "dropout": 0.0,
+          "input_dim": 63,
+          "kernel_size": 3,
+          "model_key": "causal_tcn",
+          "name": "Causal TCN",
+          "norm": "layer",
+          "num_layers": 4,
+          "seq_window": 30,
+          "use_residual": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:24:56",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8387096524238586,
+          "test_loss": 0.6207364797592163,
+          "train_accuracy": 0.9946236559139785,
+          "val_accuracy": 0.8064516129032258
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8387096524238586,
+        "test_loss": 0.6207364797592163
+      },
+      "model_key": "causal_tcn",
+      "record_id": "run-000441",
+      "run_name": "run_005",
+      "source_run_id": "20251222_162425_tcn_phase_c_run_005",
+      "started_at": "2025-12-22T21:24:50",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_001/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_001/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_001",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_001"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_001/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_001/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_001/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_001/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_001/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_001/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_001/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_001/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_001/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_001/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_162821_mamba_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:28:25",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.7580645084381104,
+          "test_loss": 1.0395251512527466,
+          "train_accuracy": 0.7580645161290323,
+          "val_accuracy": 0.6290322580645161
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.7580645084381104,
+        "test_loss": 1.0395251512527466
+      },
+      "model_key": "mamba",
+      "record_id": "run-000442",
+      "run_name": "run_001",
+      "source_run_id": "20251222_162821_mamba_phase_a_run_001",
+      "started_at": "2025-12-22T21:28:21",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_002/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_002/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_002",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_002"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_002/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_002/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_002/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_002/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_002/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_002/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_002/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_002/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_002/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_002/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_162821_mamba_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:28:30",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.7580645084381104,
+          "test_loss": 1.0395251512527466,
+          "train_accuracy": 0.7580645161290323,
+          "val_accuracy": 0.6290322580645161
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.7580645084381104,
+        "test_loss": 1.0395251512527466
+      },
+      "model_key": "mamba",
+      "record_id": "run-000443",
+      "run_name": "run_002",
+      "source_run_id": "20251222_162821_mamba_phase_a_run_002",
+      "started_at": "2025-12-22T21:28:25",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_003/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_003/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_003",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_003"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_003/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_003/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_003/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_003/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_003/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_003/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_003/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_003/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_003/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_003/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_162821_mamba_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:28:35",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8064516186714172,
+          "test_loss": 0.9419981241226196,
+          "train_accuracy": 0.7688172043010753,
+          "val_accuracy": 0.6451612903225806
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8064516186714172,
+        "test_loss": 0.9419981241226196
+      },
+      "model_key": "mamba",
+      "record_id": "run-000444",
+      "run_name": "run_003",
+      "source_run_id": "20251222_162821_mamba_phase_a_run_003",
+      "started_at": "2025-12-22T21:28:30",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_004/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_004/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_004",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_004"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_004/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_004/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_004/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_004/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_004/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_004/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_004/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_004/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_004/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_004/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_162821_mamba_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:28:40",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8064516186714172,
+          "test_loss": 0.9419981241226196,
+          "train_accuracy": 0.7688172043010753,
+          "val_accuracy": 0.6451612903225806
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8064516186714172,
+        "test_loss": 0.9419981241226196
+      },
+      "model_key": "mamba",
+      "record_id": "run-000445",
+      "run_name": "run_004",
+      "source_run_id": "20251222_162821_mamba_phase_a_run_004",
+      "started_at": "2025-12-22T21:28:35",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_005/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_005/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_005",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_005"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_005/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_005/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_005/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_005/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_005/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_005/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_005/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_005/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_005/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_005/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_162821_mamba_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:28:44",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8387096524238586,
+          "test_loss": 0.5074305534362793,
+          "train_accuracy": 0.9623655913978495,
+          "val_accuracy": 0.8387096774193549
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8387096524238586,
+        "test_loss": 0.5074305534362793
+      },
+      "model_key": "mamba",
+      "record_id": "run-000446",
+      "run_name": "run_005",
+      "source_run_id": "20251222_162821_mamba_phase_a_run_005",
+      "started_at": "2025-12-22T21:28:40",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_006/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_006/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_006",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_006"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_006/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_006/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_006/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_006/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_006/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_006/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_006/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_006/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_006/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_006/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_162821_mamba_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:28:48",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8387096524238586,
+          "test_loss": 0.5074305534362793,
+          "train_accuracy": 0.9623655913978495,
+          "val_accuracy": 0.8387096774193549
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8387096524238586,
+        "test_loss": 0.5074305534362793
+      },
+      "model_key": "mamba",
+      "record_id": "run-000447",
+      "run_name": "run_006",
+      "source_run_id": "20251222_162821_mamba_phase_a_run_006",
+      "started_at": "2025-12-22T21:28:45",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_007/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_007/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_007",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_007"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_007/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_007/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_007/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_007/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_007/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_007/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_007/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_007/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_007/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_007/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_162821_mamba_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:28:53",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8387096524238586,
+          "test_loss": 0.5854417085647583,
+          "train_accuracy": 0.9516129032258065,
+          "val_accuracy": 0.8225806451612904
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8387096524238586,
+        "test_loss": 0.5854417085647583
+      },
+      "model_key": "mamba",
+      "record_id": "run-000448",
+      "run_name": "run_007",
+      "source_run_id": "20251222_162821_mamba_phase_a_run_007",
+      "started_at": "2025-12-22T21:28:49",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_008/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_008/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_008",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_008"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_008/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_008/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_008/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_008/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_008/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_008/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_008/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_008/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_008/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_162821_mamba_phase_a/run_008/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.001,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_162821_mamba_phase_a",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.2,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:28:57",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8387096524238586,
+          "test_loss": 0.5854417085647583,
+          "train_accuracy": 0.9516129032258065,
+          "val_accuracy": 0.8225806451612904
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8387096524238586,
+        "test_loss": 0.5854417085647583
+      },
+      "model_key": "mamba",
+      "record_id": "run-000449",
+      "run_name": "run_008",
+      "source_run_id": "20251222_162821_mamba_phase_a_run_008",
+      "started_at": "2025-12-22T21:28:53",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_001/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_001/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_001",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_001"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_001/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_001/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_001/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_001/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_001/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_001/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_001/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_001/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_001/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_001/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_163257_mamba_phase_b",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "d_model": 64,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 1,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:33:02",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.725806474685669,
+          "test_loss": 1.032636284828186,
+          "train_accuracy": 0.7903225806451613,
+          "val_accuracy": 0.6612903225806451
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.725806474685669,
+        "test_loss": 1.032636284828186
+      },
+      "model_key": "mamba",
+      "record_id": "run-000450",
+      "run_name": "run_001",
+      "source_run_id": "20251222_163257_mamba_phase_b_run_001",
+      "started_at": "2025-12-22T21:32:57",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_002/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_002/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_002",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_002"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_002/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_002/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_002/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_002/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_002/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_002/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_002/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_002/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_002/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_002/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_163257_mamba_phase_b",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "d_model": 64,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:33:05",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.7096773982048035,
+          "test_loss": 1.1147761344909668,
+          "train_accuracy": 0.7365591397849462,
+          "val_accuracy": 0.7096774193548387
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.7096773982048035,
+        "test_loss": 1.1147761344909668
+      },
+      "model_key": "mamba",
+      "record_id": "run-000451",
+      "run_name": "run_002",
+      "source_run_id": "20251222_163257_mamba_phase_b_run_002",
+      "started_at": "2025-12-22T21:33:02",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_003/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_003/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_003",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_003"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_003/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_003/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_003/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_003/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_003/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_003/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_003/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_003/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_003/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_003/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_163257_mamba_phase_b",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "d_model": 64,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 3,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:33:11",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.7903226017951965,
+          "test_loss": 0.7198669910430908,
+          "train_accuracy": 0.8817204301075269,
+          "val_accuracy": 0.6935483870967742
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.7903226017951965,
+        "test_loss": 0.7198669910430908
+      },
+      "model_key": "mamba",
+      "record_id": "run-000452",
+      "run_name": "run_003",
+      "source_run_id": "20251222_163257_mamba_phase_b_run_003",
+      "started_at": "2025-12-22T21:33:05",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_004/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_004/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_004",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_004"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_004/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_004/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_004/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_004/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_004/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_004/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_004/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_004/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_004/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_004/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_163257_mamba_phase_b",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 1,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:33:16",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.7580645084381104,
+          "test_loss": 0.8012274503707886,
+          "train_accuracy": 0.8602150537634409,
+          "val_accuracy": 0.8064516129032258
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.7580645084381104,
+        "test_loss": 0.8012274503707886
+      },
+      "model_key": "mamba",
+      "record_id": "run-000453",
+      "run_name": "run_004",
+      "source_run_id": "20251222_163257_mamba_phase_b_run_004",
+      "started_at": "2025-12-22T21:33:11",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_005/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_005/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_005",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_005"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_005/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_005/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_005/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_005/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_005/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_005/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_005/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_005/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_005/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_005/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_163257_mamba_phase_b",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:33:21",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8387096524238586,
+          "test_loss": 0.5801564455032349,
+          "train_accuracy": 0.9408602150537635,
+          "val_accuracy": 0.8225806451612904
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8387096524238586,
+        "test_loss": 0.5801564455032349
+      },
+      "model_key": "mamba",
+      "record_id": "run-000454",
+      "run_name": "run_005",
+      "source_run_id": "20251222_163257_mamba_phase_b_run_005",
+      "started_at": "2025-12-22T21:33:16",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_006/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_006/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_006",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_006"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_006/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_006/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_006/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_006/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_006/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_006/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_006/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_006/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_006/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_006/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_163257_mamba_phase_b",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 3,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:33:26",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8064516186714172,
+          "test_loss": 0.7168372273445129,
+          "train_accuracy": 0.9354838709677419,
+          "val_accuracy": 0.7580645161290323
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8064516186714172,
+        "test_loss": 0.7168372273445129
+      },
+      "model_key": "mamba",
+      "record_id": "run-000455",
+      "run_name": "run_006",
+      "source_run_id": "20251222_163257_mamba_phase_b_run_006",
+      "started_at": "2025-12-22T21:33:21",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_007/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_007/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_007",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_007"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_007/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_007/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_007/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_007/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_007/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_007/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_007/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_007/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_007/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_007/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_163257_mamba_phase_b",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "d_model": 256,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 1,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:33:31",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.774193525314331,
+          "test_loss": 0.7016036510467529,
+          "train_accuracy": 0.8655913978494624,
+          "val_accuracy": 0.7258064516129032
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.774193525314331,
+        "test_loss": 0.7016036510467529
+      },
+      "model_key": "mamba",
+      "record_id": "run-000456",
+      "run_name": "run_007",
+      "source_run_id": "20251222_163257_mamba_phase_b_run_007",
+      "started_at": "2025-12-22T21:33:26",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_008/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_008/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_008",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_008"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_008/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_008/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_008/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_008/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_008/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_008/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_008/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_008/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_008/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_008/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_163257_mamba_phase_b",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "d_model": 256,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:33:37",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.7903226017951965,
+          "test_loss": 0.6411483287811279,
+          "train_accuracy": 0.9838709677419355,
+          "val_accuracy": 0.8225806451612904
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.7903226017951965,
+        "test_loss": 0.6411483287811279
+      },
+      "model_key": "mamba",
+      "record_id": "run-000457",
+      "run_name": "run_008",
+      "source_run_id": "20251222_163257_mamba_phase_b_run_008",
+      "started_at": "2025-12-22T21:33:31",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_009/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_009/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_009",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_009"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_009/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_009/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_009/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_009/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_009/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_009/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_009/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_009/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_009/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163257_mamba_phase_b/run_009/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_163257_mamba_phase_b",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "d_model": 256,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 3,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:33:41",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.7903226017951965,
+          "test_loss": 0.6927222013473511,
+          "train_accuracy": 0.9193548387096774,
+          "val_accuracy": 0.8064516129032258
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.7903226017951965,
+        "test_loss": 0.6927222013473511
+      },
+      "model_key": "mamba",
+      "record_id": "run-000458",
+      "run_name": "run_009",
+      "source_run_id": "20251222_163257_mamba_phase_b_run_009",
+      "started_at": "2025-12-22T21:33:37",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_001/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_001/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_001",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_001"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_001/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_001/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_001/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_001/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_001/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_001/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_001/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_001/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_001/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_001/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 8,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 42,
+          "seq_len": 30,
+          "sweep_id": "20251222_163528_mamba_phase_c",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:35:34",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8387096524238586,
+          "test_loss": 0.5801564455032349,
+          "train_accuracy": 0.9408602150537635,
+          "val_accuracy": 0.8225806451612904
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8387096524238586,
+        "test_loss": 0.5801564455032349
+      },
+      "model_key": "mamba",
+      "record_id": "run-000459",
+      "run_name": "run_001",
+      "source_run_id": "20251222_163528_mamba_phase_c_run_001",
+      "started_at": "2025-12-22T21:35:28",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_002/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_002/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_002",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_002"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_002/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_002/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_002/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_002/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_002/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_002/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_002/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_002/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_002/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_002/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 8,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 43,
+          "seq_len": 30,
+          "sweep_id": "20251222_163528_mamba_phase_c",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:35:40",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8064516186714172,
+          "test_loss": 0.6818185448646545,
+          "train_accuracy": 0.9408602150537635,
+          "val_accuracy": 0.7903225806451613
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8064516186714172,
+        "test_loss": 0.6818185448646545
+      },
+      "model_key": "mamba",
+      "record_id": "run-000460",
+      "run_name": "run_002",
+      "source_run_id": "20251222_163528_mamba_phase_c_run_002",
+      "started_at": "2025-12-22T21:35:34",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_003/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_003/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_003",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_003"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_003/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_003/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_003/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_003/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_003/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_003/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_003/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_003/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_003/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_003/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 8,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 44,
+          "seq_len": 30,
+          "sweep_id": "20251222_163528_mamba_phase_c",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:35:45",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8225806355476379,
+          "test_loss": 0.6846921443939209,
+          "train_accuracy": 0.9139784946236559,
+          "val_accuracy": 0.8064516129032258
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8225806355476379,
+        "test_loss": 0.6846921443939209
+      },
+      "model_key": "mamba",
+      "record_id": "run-000461",
+      "run_name": "run_003",
+      "source_run_id": "20251222_163528_mamba_phase_c_run_003",
+      "started_at": "2025-12-22T21:35:40",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_004/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_004/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_004",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_004"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_004/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_004/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_004/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_004/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_004/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_004/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_004/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_004/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_004/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_004/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 8,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 45,
+          "seq_len": 30,
+          "sweep_id": "20251222_163528_mamba_phase_c",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:35:49",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.774193525314331,
+          "test_loss": 0.8123875260353088,
+          "train_accuracy": 0.8279569892473119,
+          "val_accuracy": 0.7419354838709677
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.774193525314331,
+        "test_loss": 0.8123875260353088
+      },
+      "model_key": "mamba",
+      "record_id": "run-000462",
+      "run_name": "run_004",
+      "source_run_id": "20251222_163528_mamba_phase_c_run_004",
+      "started_at": "2025-12-22T21:35:45",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_005/config.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_005/config.json"
+        },
+        "directory": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_005",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_005"
+        },
+        "history": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_005/history.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_005/history.json"
+        },
+        "label_map": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_005/label_map.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_005/label_map.json"
+        },
+        "metrics": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_005/metrics.json",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_005/metrics.json"
+        },
+        "model": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_005/sign_model_best.keras",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_005/sign_model_best.keras"
+        },
+        "predictions": {
+          "availability": "available",
+          "registered_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_005/predictions.csv",
+          "resolved_locator": "legacy://runs/sweeps/20251222_163528_mamba_phase_c/run_005/predictions.csv"
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 8,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.0003,
+          "optimizer_type": "adam",
+          "seed": 46,
+          "seq_len": 30,
+          "sweep_id": "20251222_163528_mamba_phase_c",
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0001
+        },
+        "model_settings": {
+          "d_model": 128,
+          "d_state": 16,
+          "direction": "forward",
+          "dropout": 0.0,
+          "expand": 2,
+          "input_dim": 63,
+          "model_key": "mamba",
+          "n_layers": 2,
+          "name": "Mamba (SSM)",
+          "norm_type": "rms",
+          "seq_window": 30,
+          "use_attention_pool": true
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T21:35:53",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.774193525314331,
+          "test_loss": 0.9354885816574097,
+          "train_accuracy": 0.8064516129032258,
+          "val_accuracy": 0.7096774193548387
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.774193525314331,
+        "test_loss": 0.9354885816574097
+      },
+      "model_key": "mamba",
+      "record_id": "run-000463",
+      "run_name": "run_005",
+      "source_run_id": "20251222_163528_mamba_phase_c_run_005",
+      "started_at": "2025-12-22T21:35:49",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class",
+          "misleading-legacy-mamba-name"
+        ]
+      }
+    },
+    {
+      "artifacts": {
+        "configuration": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251222_184148/config.json",
+          "resolved_locator": null
+        },
+        "directory": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251222_184148",
+          "resolved_locator": null
+        },
+        "history": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251222_184148/history.json",
+          "resolved_locator": null
+        },
+        "label_map": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251222_184148/label_map.json",
+          "resolved_locator": null
+        },
+        "metrics": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251222_184148/metrics.json",
+          "resolved_locator": null
+        },
+        "model": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251222_184148/sign_model_best.keras",
+          "resolved_locator": null
+        },
+        "predictions": {
+          "availability": "missing",
+          "registered_locator": "legacy://data/results/causal_gru_20251222_184148/predictions.csv",
+          "resolved_locator": null
+        }
+      },
+      "configuration": {
+        "batch_size": 32,
+        "data_locator": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+        "epochs": 30,
+        "global_settings": {
+          "active_model_key": "mamba",
+          "batch_size": 32,
+          "data_root": "legacy://data/landmarks/pos_vel_handscale_smooth_30f",
+          "early_stopping_enabled": true,
+          "early_stopping_patience": 5,
+          "epochs": 30,
+          "grad_clip_norm": 0.0,
+          "learning_rate": 0.01,
+          "optimizer_type": "adam",
+          "seq_len": 30,
+          "test_frac": 0.2,
+          "val_frac": 0.2,
+          "weight_decay": 0.0
+        },
+        "model_settings": {
+          "direction": "forward",
+          "dropout": 0.3,
+          "hidden_dim": 128,
+          "input_dim": 63,
+          "model_key": "causal_gru",
+          "name": "Causal GRU",
+          "num_layers": 1,
+          "seq_window": 30,
+          "stateful": false,
+          "use_attention_pool": false
+        },
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2
+      },
+      "finished_at": "2025-12-22T23:41:53",
+      "metrics": {
+        "quick": {
+          "label_counts": {
+            "hello": 60,
+            "no": 71,
+            "please": 58,
+            "thank you": 53,
+            "yes": 68
+          },
+          "label_counts_test": {
+            "hello": 12,
+            "no": 14,
+            "please": 11,
+            "thank you": 11,
+            "yes": 14
+          },
+          "label_counts_train": {
+            "hello": 36,
+            "no": 43,
+            "please": 35,
+            "thank you": 31,
+            "yes": 41
+          },
+          "label_counts_val": {
+            "hello": 12,
+            "no": 14,
+            "please": 12,
+            "thank you": 11,
+            "yes": 13
+          },
+          "num_classes": 5,
+          "samples_test": 62,
+          "samples_train": 186,
+          "samples_val": 62,
+          "test_accuracy": 0.8064516186714172,
+          "test_loss": 0.9417628645896912,
+          "train_accuracy": 0.978494623655914,
+          "val_accuracy": 0.7096774193548387
+        },
+        "samples_test": 62,
+        "samples_train": 186,
+        "samples_validation": 62,
+        "test_accuracy": 0.8064516186714172,
+        "test_loss": 0.9417628645896912
+      },
+      "model_key": "causal_gru",
+      "record_id": "run-000464",
+      "run_name": "causal_gru_20251222_184148",
+      "source_run_id": "causal_gru_20251222_184148",
+      "started_at": "2025-12-22T23:41:49",
+      "status": "succeeded",
+      "validity": {
+        "data_role": "development-only",
+        "eligible_for_locked_test": false,
+        "legacy_error_present": false,
+        "legacy_notes_present": false,
+        "notes": [
+          "development-only",
+          "sample-level-split-without-signer-or-session-grouping",
+          "test-split-repeatedly-inspected",
+          "no-learned-negative-class"
+        ]
+      }
+    }
+  ],
+  "schema_version": 1,
+  "shard": 4
+}

--- a/docs/legacy/export/v1/schemas/annotation.schema.json
+++ b/docs/legacy/export/v1/schemas/annotation.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "attempt_ref": {
+      "pattern": "^attempt-[0-9]{6}$",
+      "type": "string"
+    },
+    "corrected_label": {
+      "anyOf": [
+        {
+          "enum": [
+            "hello",
+            "no",
+            "please",
+            "thank you",
+            "yes"
+          ]
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "data_role": {
+      "const": "development-only"
+    },
+    "feedback_type": {
+      "enum": [
+        "confirm",
+        "missed",
+        "wrong"
+      ]
+    },
+    "freeform_note_present": {
+      "type": "boolean"
+    },
+    "offset_ms": {
+      "minimum": 0,
+      "type": "integer"
+    },
+    "record_id": {
+      "pattern": "^annotation-[0-9]{6}$",
+      "type": "string"
+    }
+  },
+  "required": [
+    "record_id",
+    "attempt_ref",
+    "data_role",
+    "offset_ms",
+    "feedback_type",
+    "corrected_label",
+    "freeform_note_present"
+  ],
+  "title": "Sanitized feedback annotation",
+  "type": "object"
+}

--- a/docs/legacy/export/v1/schemas/detection.schema.json
+++ b/docs/legacy/export/v1/schemas/detection.schema.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "actual_label": {
+      "anyOf": [
+        {
+          "enum": [
+            "hello",
+            "no",
+            "please",
+            "thank you",
+            "yes"
+          ]
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "confidence": {
+      "maximum": 1,
+      "minimum": 0,
+      "type": [
+        "number",
+        "null"
+      ]
+    },
+    "correct": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "data_role": {
+      "const": "development-only"
+    },
+    "offset_ms": {
+      "minimum": 0,
+      "type": "integer"
+    },
+    "predicted_label": {
+      "anyOf": [
+        {
+          "enum": [
+            "hello",
+            "no",
+            "please",
+            "thank you",
+            "yes"
+          ]
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "record_id": {
+      "pattern": "^detection-[0-9]{6}$",
+      "type": "string"
+    },
+    "session_ref": {
+      "pattern": "^session-[0-9]{4}$",
+      "type": "string"
+    }
+  },
+  "required": [
+    "record_id",
+    "session_ref",
+    "data_role",
+    "offset_ms",
+    "predicted_label",
+    "actual_label",
+    "confidence",
+    "correct"
+  ],
+  "title": "Sanitized legacy detection",
+  "type": "object"
+}

--- a/docs/legacy/export/v1/schemas/live-attempt.schema.json
+++ b/docs/legacy/export/v1/schemas/live-attempt.schema.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "confidence": {
+      "maximum": 1,
+      "minimum": 0,
+      "type": [
+        "number",
+        "null"
+      ]
+    },
+    "correct": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "data_role": {
+      "const": "development-only"
+    },
+    "detected": {
+      "type": "boolean"
+    },
+    "duration_ms": {
+      "minimum": 0,
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "intended_label": {
+      "anyOf": [
+        {
+          "enum": [
+            "hello",
+            "no",
+            "please",
+            "thank you",
+            "yes"
+          ]
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "latency_ms": {
+      "minimum": 0,
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "model_run_id": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "predicted_label": {
+      "enum": [
+        "NONE",
+        "hello",
+        "no",
+        "nothing",
+        "please",
+        "thank you",
+        "yes"
+      ]
+    },
+    "record_id": {
+      "pattern": "^attempt-[0-9]{6}$",
+      "type": "string"
+    },
+    "segment_frames": {
+      "minimum": 0,
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "segment_uri": {
+      "anyOf": [
+        {
+          "pattern": "^quarantine://sha256/[0-9a-f]{64}\\.(json|keras|npz)$",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "segmentation": {
+      "type": "object"
+    },
+    "start_offset_ms": {
+      "minimum": 0,
+      "type": "integer"
+    }
+  },
+  "required": [
+    "record_id",
+    "data_role",
+    "start_offset_ms",
+    "duration_ms",
+    "detected",
+    "intended_label",
+    "predicted_label",
+    "correct",
+    "confidence",
+    "latency_ms",
+    "segment_frames",
+    "model_run_id",
+    "segmentation",
+    "segment_uri"
+  ],
+  "title": "Sanitized live attempt",
+  "type": "object"
+}

--- a/docs/legacy/export/v1/schemas/preprocessing-plans.schema.json
+++ b/docs/legacy/export/v1/schemas/preprocessing-plans.schema.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "kind": {
+      "const": "signlab.legacy-preprocessing-plans"
+    },
+    "plans": {
+      "additionalProperties": {
+        "additionalProperties": false,
+        "properties": {
+          "created_at": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "steps": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "key": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "params": {
+                  "type": "object"
+                }
+              },
+              "required": [
+                "key",
+                "params"
+              ],
+              "title": "Historical preprocessing step",
+              "type": "object"
+            },
+            "minItems": 1,
+            "type": "array"
+          },
+          "updated_at": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "description",
+          "created_at",
+          "updated_at",
+          "steps"
+        ],
+        "title": "Historical preprocessing plan",
+        "type": "object"
+      },
+      "minProperties": 1,
+      "type": "object"
+    },
+    "quarantine_uri": {
+      "pattern": "^quarantine://sha256/[0-9a-f]{64}\\.(json|keras|npz)$",
+      "type": "string"
+    },
+    "schema_version": {
+      "const": 1
+    },
+    "source_sha256": {
+      "pattern": "^[0-9a-f]{64}$",
+      "type": "string"
+    }
+  },
+  "required": [
+    "schema_version",
+    "kind",
+    "source_sha256",
+    "quarantine_uri",
+    "plans"
+  ],
+  "title": "Historical preprocessing plans",
+  "type": "object"
+}

--- a/docs/legacy/export/v1/schemas/promoted-artifacts.schema.json
+++ b/docs/legacy/export/v1/schemas/promoted-artifacts.schema.json
@@ -1,0 +1,145 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "artifacts": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "label_map": {
+            "additionalProperties": false,
+            "properties": {
+              "bytes": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "labels": {
+                "additionalProperties": {
+                  "enum": [
+                    "hello",
+                    "no",
+                    "please",
+                    "thank you",
+                    "yes"
+                  ]
+                },
+                "propertyNames": {
+                  "pattern": "^[0-9]+$"
+                },
+                "type": "object"
+              },
+              "quarantine_uri": {
+                "pattern": "^quarantine://sha256/[0-9a-f]{64}\\.(json|keras|npz)$",
+                "type": "string"
+              },
+              "sha256": {
+                "pattern": "^[0-9a-f]{64}$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "bytes",
+              "sha256",
+              "quarantine_uri",
+              "labels"
+            ],
+            "title": "Promoted label-map identity",
+            "type": "object"
+          },
+          "model": {
+            "additionalProperties": false,
+            "properties": {
+              "bytes": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "quarantine_uri": {
+                "pattern": "^quarantine://sha256/[0-9a-f]{64}\\.(json|keras|npz)$",
+                "type": "string"
+              },
+              "sha256": {
+                "pattern": "^[0-9a-f]{64}$",
+                "type": "string"
+              },
+              "storage_status": {
+                "const": "local-quarantine"
+              }
+            },
+            "required": [
+              "bytes",
+              "sha256",
+              "quarantine_uri",
+              "storage_status"
+            ],
+            "title": "Promoted model identity",
+            "type": "object"
+          },
+          "model_key": {
+            "maxLength": 160,
+            "minLength": 1,
+            "type": "string"
+          },
+          "preprocessing_plan": {
+            "maxLength": 160,
+            "minLength": 1,
+            "type": "string"
+          },
+          "run_id": {
+            "maxLength": 160,
+            "minLength": 1,
+            "type": "string"
+          },
+          "validity": {
+            "additionalProperties": false,
+            "properties": {
+              "data_role": {
+                "const": "development-only"
+              },
+              "eligible_for_locked_test": {
+                "const": false
+              },
+              "notes": {
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 1,
+                "type": "array"
+              }
+            },
+            "required": [
+              "data_role",
+              "eligible_for_locked_test",
+              "notes"
+            ],
+            "title": "Promoted artifact validity",
+            "type": "object"
+          }
+        },
+        "required": [
+          "run_id",
+          "model_key",
+          "preprocessing_plan",
+          "model",
+          "label_map",
+          "validity"
+        ],
+        "title": "Promoted legacy artifact",
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "kind": {
+      "const": "signlab.legacy-promoted-artifacts"
+    },
+    "schema_version": {
+      "const": 1
+    }
+  },
+  "required": [
+    "schema_version",
+    "kind",
+    "artifacts"
+  ],
+  "title": "Promoted legacy artifacts",
+  "type": "object"
+}

--- a/docs/legacy/export/v1/schemas/public-manifest.schema.json
+++ b/docs/legacy/export/v1/schemas/public-manifest.schema.json
@@ -1,0 +1,186 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "components": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "bytes": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "path": {
+            "pattern": "^[a-z0-9][a-z0-9_.-]*(/[a-z0-9_.-]+)*$",
+            "type": "string"
+          },
+          "records": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "sha256": {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          }
+        },
+        "required": [
+          "path",
+          "bytes",
+          "sha256"
+        ],
+        "title": "Portable component",
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "counts": {
+      "additionalProperties": false,
+      "properties": {
+        "annotated_attempts": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "annotations": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "attempts": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "detections": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "orphan_segments": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "preprocessing_plans": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "promoted_models": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "referenced_segments": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "runs": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "runs_failed": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "runs_running": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "runs_succeeded": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "segments": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "sessions": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "unannotated_attempts": {
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "runs",
+        "runs_succeeded",
+        "runs_failed",
+        "runs_running",
+        "preprocessing_plans",
+        "promoted_models",
+        "attempts",
+        "annotations",
+        "annotated_attempts",
+        "unannotated_attempts",
+        "sessions",
+        "detections",
+        "segments",
+        "referenced_segments",
+        "orphan_segments"
+      ],
+      "title": "Public export counts",
+      "type": "object"
+    },
+    "kind": {
+      "const": "signlab.legacy-public-export"
+    },
+    "policy": {
+      "additionalProperties": false,
+      "properties": {
+        "contains_private_artifacts": {
+          "const": false
+        },
+        "data_role": {
+          "const": "development-only"
+        },
+        "durability": {
+          "const": "local-only-pending-private-remote"
+        },
+        "eligible_for_locked_test": {
+          "const": false
+        }
+      },
+      "required": [
+        "data_role",
+        "eligible_for_locked_test",
+        "contains_private_artifacts",
+        "durability"
+      ],
+      "title": "Legacy evidence policy",
+      "type": "object"
+    },
+    "schema_version": {
+      "const": 1
+    },
+    "source": {
+      "additionalProperties": false,
+      "properties": {
+        "audit_sha256": {
+          "pattern": "^[0-9a-f]{64}$",
+          "type": "string"
+        },
+        "head_commit": {
+          "pattern": "^[0-9a-f]{40}$",
+          "type": "string"
+        },
+        "tree_object": {
+          "pattern": "^[0-9a-f]{40}$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "head_commit",
+        "tree_object",
+        "audit_sha256"
+      ],
+      "title": "Legacy source anchor",
+      "type": "object"
+    }
+  },
+  "required": [
+    "schema_version",
+    "kind",
+    "source",
+    "policy",
+    "counts",
+    "components"
+  ],
+  "title": "SignLab public legacy export manifest",
+  "type": "object"
+}

--- a/docs/legacy/export/v1/schemas/quarantine-manifest.schema.json
+++ b/docs/legacy/export/v1/schemas/quarantine-manifest.schema.json
@@ -1,0 +1,192 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "counts": {
+      "additionalProperties": false,
+      "properties": {
+        "annotated_attempts": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "annotations": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "attempts": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "detections": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "orphan_segments": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "promoted_models": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "quarantine_objects": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "referenced_segments": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "segments": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "sessions": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "unannotated_attempts": {
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "attempts",
+        "annotations",
+        "annotated_attempts",
+        "unannotated_attempts",
+        "sessions",
+        "detections",
+        "segments",
+        "referenced_segments",
+        "orphan_segments",
+        "promoted_models",
+        "quarantine_objects"
+      ],
+      "title": "Private quarantine counts",
+      "type": "object"
+    },
+    "kind": {
+      "const": "signlab.legacy-quarantine"
+    },
+    "objects": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "bytes": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "roles": {
+            "items": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "minItems": 1,
+            "type": "array",
+            "uniqueItems": true
+          },
+          "sha256": {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "storage_key": {
+            "pattern": "^objects/sha256/[0-9a-f]{64}\\.(json|keras|npz)$",
+            "type": "string"
+          },
+          "uri": {
+            "pattern": "^quarantine://sha256/[0-9a-f]{64}\\.(json|keras|npz)$",
+            "type": "string"
+          }
+        },
+        "required": [
+          "uri",
+          "storage_key",
+          "bytes",
+          "sha256",
+          "roles"
+        ],
+        "title": "Content-addressed quarantine object",
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "policy": {
+      "additionalProperties": false,
+      "properties": {
+        "contains_private_artifacts": {
+          "const": true
+        },
+        "data_role": {
+          "const": "development-only"
+        },
+        "eligible_for_locked_test": {
+          "const": false
+        },
+        "identifiers": {
+          "const": "pseudonymized-ordinal"
+        },
+        "publishable": {
+          "const": false
+        },
+        "timestamps": {
+          "const": "live-records-relative-offsets-only"
+        }
+      },
+      "required": [
+        "data_role",
+        "eligible_for_locked_test",
+        "contains_private_artifacts",
+        "publishable",
+        "identifiers",
+        "timestamps"
+      ],
+      "title": "Private quarantine policy",
+      "type": "object"
+    },
+    "record_components": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "bytes": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "path": {
+            "pattern": "^[a-z0-9][a-z0-9_.-]*(/[a-z0-9_.-]+)*$",
+            "type": "string"
+          },
+          "records": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "sha256": {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          }
+        },
+        "required": [
+          "path",
+          "bytes",
+          "sha256"
+        ],
+        "title": "Portable component",
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "schema_version": {
+      "const": 1
+    }
+  },
+  "required": [
+    "schema_version",
+    "kind",
+    "policy",
+    "counts",
+    "record_components",
+    "objects"
+  ],
+  "title": "Private legacy quarantine manifest",
+  "type": "object"
+}

--- a/docs/legacy/export/v1/schemas/quarantine-receipt.schema.json
+++ b/docs/legacy/export/v1/schemas/quarantine-receipt.schema.json
@@ -1,0 +1,145 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "components": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "bytes": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "path": {
+            "pattern": "^[a-z0-9][a-z0-9_.-]*(/[a-z0-9_.-]+)*$",
+            "type": "string"
+          },
+          "records": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "sha256": {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          }
+        },
+        "required": [
+          "path",
+          "bytes",
+          "sha256"
+        ],
+        "title": "Portable component",
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "counts": {
+      "additionalProperties": false,
+      "properties": {
+        "annotated_attempts": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "annotations": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "attempts": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "detections": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "orphan_segments": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "promoted_models": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "quarantine_objects": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "referenced_segments": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "segments": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "sessions": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "unannotated_attempts": {
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "attempts",
+        "annotations",
+        "annotated_attempts",
+        "unannotated_attempts",
+        "sessions",
+        "detections",
+        "segments",
+        "referenced_segments",
+        "orphan_segments",
+        "promoted_models",
+        "quarantine_objects"
+      ],
+      "title": "Private quarantine counts",
+      "type": "object"
+    },
+    "kind": {
+      "const": "signlab.legacy-quarantine-receipt"
+    },
+    "policy": {
+      "additionalProperties": false,
+      "properties": {
+        "contains_individual_object_hashes": {
+          "const": false
+        },
+        "data_role": {
+          "const": "development-only"
+        },
+        "durability": {
+          "const": "local-only-pending-private-remote"
+        },
+        "eligible_for_locked_test": {
+          "const": false
+        },
+        "publishable": {
+          "const": false
+        }
+      },
+      "required": [
+        "data_role",
+        "eligible_for_locked_test",
+        "publishable",
+        "durability",
+        "contains_individual_object_hashes"
+      ],
+      "title": "Public quarantine-receipt policy",
+      "type": "object"
+    },
+    "schema_version": {
+      "const": 1
+    }
+  },
+  "required": [
+    "schema_version",
+    "kind",
+    "policy",
+    "counts",
+    "components"
+  ],
+  "title": "Private quarantine receipt",
+  "type": "object"
+}

--- a/docs/legacy/export/v1/schemas/run-index.schema.json
+++ b/docs/legacy/export/v1/schemas/run-index.schema.json
@@ -1,0 +1,604 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "kind": {
+      "const": "signlab.legacy-run-index"
+    },
+    "records": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "artifacts": {
+            "additionalProperties": false,
+            "properties": {
+              "configuration": {
+                "additionalProperties": false,
+                "properties": {
+                  "availability": {
+                    "enum": [
+                      "available",
+                      "ambiguous",
+                      "missing",
+                      "not-recorded"
+                    ]
+                  },
+                  "registered_locator": {
+                    "anyOf": [
+                      {
+                        "maxLength": 4096,
+                        "not": {
+                          "pattern": "(?:^[A-Za-z]:[\\\\/]|^/|^[Ff][Ii][Ll][Ee]:///|^\\\\\\\\)"
+                        },
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "resolved_locator": {
+                    "anyOf": [
+                      {
+                        "maxLength": 4096,
+                        "not": {
+                          "pattern": "(?:^[A-Za-z]:[\\\\/]|^/|^[Ff][Ii][Ll][Ee]:///|^\\\\\\\\)"
+                        },
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "registered_locator",
+                  "resolved_locator",
+                  "availability"
+                ],
+                "title": "Historical artifact locator",
+                "type": "object"
+              },
+              "directory": {
+                "additionalProperties": false,
+                "properties": {
+                  "availability": {
+                    "enum": [
+                      "available",
+                      "ambiguous",
+                      "missing",
+                      "not-recorded"
+                    ]
+                  },
+                  "registered_locator": {
+                    "anyOf": [
+                      {
+                        "maxLength": 4096,
+                        "not": {
+                          "pattern": "(?:^[A-Za-z]:[\\\\/]|^/|^[Ff][Ii][Ll][Ee]:///|^\\\\\\\\)"
+                        },
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "resolved_locator": {
+                    "anyOf": [
+                      {
+                        "maxLength": 4096,
+                        "not": {
+                          "pattern": "(?:^[A-Za-z]:[\\\\/]|^/|^[Ff][Ii][Ll][Ee]:///|^\\\\\\\\)"
+                        },
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "registered_locator",
+                  "resolved_locator",
+                  "availability"
+                ],
+                "title": "Historical artifact locator",
+                "type": "object"
+              },
+              "history": {
+                "additionalProperties": false,
+                "properties": {
+                  "availability": {
+                    "enum": [
+                      "available",
+                      "ambiguous",
+                      "missing",
+                      "not-recorded"
+                    ]
+                  },
+                  "registered_locator": {
+                    "anyOf": [
+                      {
+                        "maxLength": 4096,
+                        "not": {
+                          "pattern": "(?:^[A-Za-z]:[\\\\/]|^/|^[Ff][Ii][Ll][Ee]:///|^\\\\\\\\)"
+                        },
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "resolved_locator": {
+                    "anyOf": [
+                      {
+                        "maxLength": 4096,
+                        "not": {
+                          "pattern": "(?:^[A-Za-z]:[\\\\/]|^/|^[Ff][Ii][Ll][Ee]:///|^\\\\\\\\)"
+                        },
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "registered_locator",
+                  "resolved_locator",
+                  "availability"
+                ],
+                "title": "Historical artifact locator",
+                "type": "object"
+              },
+              "label_map": {
+                "additionalProperties": false,
+                "properties": {
+                  "availability": {
+                    "enum": [
+                      "available",
+                      "ambiguous",
+                      "missing",
+                      "not-recorded"
+                    ]
+                  },
+                  "registered_locator": {
+                    "anyOf": [
+                      {
+                        "maxLength": 4096,
+                        "not": {
+                          "pattern": "(?:^[A-Za-z]:[\\\\/]|^/|^[Ff][Ii][Ll][Ee]:///|^\\\\\\\\)"
+                        },
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "resolved_locator": {
+                    "anyOf": [
+                      {
+                        "maxLength": 4096,
+                        "not": {
+                          "pattern": "(?:^[A-Za-z]:[\\\\/]|^/|^[Ff][Ii][Ll][Ee]:///|^\\\\\\\\)"
+                        },
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "registered_locator",
+                  "resolved_locator",
+                  "availability"
+                ],
+                "title": "Historical artifact locator",
+                "type": "object"
+              },
+              "metrics": {
+                "additionalProperties": false,
+                "properties": {
+                  "availability": {
+                    "enum": [
+                      "available",
+                      "ambiguous",
+                      "missing",
+                      "not-recorded"
+                    ]
+                  },
+                  "registered_locator": {
+                    "anyOf": [
+                      {
+                        "maxLength": 4096,
+                        "not": {
+                          "pattern": "(?:^[A-Za-z]:[\\\\/]|^/|^[Ff][Ii][Ll][Ee]:///|^\\\\\\\\)"
+                        },
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "resolved_locator": {
+                    "anyOf": [
+                      {
+                        "maxLength": 4096,
+                        "not": {
+                          "pattern": "(?:^[A-Za-z]:[\\\\/]|^/|^[Ff][Ii][Ll][Ee]:///|^\\\\\\\\)"
+                        },
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "registered_locator",
+                  "resolved_locator",
+                  "availability"
+                ],
+                "title": "Historical artifact locator",
+                "type": "object"
+              },
+              "model": {
+                "additionalProperties": false,
+                "properties": {
+                  "availability": {
+                    "enum": [
+                      "available",
+                      "ambiguous",
+                      "missing",
+                      "not-recorded"
+                    ]
+                  },
+                  "registered_locator": {
+                    "anyOf": [
+                      {
+                        "maxLength": 4096,
+                        "not": {
+                          "pattern": "(?:^[A-Za-z]:[\\\\/]|^/|^[Ff][Ii][Ll][Ee]:///|^\\\\\\\\)"
+                        },
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "resolved_locator": {
+                    "anyOf": [
+                      {
+                        "maxLength": 4096,
+                        "not": {
+                          "pattern": "(?:^[A-Za-z]:[\\\\/]|^/|^[Ff][Ii][Ll][Ee]:///|^\\\\\\\\)"
+                        },
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "registered_locator",
+                  "resolved_locator",
+                  "availability"
+                ],
+                "title": "Historical artifact locator",
+                "type": "object"
+              },
+              "predictions": {
+                "additionalProperties": false,
+                "properties": {
+                  "availability": {
+                    "enum": [
+                      "available",
+                      "ambiguous",
+                      "missing",
+                      "not-recorded"
+                    ]
+                  },
+                  "registered_locator": {
+                    "anyOf": [
+                      {
+                        "maxLength": 4096,
+                        "not": {
+                          "pattern": "(?:^[A-Za-z]:[\\\\/]|^/|^[Ff][Ii][Ll][Ee]:///|^\\\\\\\\)"
+                        },
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "resolved_locator": {
+                    "anyOf": [
+                      {
+                        "maxLength": 4096,
+                        "not": {
+                          "pattern": "(?:^[A-Za-z]:[\\\\/]|^/|^[Ff][Ii][Ll][Ee]:///|^\\\\\\\\)"
+                        },
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "registered_locator",
+                  "resolved_locator",
+                  "availability"
+                ],
+                "title": "Historical artifact locator",
+                "type": "object"
+              }
+            },
+            "required": [
+              "directory",
+              "model",
+              "label_map",
+              "configuration",
+              "history",
+              "predictions",
+              "metrics"
+            ],
+            "title": "Historical run artifacts",
+            "type": "object"
+          },
+          "configuration": {
+            "additionalProperties": false,
+            "properties": {
+              "batch_size": {
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "data_locator": {
+                "anyOf": [
+                  {
+                    "maxLength": 4096,
+                    "not": {
+                      "pattern": "(?:^[A-Za-z]:[\\\\/]|^/|^[Ff][Ii][Ll][Ee]:///|^\\\\\\\\)"
+                    },
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "epochs": {
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "global_settings": {
+                "type": [
+                  "object",
+                  "null"
+                ]
+              },
+              "model_settings": {
+                "type": [
+                  "object",
+                  "null"
+                ]
+              },
+              "sequence_length": {
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "test_fraction": {
+                "maximum": 1,
+                "minimum": 0,
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "validation_fraction": {
+                "maximum": 1,
+                "minimum": 0,
+                "type": [
+                  "number",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "model_settings",
+              "global_settings",
+              "data_locator",
+              "sequence_length",
+              "test_fraction",
+              "validation_fraction",
+              "batch_size",
+              "epochs"
+            ],
+            "title": "Historical run configuration",
+            "type": "object"
+          },
+          "finished_at": {
+            "maxLength": 64,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "metrics": {
+            "additionalProperties": false,
+            "properties": {
+              "quick": {
+                "type": [
+                  "object",
+                  "null"
+                ]
+              },
+              "samples_test": {
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "samples_train": {
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "samples_validation": {
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "test_accuracy": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "test_loss": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "quick",
+              "test_loss",
+              "test_accuracy",
+              "samples_train",
+              "samples_validation",
+              "samples_test"
+            ],
+            "title": "Historical run metrics",
+            "type": "object"
+          },
+          "model_key": {
+            "maxLength": 160,
+            "minLength": 1,
+            "type": "string"
+          },
+          "record_id": {
+            "pattern": "^run-[0-9]{6}$",
+            "type": "string"
+          },
+          "run_name": {
+            "maxLength": 160,
+            "minLength": 1,
+            "type": "string"
+          },
+          "source_run_id": {
+            "maxLength": 321,
+            "minLength": 1,
+            "type": "string"
+          },
+          "started_at": {
+            "maxLength": 64,
+            "minLength": 1,
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "succeeded",
+              "failed",
+              "running"
+            ]
+          },
+          "validity": {
+            "additionalProperties": false,
+            "properties": {
+              "data_role": {
+                "const": "development-only"
+              },
+              "eligible_for_locked_test": {
+                "const": false
+              },
+              "legacy_error_present": {
+                "type": "boolean"
+              },
+              "legacy_notes_present": {
+                "type": "boolean"
+              },
+              "notes": {
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 1,
+                "type": "array"
+              }
+            },
+            "required": [
+              "data_role",
+              "eligible_for_locked_test",
+              "notes",
+              "legacy_notes_present",
+              "legacy_error_present"
+            ],
+            "title": "Historical run validity",
+            "type": "object"
+          }
+        },
+        "required": [
+          "record_id",
+          "run_name",
+          "source_run_id",
+          "started_at",
+          "finished_at",
+          "status",
+          "model_key",
+          "configuration",
+          "metrics",
+          "artifacts",
+          "validity"
+        ],
+        "title": "Historical run record",
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "schema_version": {
+      "const": 1
+    },
+    "shard": {
+      "minimum": 0,
+      "type": "integer"
+    }
+  },
+  "required": [
+    "schema_version",
+    "kind",
+    "shard",
+    "records"
+  ],
+  "title": "Legacy run-index shard",
+  "type": "object"
+}

--- a/docs/legacy/export/v1/schemas/session.schema.json
+++ b/docs/legacy/export/v1/schemas/session.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "data_role": {
+      "const": "development-only"
+    },
+    "duration_ms": {
+      "minimum": 0,
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "model_run_id": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "record_id": {
+      "pattern": "^session-[0-9]{4}$",
+      "type": "string"
+    },
+    "start_offset_ms": {
+      "minimum": 0,
+      "type": "integer"
+    }
+  },
+  "required": [
+    "record_id",
+    "data_role",
+    "model_run_id",
+    "start_offset_ms",
+    "duration_ms"
+  ],
+  "title": "Sanitized legacy feedback session",
+  "type": "object"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,10 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Typing :: Typed",
 ]
-dependencies = ["typer>=0.27.1,<0.28"]
+dependencies = [
+  "jsonschema>=4.26,<5",
+  "typer>=0.27.1,<0.28",
+]
 
 [project.urls]
 Homepage = "https://github.com/peterbucci/signlab"
@@ -38,6 +41,7 @@ dev = [
   "pytest>=9.1.1,<10",
   "pytest-cov>=7,<8",
   "ruff==0.16.3",
+  "types-jsonschema==4.26.0.20260518",
 ]
 
 [tool.hatch.version]

--- a/src/signlab/commands/data.py
+++ b/src/signlab/commands/data.py
@@ -1,7 +1,114 @@
-"""Dataset command group."""
+"""Dataset and legacy-evidence command group."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated
+
+import typer
 
 from signlab.commands._group import create_group
+from signlab.legacy.exporter import LegacyExportError, export_legacy_evidence
+from signlab.legacy.validator import validate_legacy_export
 
 app = create_group(
     help_text="Capture, import, validate, version, and split consent-approved datasets."
 )
+
+
+@app.command("export-legacy")
+def export_legacy(
+    legacy_root: Annotated[
+        Path,
+        typer.Option(
+            "--legacy-root",
+            exists=True,
+            file_okay=False,
+            readable=True,
+            resolve_path=True,
+            help="Legacy project root to inspect read-only.",
+        ),
+    ],
+    audit_snapshot: Annotated[
+        Path,
+        typer.Option(
+            "--audit-snapshot",
+            exists=True,
+            dir_okay=False,
+            readable=True,
+            resolve_path=True,
+            help="Immutable legacy-state audit snapshot.",
+        ),
+    ],
+    public_output: Annotated[
+        Path,
+        typer.Option(
+            "--public-output",
+            resolve_path=True,
+            help="Empty target for portfolio-safe evidence.",
+        ),
+    ],
+    quarantine_output: Annotated[
+        Path,
+        typer.Option(
+            "--quarantine-output",
+            resolve_path=True,
+            help="Empty ignored target for private content-addressed objects.",
+        ),
+    ],
+) -> None:
+    """Export sanitized evidence and an ignored private quarantine."""
+    try:
+        summary = export_legacy_evidence(
+            legacy_root=legacy_root,
+            audit_snapshot=audit_snapshot,
+            public_output=public_output,
+            quarantine_output=quarantine_output,
+        )
+    except LegacyExportError as error:
+        typer.echo(f"Legacy export failed: {error}", err=True)
+        raise typer.Exit(code=1) from error
+    typer.echo(
+        "Legacy export complete: "
+        f"{summary.runs} runs, {summary.attempts} attempts, "
+        f"{summary.promoted_models} promoted models, "
+        f"{summary.quarantined_segments} quarantined segments."
+    )
+
+
+@app.command("validate-legacy")
+def validate_legacy(
+    public_root: Annotated[
+        Path,
+        typer.Option(
+            "--public-root",
+            exists=True,
+            file_okay=False,
+            readable=True,
+            resolve_path=True,
+            help="Public legacy-export root.",
+        ),
+    ],
+    quarantine_root: Annotated[
+        Path | None,
+        typer.Option(
+            "--quarantine-root",
+            exists=True,
+            file_okay=False,
+            readable=True,
+            resolve_path=True,
+            help="Optional private quarantine root.",
+        ),
+    ] = None,
+) -> None:
+    """Validate public evidence and optionally verify every private object."""
+    try:
+        summary = validate_legacy_export(
+            public_root=public_root,
+            quarantine_root=quarantine_root,
+        )
+    except LegacyExportError as error:
+        typer.echo(f"Legacy export validation failed: {error}", err=True)
+        raise typer.Exit(code=1) from error
+    private_status = " and private quarantine" if summary.quarantine_verified else ""
+    typer.echo(f"Validated {summary.runs} runs and {summary.attempts} attempts{private_status}.")

--- a/src/signlab/legacy/__init__.py
+++ b/src/signlab/legacy/__init__.py
@@ -1,0 +1,11 @@
+"""Read-only migration of sanitized evidence from the legacy project."""
+
+from signlab.legacy.exporter import ExportSummary, export_legacy_evidence
+from signlab.legacy.validator import ValidationSummary, validate_legacy_export
+
+__all__ = [
+    "ExportSummary",
+    "ValidationSummary",
+    "export_legacy_evidence",
+    "validate_legacy_export",
+]

--- a/src/signlab/legacy/exporter.py
+++ b/src/signlab/legacy/exporter.py
@@ -1,0 +1,1126 @@
+"""Deterministic, read-only export of legacy development evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import sqlite3
+import subprocess
+import tempfile
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import Any, cast
+from urllib.parse import quote
+
+from signlab.legacy.schemas import (
+    DATA_ROLE,
+    FORMAT_VERSION,
+    PUBLIC_KIND,
+    QUARANTINE_KIND,
+    SCHEMAS,
+)
+
+type JsonObject = dict[str, object]
+
+RUN_SHARD_SIZE = 100
+KNOWN_LOGICAL_ROOTS = (
+    ("data", "live_eval", "segments"),
+    ("data", "landmarks"),
+    ("data", "results_old"),
+    ("data", "results"),
+    ("runs", "sweeps"),
+    ("data", "models"),
+    ("data", "plans"),
+    ("data", "live_eval"),
+    ("data", "live"),
+)
+ARTIFACT_COLUMNS = {
+    "model": "model_path",
+    "label_map": "label_map_path",
+    "configuration": "config_path",
+    "history": "history_path",
+    "predictions": "predictions_path",
+    "metrics": "metrics_path",
+}
+MACHINE_PATH_PATTERNS = (
+    re.compile(r"(?i)(?<![a-z0-9])[a-z]:[\\/]"),
+    re.compile(r"(?i)(?:^|[\s\"'=(])/(?:users|home)/[^/\s]+(?:/|\\)"),
+    re.compile(r"(?i)file:///(?:[a-z]:|users/|home/)"),
+    re.compile(r"^\\\\[^\\]+\\[^\\]+"),
+)
+SENSITIVE_KEYS = {
+    "email",
+    "participant",
+    "participant_id",
+    "subject",
+    "subject_id",
+    "user_id",
+    "username",
+}
+FREEFORM_KEYS = {"error", "freeform_note", "notes"}
+SAFE_OBJECT_SUFFIXES = {".json", ".keras", ".npz"}
+LEGACY_LABELS = frozenset({"NONE", "hello", "no", "nothing", "please", "thank you", "yes"})
+LOCATOR_KEY_SUFFIXES = (
+    "_dir",
+    "_directory",
+    "_file",
+    "_files",
+    "_locator",
+    "_locators",
+    "_path",
+    "_paths",
+    "_root",
+    "_roots",
+    "_uri",
+    "_uris",
+    "_url",
+    "_urls",
+)
+
+
+class LegacyExportError(RuntimeError):
+    """A sanitized legacy-export failure safe to display in a public CLI."""
+
+
+@dataclass(frozen=True)
+class ExportSummary:
+    """Aggregate evidence from one successful export."""
+
+    runs: int
+    attempts: int
+    annotations: int
+    detections: int
+    sessions: int
+    promoted_models: int
+    quarantined_segments: int
+    quarantine_objects: int
+
+
+def _read_json_object(path: Path) -> JsonObject:
+    value: Any = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict) or not all(isinstance(key, str) for key in value):
+        raise LegacyExportError("A required JSON source is not an object.")
+    return cast(JsonObject, value)
+
+
+def _canonical_json_bytes(value: object) -> bytes:
+    return (json.dumps(value, indent=2, sort_keys=True, ensure_ascii=True) + "\n").encode()
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(_canonical_json_bytes(value))
+
+
+def _write_jsonl(path: Path, records: Sequence[Mapping[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    content = b"".join(
+        (
+            json.dumps(record, sort_keys=True, separators=(",", ":"), ensure_ascii=True) + "\n"
+        ).encode()
+        for record in records
+    )
+    path.write_bytes(content)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _component(path: Path, root: Path, *, records: int | None = None) -> JsonObject:
+    relative = path.relative_to(root).as_posix()
+    result: JsonObject = {
+        "path": relative,
+        "bytes": path.stat().st_size,
+        "sha256": _sha256(path),
+    }
+    if records is not None:
+        result["records"] = records
+    return result
+
+
+def _safe_source(legacy_root: Path, logical_path: str) -> Path:
+    portable = PurePosixPath(logical_path)
+    if portable.is_absolute() or not portable.parts or ".." in portable.parts:
+        raise LegacyExportError("A legacy logical path is not portable.")
+    candidate = legacy_root
+    for part in portable.parts:
+        candidate /= part
+        if candidate.is_symlink():
+            raise LegacyExportError("A legacy source path crosses a symbolic link.")
+    resolved_root = legacy_root.resolve()
+    resolved = candidate.resolve()
+    try:
+        resolved.relative_to(resolved_root)
+    except ValueError as error:
+        raise LegacyExportError("A legacy logical path escapes the supplied root.") from error
+    return resolved
+
+
+def _open_immutable_database(path: Path) -> sqlite3.Connection:
+    if path.with_name(f"{path.name}-wal").exists():
+        raise LegacyExportError("A legacy database has an active WAL and cannot be exported.")
+    connection = sqlite3.connect(
+        f"{path.resolve().as_uri()}?mode=ro&immutable=1",
+        uri=True,
+    )
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA query_only = ON")
+    return connection
+
+
+def _run_git(legacy_root: Path, *arguments: str) -> str:
+    environment = os.environ.copy()
+    environment["GIT_OPTIONAL_LOCKS"] = "0"
+    completed = subprocess.run(
+        ["git", "--no-optional-locks", "-C", str(legacy_root), *arguments],
+        check=True,
+        capture_output=True,
+        encoding="utf-8",
+        env=environment,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+def _expected_mapping(value: object, label: str) -> JsonObject:
+    if not isinstance(value, dict) or not all(isinstance(key, str) for key in value):
+        raise LegacyExportError(f"The audit snapshot has an invalid {label} section.")
+    return cast(JsonObject, value)
+
+
+def _expected_sequence(value: object, label: str) -> list[object]:
+    if not isinstance(value, list):
+        raise LegacyExportError(f"The audit snapshot has an invalid {label} section.")
+    return cast(list[object], value)
+
+
+def _verify_file(legacy_root: Path, evidence: JsonObject) -> None:
+    logical_path = evidence.get("logical_path")
+    expected_bytes = evidence.get("bytes")
+    expected_sha256 = evidence.get("sha256")
+    if not isinstance(logical_path, str) or not isinstance(expected_bytes, int):
+        raise LegacyExportError("The audit contains invalid file evidence.")
+    if not isinstance(expected_sha256, str):
+        raise LegacyExportError("The audit contains invalid file evidence.")
+    source = _safe_source(legacy_root, logical_path)
+    if not source.is_file():
+        raise LegacyExportError("An audited legacy source artifact is missing.")
+    if source.stat().st_size != expected_bytes or _sha256(source) != expected_sha256:
+        raise LegacyExportError("An audited legacy source artifact changed.")
+
+
+def _verify_source(legacy_root: Path, audit: JsonObject) -> None:
+    if audit.get("schema_version") != 2:
+        raise LegacyExportError("The legacy audit version is unsupported.")
+    repository = _expected_mapping(audit.get("repository"), "repository")
+    expected_head = repository.get("head_commit")
+    expected_tree = repository.get("tree_object")
+    if not isinstance(expected_head, str) or not isinstance(expected_tree, str):
+        raise LegacyExportError("The legacy Git anchors are invalid.")
+    try:
+        actual_head = _run_git(legacy_root, "rev-parse", "HEAD")
+        actual_tree = _run_git(legacy_root, "rev-parse", "HEAD^{tree}")
+    except (OSError, subprocess.SubprocessError) as error:
+        raise LegacyExportError("The legacy Git anchors could not be read.") from error
+    if (actual_head, actual_tree) != (expected_head, expected_tree):
+        raise LegacyExportError("The legacy Git anchors do not match the audit.")
+
+    for raw_evidence in _expected_sequence(audit.get("integrity"), "integrity"):
+        _verify_file(legacy_root, _expected_mapping(raw_evidence, "integrity item"))
+    for raw_run in _expected_sequence(audit.get("reported_runs"), "reported runs"):
+        run = _expected_mapping(raw_run, "reported run")
+        model_evidence: JsonObject = {
+            "logical_path": run.get("model_logical_path"),
+            "bytes": run.get("model_bytes"),
+            "sha256": run.get("model_sha256"),
+        }
+        _verify_file(legacy_root, model_evidence)
+        for raw_evidence in _expected_sequence(run.get("source_evidence"), "source evidence"):
+            _verify_file(legacy_root, _expected_mapping(raw_evidence, "source evidence item"))
+
+    live_state = _expected_mapping(audit.get("live_state"), "live state")
+    database_checks = (
+        ("data/models/runs.db", "runs", "run_database", "runs"),
+        ("data/models/live_feedback.db", "feedback", "feedback_database", "feedback_records"),
+        ("data/live_eval/live_eval.db", "attempts", "live_evaluation_database", "attempts"),
+    )
+    for logical_path, table, section_name, count_name in database_checks:
+        section = _expected_mapping(live_state.get(section_name), section_name)
+        expected_count = section.get(count_name)
+        if not isinstance(expected_count, int):
+            raise LegacyExportError("The audit contains an invalid database count.")
+        connection = _open_immutable_database(_safe_source(legacy_root, logical_path))
+        try:
+            row = connection.execute(f"SELECT COUNT(*) FROM {table}").fetchone()
+            actual_count = cast(int, row[0])
+        finally:
+            connection.close()
+        if actual_count != expected_count:
+            raise LegacyExportError("A legacy database count does not match the audit.")
+
+
+def _path_parts(value: str) -> tuple[str, ...]:
+    if "\\" in value or re.match(r"(?i)^[a-z]:", value):
+        return PureWindowsPath(value).parts
+    return PurePosixPath(value).parts
+
+
+def _logical_path_from_value(value: str) -> PurePosixPath | None:
+    parts = _path_parts(value)
+    lowered = tuple(part.lower() for part in parts)
+    for root in KNOWN_LOGICAL_ROOTS:
+        for index in range(len(parts) - len(root) + 1):
+            if lowered[index : index + len(root)] == root:
+                selected = parts[index:]
+                if ".." in selected:
+                    return None
+                return PurePosixPath(*selected)
+    return None
+
+
+def _portable_locator(value: str | None) -> str | None:
+    if not value:
+        return None
+    logical_path = _logical_path_from_value(value)
+    if logical_path is not None:
+        encoded = "/".join(quote(part, safe="-._~") for part in logical_path.parts)
+        return f"legacy://{encoded}"
+    if any(pattern.search(value) for pattern in MACHINE_PATH_PATTERNS):
+        return "redacted://machine-path"
+    portable = PurePosixPath(value.replace("\\", "/"))
+    if portable.is_absolute() or ".." in portable.parts:
+        return "redacted://nonportable-path"
+    if "/" in value or "\\" in value:
+        # A slash in prose (for example, "orientation/scale") is not a path.
+        # Known logical roots and absolute machine paths were handled above.
+        if any(character.isspace() for character in value):
+            return value
+        encoded = "/".join(quote(part, safe="-._~") for part in portable.parts)
+        return f"legacy-relative://{encoded}"
+    return value
+
+
+def _is_locator_field(key: str | None) -> bool:
+    if key is None:
+        return False
+    lowered = key.casefold()
+    return lowered in {"dir", "directory", "file", "locator", "path", "root", "uri", "url"} or (
+        lowered.endswith(LOCATOR_KEY_SUFFIXES)
+    )
+
+
+def _sanitize(value: object, *, field: str | None = None) -> object:
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    if isinstance(value, str):
+        portable = PurePosixPath(value.replace("\\", "/"))
+        if (
+            _logical_path_from_value(value) is not None
+            or any(pattern.search(value) for pattern in MACHINE_PATH_PATTERNS)
+            or portable.is_absolute()
+            or ".." in portable.parts
+            or _is_locator_field(field)
+        ):
+            return _portable_locator(value)
+        return value
+    if isinstance(value, list):
+        return [_sanitize(item, field=field) for item in value]
+    if isinstance(value, dict):
+        sanitized: JsonObject = {}
+        for raw_key, child in value.items():
+            key = str(raw_key)
+            lowered_key = key.lower()
+            if lowered_key in SENSITIVE_KEYS:
+                sanitized[f"{lowered_key}_redacted"] = True
+            elif lowered_key in FREEFORM_KEYS:
+                sanitized[f"{lowered_key}_present"] = bool(child)
+            else:
+                sanitized[key] = _sanitize(child, field=key)
+        return sanitized
+    return str(value)
+
+
+def _parse_json_value(value: object) -> object:
+    if value in (None, ""):
+        return None
+    if not isinstance(value, str):
+        raise LegacyExportError("A legacy JSON database field has an invalid type.")
+    try:
+        return _sanitize(json.loads(value))
+    except json.JSONDecodeError as error:
+        raise LegacyExportError("A legacy JSON database field is invalid.") from error
+
+
+def _safe_token(value: object, *, fallback: str) -> str:
+    if value is None:
+        return fallback
+    text = str(value)
+    if re.fullmatch(r"[A-Za-z0-9_.-]{1,160}", text):
+        return text
+    digest = hashlib.sha256(text.encode()).hexdigest()[:16]
+    return f"redacted-{digest}"
+
+
+def _legacy_label(value: object, *, fallback: str) -> str:
+    """Preserve the bounded historical vocabulary, including its spaced label."""
+    if value is None:
+        return fallback
+    if not isinstance(value, str) or value not in LEGACY_LABELS:
+        raise LegacyExportError("A legacy label is outside the audited vocabulary.")
+    return value
+
+
+def _normalized_run_timestamp(value: object, *, fallback: str) -> str:
+    """Keep useful training-run chronology while rejecting arbitrary text."""
+    if value is None:
+        return fallback
+    if not isinstance(value, str):
+        raise LegacyExportError("A legacy run timestamp has an invalid type.")
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).isoformat()
+    except ValueError as error:
+        raise LegacyExportError("A legacy run timestamp is invalid.") from error
+
+
+def _build_result_directory_index(legacy_root: Path) -> dict[str, tuple[PurePosixPath, ...]]:
+    indexed: defaultdict[str, list[PurePosixPath]] = defaultdict(list)
+    for logical_root in ("data/results", "data/results_old"):
+        root = _safe_source(legacy_root, logical_root)
+        if not root.is_dir():
+            continue
+        for candidate in root.rglob("*"):
+            if candidate.is_symlink():
+                raise LegacyExportError("A legacy results tree contains a symbolic link.")
+            if candidate.is_dir():
+                indexed[candidate.name].append(
+                    PurePosixPath(candidate.relative_to(legacy_root).as_posix())
+                )
+    return {name: tuple(sorted(paths, key=str)) for name, paths in indexed.items()}
+
+
+def _locator_for_logical(path: PurePosixPath) -> str:
+    return "legacy://" + "/".join(quote(part, safe="-._~") for part in path.parts)
+
+
+def _artifact_entry(
+    legacy_root: Path,
+    raw_value: object,
+    *,
+    discovered_directories: Sequence[PurePosixPath],
+    directory_role: bool = False,
+) -> JsonObject:
+    if raw_value in (None, ""):
+        return {
+            "registered_locator": None,
+            "resolved_locator": None,
+            "availability": "not-recorded",
+        }
+    if not isinstance(raw_value, str):
+        raise LegacyExportError("A legacy artifact locator has an invalid type.")
+    registered_path = _logical_path_from_value(raw_value)
+    registered_locator = _portable_locator(raw_value)
+    candidates: list[PurePosixPath] = []
+    if (
+        registered_path is not None
+        and _safe_source(legacy_root, registered_path.as_posix()).exists()
+    ):
+        candidates.append(registered_path)
+    basename = (
+        PureWindowsPath(raw_value).name if "\\" in raw_value else PurePosixPath(raw_value).name
+    )
+    for directory in discovered_directories:
+        candidate = directory if directory_role else directory / basename
+        if _safe_source(legacy_root, candidate.as_posix()).exists():
+            candidates.append(candidate)
+    unique_candidates = tuple(sorted(set(candidates), key=str))
+    if len(unique_candidates) == 1:
+        return {
+            "registered_locator": registered_locator,
+            "resolved_locator": _locator_for_logical(unique_candidates[0]),
+            "availability": "available",
+        }
+    if len(unique_candidates) > 1:
+        return {
+            "registered_locator": registered_locator,
+            "resolved_locator": None,
+            "availability": "ambiguous",
+        }
+    return {
+        "registered_locator": registered_locator,
+        "resolved_locator": None,
+        "availability": "missing",
+    }
+
+
+def _run_validity(
+    status: str,
+    model_key: str,
+    *,
+    notes_present: bool,
+    error_present: bool,
+) -> JsonObject:
+    notes = [
+        "development-only",
+        "sample-level-split-without-signer-or-session-grouping",
+        "test-split-repeatedly-inspected",
+        "no-learned-negative-class",
+    ]
+    if model_key == "mamba":
+        notes.append("misleading-legacy-mamba-name")
+    if status == "failed":
+        notes.append("failed-run")
+    elif status == "running":
+        notes.append("stale-running-run")
+    return {
+        "data_role": DATA_ROLE,
+        "eligible_for_locked_test": False,
+        "notes": notes,
+        "legacy_notes_present": notes_present,
+        "legacy_error_present": error_present,
+    }
+
+
+def _source_run_id(run_name: str, global_settings: object) -> str:
+    """Recover the cross-store run identity used by sweeps and live evaluation."""
+    if isinstance(global_settings, dict):
+        sweep_id = global_settings.get("sweep_id")
+        if sweep_id is not None:
+            return f"{_safe_token(sweep_id, fallback='unknown-sweep')}_{run_name}"
+    return run_name
+
+
+def _build_run_records(legacy_root: Path) -> list[JsonObject]:
+    database = _safe_source(legacy_root, "data/models/runs.db")
+    result_index = _build_result_directory_index(legacy_root)
+    connection = _open_immutable_database(database)
+    try:
+        rows = connection.execute("SELECT * FROM runs ORDER BY id").fetchall()
+    finally:
+        connection.close()
+    records: list[JsonObject] = []
+    for ordinal, row in enumerate(rows, start=1):
+        run_name = _safe_token(row["run_name"], fallback=f"unnamed-{ordinal:06d}")
+        status = _safe_token(row["status"], fallback="unknown")
+        model_key = _safe_token(row["model_key"], fallback="unknown")
+        discovered_directories = result_index.get(run_name, ())
+        model_settings = _parse_json_value(row["model_settings_json"])
+        global_settings = _parse_json_value(row["global_settings_json"])
+        artifacts: JsonObject = {
+            "directory": _artifact_entry(
+                legacy_root,
+                row["artifacts_dir"],
+                discovered_directories=discovered_directories,
+                directory_role=True,
+            )
+        }
+        for role, column in ARTIFACT_COLUMNS.items():
+            artifacts[role] = _artifact_entry(
+                legacy_root,
+                row[column],
+                discovered_directories=discovered_directories,
+            )
+        configuration: JsonObject = {
+            "model_settings": model_settings,
+            "global_settings": global_settings,
+            "data_locator": _portable_locator(cast(str | None, row["data_root"])),
+            "sequence_length": row["seq_len"],
+            "test_fraction": row["test_frac"],
+            "validation_fraction": row["val_frac"],
+            "batch_size": row["batch_size"],
+            "epochs": row["epochs"],
+        }
+        metrics: JsonObject = {
+            "quick": _parse_json_value(row["quick_metrics_json"]),
+            "test_loss": row["test_loss"],
+            "test_accuracy": row["test_accuracy"],
+            "samples_train": row["samples_train"],
+            "samples_validation": row["samples_val"],
+            "samples_test": row["samples_test"],
+        }
+        records.append(
+            {
+                "record_id": f"run-{ordinal:06d}",
+                "run_name": run_name,
+                "source_run_id": _source_run_id(run_name, global_settings),
+                "started_at": _normalized_run_timestamp(row["started_at"], fallback="unknown"),
+                "finished_at": (
+                    _normalized_run_timestamp(row["finished_at"], fallback="unknown")
+                    if row["finished_at"] is not None
+                    else None
+                ),
+                "status": status,
+                "model_key": model_key,
+                "configuration": configuration,
+                "metrics": metrics,
+                "artifacts": artifacts,
+                "validity": _run_validity(
+                    status,
+                    model_key,
+                    notes_present=bool(row["notes"]),
+                    error_present=bool(row["error"]),
+                ),
+            }
+        )
+    return records
+
+
+def _parse_time(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise LegacyExportError("A legacy timestamp is invalid.") from error
+
+
+def _offset_ms(value: object, origin: datetime) -> int:
+    timestamp = _parse_time(value)
+    if timestamp is None:
+        return 0
+    return max(0, int((timestamp - origin).total_seconds() * 1000))
+
+
+def _duration_ms(start: object, end: object) -> int | None:
+    start_time = _parse_time(start)
+    end_time = _parse_time(end)
+    if start_time is None or end_time is None:
+        return None
+    return max(0, int((end_time - start_time).total_seconds() * 1000))
+
+
+class _ObjectStore:
+    def __init__(self, root: Path) -> None:
+        self._root = root
+        self._entries: dict[str, JsonObject] = {}
+
+    def add(self, source: Path, *, role: str) -> str:
+        if source.is_symlink() or not source.is_file():
+            raise LegacyExportError("A quarantined source object is unavailable.")
+        suffix = source.suffix.lower()
+        if suffix not in SAFE_OBJECT_SUFFIXES:
+            raise LegacyExportError("A quarantined source object has an unsupported type.")
+        before = source.stat()
+        digest = _sha256(source)
+        after = source.stat()
+        if (before.st_size, before.st_mtime_ns) != (after.st_size, after.st_mtime_ns):
+            raise LegacyExportError("A legacy source object changed during export.")
+        relative = PurePosixPath("objects", "sha256", f"{digest}{suffix}")
+        destination = self._root / Path(relative.as_posix())
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        if not destination.exists():
+            shutil.copyfile(source, destination)
+        if destination.stat().st_size != before.st_size or _sha256(destination) != digest:
+            raise LegacyExportError("A quarantined object failed its integrity check.")
+        uri = f"quarantine://sha256/{digest}{suffix}"
+        entry = self._entries.setdefault(
+            uri,
+            {
+                "uri": uri,
+                "storage_key": relative.as_posix(),
+                "bytes": before.st_size,
+                "sha256": digest,
+                "roles": [],
+            },
+        )
+        roles = cast(list[str], entry["roles"])
+        if role not in roles:
+            roles.append(role)
+            roles.sort()
+        return uri
+
+    def entries(self) -> list[JsonObject]:
+        return [self._entries[key] for key in sorted(self._entries)]
+
+
+def _all_segment_files(legacy_root: Path) -> list[Path]:
+    root = _safe_source(legacy_root, "data/live_eval/segments")
+    if not root.is_dir():
+        raise LegacyExportError("The legacy live-segment directory is missing.")
+    segments: list[Path] = []
+    for candidate in sorted(root.rglob("*.npz"), key=lambda item: item.as_posix()):
+        if candidate.is_symlink() or not candidate.is_file():
+            raise LegacyExportError("The legacy segment tree is not a regular-file tree.")
+        segments.append(candidate)
+    return segments
+
+
+def _resolve_segment_path(legacy_root: Path, value: object) -> Path | None:
+    if value in (None, ""):
+        return None
+    if not isinstance(value, str):
+        raise LegacyExportError("A legacy segment locator has an invalid type.")
+    logical = _logical_path_from_value(value)
+    if logical is None:
+        raise LegacyExportError("A legacy segment locator cannot be sanitized.")
+    source = _safe_source(legacy_root, logical.as_posix())
+    if not source.is_file():
+        raise LegacyExportError("A referenced legacy segment is missing.")
+    return source
+
+
+def _build_live_records(
+    legacy_root: Path,
+    store: _ObjectStore,
+) -> tuple[list[JsonObject], list[JsonObject], list[JsonObject], list[JsonObject], dict[str, int]]:
+    evaluation = _open_immutable_database(_safe_source(legacy_root, "data/live_eval/live_eval.db"))
+    feedback = _open_immutable_database(_safe_source(legacy_root, "data/models/live_feedback.db"))
+    try:
+        attempt_rows = evaluation.execute(
+            "SELECT * FROM attempts ORDER BY timestamp_start, attempt_id"
+        ).fetchall()
+        annotation_rows = feedback.execute(
+            "SELECT * FROM feedback ORDER BY timestamp, feedback_id"
+        ).fetchall()
+        session_rows = feedback.execute("SELECT * FROM sessions ORDER BY started_at, id").fetchall()
+        detection_rows = feedback.execute("SELECT * FROM detections ORDER BY ts, id").fetchall()
+    finally:
+        evaluation.close()
+        feedback.close()
+
+    attempt_times = [_parse_time(row["timestamp_start"]) for row in attempt_rows]
+    attempt_origin = min(time for time in attempt_times if time is not None)
+    attempt_aliases = {
+        cast(str, row["attempt_id"]): f"attempt-{index:06d}"
+        for index, row in enumerate(attempt_rows, start=1)
+    }
+    referenced_segments: set[Path] = set()
+    attempts: list[JsonObject] = []
+    for row in attempt_rows:
+        raw_id = cast(str, row["attempt_id"])
+        segment_source = _resolve_segment_path(legacy_root, row["segment_path"])
+        segment_uri = None
+        if segment_source is not None:
+            referenced_segments.add(segment_source)
+            segment_uri = store.add(segment_source, role="live-attempt-segment")
+        predicted_label = _legacy_label(row["predicted_label"], fallback="NONE")
+        model_run_id = _safe_token(row["model_run_id"], fallback="unknown")
+        attempts.append(
+            {
+                "record_id": attempt_aliases[raw_id],
+                "data_role": DATA_ROLE,
+                "start_offset_ms": _offset_ms(row["timestamp_start"], attempt_origin),
+                "duration_ms": _duration_ms(row["timestamp_start"], row["timestamp_end"]),
+                "detected": bool(row["detected"]),
+                "intended_label": (
+                    _legacy_label(row["intended_label"], fallback="unknown")
+                    if row["intended_label"] is not None
+                    else None
+                ),
+                "predicted_label": predicted_label,
+                "correct": bool(row["correct"]) if row["correct"] is not None else None,
+                "confidence": float(row["confidence"]) if row["confidence"] is not None else None,
+                "latency_ms": int(row["latency_ms"]) if row["latency_ms"] is not None else None,
+                "segment_frames": (
+                    int(row["segment_frames"]) if row["segment_frames"] is not None else None
+                ),
+                "model_run_id": model_run_id,
+                "segmentation": _parse_json_value(row["seg_params_json"]) or {},
+                "segment_uri": segment_uri,
+            }
+        )
+
+    annotations: list[JsonObject] = []
+    for index, row in enumerate(annotation_rows, start=1):
+        raw_attempt_id = cast(str, row["attempt_id"])
+        if raw_attempt_id not in attempt_aliases:
+            raise LegacyExportError("A feedback annotation references an unknown attempt.")
+        annotations.append(
+            {
+                "record_id": f"annotation-{index:06d}",
+                "attempt_ref": attempt_aliases[raw_attempt_id],
+                "data_role": DATA_ROLE,
+                # Use the attempt origin so feedback latency remains recoverable.
+                "offset_ms": _offset_ms(row["timestamp"], attempt_origin),
+                "feedback_type": _safe_token(row["feedback_type"], fallback="unknown"),
+                "corrected_label": (
+                    _legacy_label(row["corrected_label"], fallback="unknown")
+                    if row["corrected_label"] is not None
+                    else None
+                ),
+                "freeform_note_present": bool(row["freeform_note"]),
+            }
+        )
+
+    session_times = [_parse_time(row["started_at"]) for row in session_rows]
+    session_origin = min(time for time in session_times if time is not None)
+    session_aliases = {
+        int(row["id"]): f"session-{index:04d}" for index, row in enumerate(session_rows, start=1)
+    }
+    sessions: list[JsonObject] = []
+    for row in session_rows:
+        sessions.append(
+            {
+                "record_id": session_aliases[int(row["id"])],
+                "data_role": DATA_ROLE,
+                "model_run_id": _safe_token(row["model_name"], fallback="unknown"),
+                "start_offset_ms": _offset_ms(row["started_at"], session_origin),
+                "duration_ms": _duration_ms(row["started_at"], row["ended_at"]),
+            }
+        )
+
+    detections: list[JsonObject] = []
+    for index, row in enumerate(detection_rows, start=1):
+        session_id = int(row["session_id"])
+        if session_id not in session_aliases:
+            raise LegacyExportError("A legacy detection references an unknown session.")
+        detections.append(
+            {
+                "record_id": f"detection-{index:06d}",
+                "session_ref": session_aliases[session_id],
+                "data_role": DATA_ROLE,
+                "offset_ms": _offset_ms(row["ts"], session_origin),
+                "predicted_label": (
+                    _legacy_label(row["predicted_label"], fallback="unknown")
+                    if row["predicted_label"] is not None
+                    else None
+                ),
+                "actual_label": (
+                    _legacy_label(row["actual_label"], fallback="unknown")
+                    if row["actual_label"] is not None
+                    else None
+                ),
+                "confidence": float(row["confidence"]) if row["confidence"] is not None else None,
+                "correct": bool(row["is_correct"]) if row["is_correct"] is not None else None,
+            }
+        )
+
+    all_segments = _all_segment_files(legacy_root)
+    for source in all_segments:
+        role = "live-attempt-segment" if source in referenced_segments else "orphan-live-segment"
+        store.add(source, role=role)
+    counts = {
+        "attempts": len(attempts),
+        "annotations": len(annotations),
+        "annotated_attempts": len({record["attempt_ref"] for record in annotations}),
+        "unannotated_attempts": len(attempts)
+        - len({record["attempt_ref"] for record in annotations}),
+        "sessions": len(sessions),
+        "detections": len(detections),
+        "segments": len(all_segments),
+        "referenced_segments": len(referenced_segments),
+        "orphan_segments": len(all_segments) - len(referenced_segments),
+    }
+    return attempts, annotations, sessions, detections, counts
+
+
+def _build_promoted_artifacts(
+    legacy_root: Path,
+    audit: JsonObject,
+    store: _ObjectStore,
+) -> list[JsonObject]:
+    dataset = _expected_mapping(audit.get("dataset_snapshot"), "dataset snapshot")
+    selected_plan = _safe_token(dataset.get("selected_representation"), fallback="unknown")
+    promoted: list[JsonObject] = []
+    for raw_run in _expected_sequence(audit.get("reported_runs"), "reported runs"):
+        run = _expected_mapping(raw_run, "reported run")
+        run_id = _safe_token(run.get("run_id"), fallback="unknown")
+        model_key = _safe_token(run.get("model_key"), fallback="unknown")
+        model_path = run.get("model_logical_path")
+        if not isinstance(model_path, str):
+            raise LegacyExportError("A promoted model locator is invalid.")
+        model_source = _safe_source(legacy_root, model_path)
+        model_uri = store.add(model_source, role=f"promoted-model:{model_key}")
+        label_evidence = next(
+            (
+                _expected_mapping(item, "label-map evidence")
+                for item in _expected_sequence(run.get("source_evidence"), "source evidence")
+                if isinstance(item, dict)
+                and str(cast(dict[str, object], item).get("logical_path", "")).endswith(
+                    "/label_map.json"
+                )
+            ),
+            None,
+        )
+        if label_evidence is None or not isinstance(label_evidence.get("logical_path"), str):
+            raise LegacyExportError("A promoted run has no label-map evidence.")
+        label_path = cast(str, label_evidence["logical_path"])
+        label_source = _safe_source(legacy_root, label_path)
+        label_uri = store.add(label_source, role=f"promoted-label-map:{model_key}")
+        label_map = _read_json_object(label_source)
+        promoted.append(
+            {
+                "run_id": run_id,
+                "model_key": model_key,
+                "preprocessing_plan": selected_plan,
+                "model": {
+                    "bytes": run["model_bytes"],
+                    "sha256": run["model_sha256"],
+                    "quarantine_uri": model_uri,
+                    "storage_status": "local-quarantine",
+                },
+                "label_map": {
+                    "bytes": label_evidence["bytes"],
+                    "sha256": label_evidence["sha256"],
+                    "quarantine_uri": label_uri,
+                    "labels": _sanitize(label_map),
+                },
+                "validity": {
+                    "data_role": DATA_ROLE,
+                    "eligible_for_locked_test": False,
+                    "notes": [
+                        "sample-level-split-without-signer-or-session-grouping",
+                        "test-split-repeatedly-inspected",
+                        "parity-candidate-not-champion",
+                    ]
+                    + (["misleading-legacy-mamba-name"] if model_key == "mamba" else []),
+                },
+            }
+        )
+    return promoted
+
+
+def _write_schemas(public_root: Path) -> list[JsonObject]:
+    components: list[JsonObject] = []
+    for name, schema in sorted(SCHEMAS.items()):
+        path = public_root / "schemas" / name
+        _write_json(path, schema)
+        components.append(_component(path, public_root))
+    return components
+
+
+def _build_export(
+    legacy_root: Path,
+    audit_path: Path,
+    public_root: Path,
+    quarantine_root: Path,
+) -> ExportSummary:
+    audit = _read_json_object(audit_path)
+    _verify_source(legacy_root, audit)
+    store = _ObjectStore(quarantine_root)
+
+    runs = _build_run_records(legacy_root)
+    attempts, annotations, sessions, detections, live_counts = _build_live_records(
+        legacy_root, store
+    )
+    promoted = _build_promoted_artifacts(legacy_root, audit, store)
+    plans_source = _safe_source(legacy_root, "data/plans/plans.json")
+    plans_uri = store.add(plans_source, role="preprocessing-plan-registry")
+    plans = _read_json_object(plans_source)
+
+    record_sets: tuple[tuple[str, list[JsonObject]], ...] = (
+        ("records/attempts.jsonl", attempts),
+        ("records/annotations.jsonl", annotations),
+        ("records/sessions.jsonl", sessions),
+        ("records/detections.jsonl", detections),
+    )
+    private_components: list[JsonObject] = []
+    for relative, records in record_sets:
+        path = quarantine_root / relative
+        _write_jsonl(path, records)
+        private_components.append(_component(path, quarantine_root, records=len(records)))
+
+    object_entries = store.entries()
+    private_counts = {
+        **live_counts,
+        "promoted_models": len(promoted),
+        "quarantine_objects": len(object_entries),
+    }
+    private_manifest: JsonObject = {
+        "schema_version": FORMAT_VERSION,
+        "kind": QUARANTINE_KIND,
+        "policy": {
+            "data_role": DATA_ROLE,
+            "eligible_for_locked_test": False,
+            "contains_private_artifacts": True,
+            "publishable": False,
+            "identifiers": "pseudonymized-ordinal",
+            "timestamps": "live-records-relative-offsets-only",
+        },
+        "counts": private_counts,
+        "record_components": private_components,
+        "objects": object_entries,
+    }
+    private_manifest_path = quarantine_root / "manifest.json"
+    _write_json(private_manifest_path, private_manifest)
+
+    public_components = _write_schemas(public_root)
+    for shard_index, start in enumerate(range(0, len(runs), RUN_SHARD_SIZE)):
+        shard_records = runs[start : start + RUN_SHARD_SIZE]
+        shard_path = public_root / "runs" / f"runs-{shard_index:03d}.json"
+        _write_json(
+            shard_path,
+            {
+                "schema_version": FORMAT_VERSION,
+                "kind": "signlab.legacy-run-index",
+                "shard": shard_index,
+                "records": shard_records,
+            },
+        )
+        public_components.append(_component(shard_path, public_root, records=len(shard_records)))
+
+    plans_path = public_root / "preprocessing-plans.json"
+    _write_json(
+        plans_path,
+        {
+            "schema_version": FORMAT_VERSION,
+            "kind": "signlab.legacy-preprocessing-plans",
+            "source_sha256": _sha256(plans_source),
+            "quarantine_uri": plans_uri,
+            "plans": _sanitize(plans),
+        },
+    )
+    public_components.append(_component(plans_path, public_root, records=len(plans)))
+
+    promoted_path = public_root / "promoted-artifacts.json"
+    _write_json(
+        promoted_path,
+        {
+            "schema_version": FORMAT_VERSION,
+            "kind": "signlab.legacy-promoted-artifacts",
+            "artifacts": promoted,
+        },
+    )
+    public_components.append(_component(promoted_path, public_root, records=len(promoted)))
+
+    receipt_components = [
+        _component(private_manifest_path, quarantine_root),
+        *private_components,
+    ]
+    receipt_path = public_root / "quarantine-receipt.json"
+    _write_json(
+        receipt_path,
+        {
+            "schema_version": FORMAT_VERSION,
+            "kind": "signlab.legacy-quarantine-receipt",
+            "policy": {
+                "data_role": DATA_ROLE,
+                "eligible_for_locked_test": False,
+                "publishable": False,
+                "durability": "local-only-pending-private-remote",
+                "contains_individual_object_hashes": False,
+            },
+            "counts": private_counts,
+            "components": receipt_components,
+        },
+    )
+    public_components.append(_component(receipt_path, public_root))
+
+    status_counts: defaultdict[str, int] = defaultdict(int)
+    for record in runs:
+        status_counts[cast(str, record["status"])] += 1
+    source = _expected_mapping(audit.get("repository"), "repository")
+    public_counts = {
+        "runs": len(runs),
+        "runs_succeeded": status_counts["succeeded"],
+        "runs_failed": status_counts["failed"],
+        "runs_running": status_counts["running"],
+        "preprocessing_plans": len(plans),
+        "promoted_models": len(promoted),
+        **live_counts,
+    }
+    public_manifest: JsonObject = {
+        "schema_version": FORMAT_VERSION,
+        "kind": PUBLIC_KIND,
+        "source": {
+            "head_commit": source["head_commit"],
+            "tree_object": source["tree_object"],
+            "audit_sha256": _sha256(audit_path),
+        },
+        "policy": {
+            "data_role": DATA_ROLE,
+            "eligible_for_locked_test": False,
+            "contains_private_artifacts": False,
+            "durability": "local-only-pending-private-remote",
+        },
+        "counts": public_counts,
+        "components": sorted(public_components, key=lambda item: cast(str, item["path"])),
+    }
+    _write_json(public_root / "manifest.json", public_manifest)
+
+    _verify_source(legacy_root, audit)
+    return ExportSummary(
+        runs=len(runs),
+        attempts=len(attempts),
+        annotations=len(annotations),
+        detections=len(detections),
+        sessions=len(sessions),
+        promoted_models=len(promoted),
+        quarantined_segments=live_counts["segments"],
+        quarantine_objects=len(object_entries),
+    )
+
+
+def _target_is_nonempty(path: Path) -> bool:
+    return path.exists() and (not path.is_dir() or next(path.iterdir(), None) is not None)
+
+
+def _validate_output_boundaries(
+    legacy_root: Path,
+    public_output: Path,
+    quarantine_output: Path,
+) -> None:
+    resolved_legacy = legacy_root.resolve()
+    resolved_public = public_output.resolve()
+    resolved_quarantine = quarantine_output.resolve()
+    if resolved_public == resolved_quarantine:
+        raise LegacyExportError("Public and quarantine outputs must be separate.")
+    if resolved_public.is_relative_to(resolved_quarantine) or resolved_quarantine.is_relative_to(
+        resolved_public
+    ):
+        raise LegacyExportError("Public and quarantine outputs must not be nested.")
+    if resolved_public.is_relative_to(resolved_legacy) or resolved_quarantine.is_relative_to(
+        resolved_legacy
+    ):
+        raise LegacyExportError("Export outputs must not be inside the legacy source.")
+    if _target_is_nonempty(public_output) or _target_is_nonempty(quarantine_output):
+        raise LegacyExportError("Export outputs must be absent or empty.")
+
+
+def export_legacy_evidence(
+    *,
+    legacy_root: Path,
+    audit_snapshot: Path,
+    public_output: Path,
+    quarantine_output: Path,
+) -> ExportSummary:
+    """Export public evidence and a private quarantine without mutating the source."""
+    if not legacy_root.is_dir() or not audit_snapshot.is_file():
+        raise LegacyExportError("The legacy root or audit snapshot is unavailable.")
+    _validate_output_boundaries(legacy_root, public_output, quarantine_output)
+    public_output.parent.mkdir(parents=True, exist_ok=True)
+    quarantine_output.parent.mkdir(parents=True, exist_ok=True)
+    public_staging = Path(tempfile.mkdtemp(prefix=".signlab-public-", dir=public_output.parent))
+    quarantine_staging = Path(
+        tempfile.mkdtemp(prefix=".signlab-private-", dir=quarantine_output.parent)
+    )
+    moved_public = False
+    moved_quarantine = False
+    try:
+        summary = _build_export(
+            legacy_root.resolve(),
+            audit_snapshot.resolve(),
+            public_staging,
+            quarantine_staging,
+        )
+        from signlab.legacy.validator import validate_legacy_export
+
+        validate_legacy_export(public_root=public_staging, quarantine_root=quarantine_staging)
+        if public_output.exists():
+            public_output.rmdir()
+        if quarantine_output.exists():
+            quarantine_output.rmdir()
+        quarantine_staging.replace(quarantine_output)
+        moved_quarantine = True
+        public_staging.replace(public_output)
+        moved_public = True
+        return summary
+    except (OSError, ValueError, sqlite3.Error, subprocess.SubprocessError) as error:
+        raise LegacyExportError("The legacy export could not complete safely.") from error
+    finally:
+        if public_staging.exists():
+            shutil.rmtree(public_staging)
+        if quarantine_staging.exists():
+            shutil.rmtree(quarantine_staging)
+        if moved_quarantine and not moved_public and quarantine_output.exists():
+            shutil.rmtree(quarantine_output)

--- a/src/signlab/legacy/schemas.py
+++ b/src/signlab/legacy/schemas.py
@@ -1,0 +1,593 @@
+"""JSON Schema 2020-12 contracts for the legacy export."""
+
+from __future__ import annotations
+
+from typing import Final, cast
+
+type JsonValue = bool | int | float | str | list[JsonValue] | dict[str, JsonValue] | None
+type JsonObject = dict[str, JsonValue]
+
+SCHEMA_DIALECT: Final = "https://json-schema.org/draft/2020-12/schema"
+FORMAT_VERSION: Final = 1
+PUBLIC_KIND: Final = "signlab.legacy-public-export"
+QUARANTINE_KIND: Final = "signlab.legacy-quarantine"
+DATA_ROLE: Final = "development-only"
+
+
+def _object_schema(
+    properties: JsonObject,
+    required: list[str],
+    *,
+    title: str,
+) -> JsonObject:
+    return {
+        "title": title,
+        "type": "object",
+        "properties": properties,
+        "required": cast(JsonValue, required),
+        "additionalProperties": False,
+    }
+
+
+def _root_schema(properties: JsonObject, required: list[str], *, title: str) -> JsonObject:
+    schema = _object_schema(properties, required, title=title)
+    schema["$schema"] = SCHEMA_DIALECT
+    return schema
+
+
+SHA256_SCHEMA: JsonObject = {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+NONNEGATIVE_INTEGER_SCHEMA: JsonObject = {"type": "integer", "minimum": 0}
+NULLABLE_NONNEGATIVE_INTEGER_SCHEMA: JsonObject = {
+    "type": ["integer", "null"],
+    "minimum": 0,
+}
+NULLABLE_NUMBER_SCHEMA: JsonObject = {"type": ["number", "null"]}
+QUARANTINE_URI_SCHEMA: JsonObject = {
+    "type": "string",
+    "pattern": "^quarantine://sha256/[0-9a-f]{64}\\.(json|keras|npz)$",
+}
+PORTABLE_LOCATOR_SCHEMA: JsonObject = {
+    "anyOf": [
+        {
+            "type": "string",
+            "maxLength": 4096,
+            "not": {
+                "pattern": "(?:^[A-Za-z]:[\\\\/]|^/|^[Ff][Ii][Ll][Ee]:///|^\\\\\\\\)",
+            },
+        },
+        {"type": "null"},
+    ]
+}
+
+PORTABLE_COMPONENT_SCHEMA: JsonObject = _object_schema(
+    {
+        "path": {"type": "string", "pattern": "^[a-z0-9][a-z0-9_.-]*(/[a-z0-9_.-]+)*$"},
+        "bytes": NONNEGATIVE_INTEGER_SCHEMA,
+        "sha256": SHA256_SCHEMA,
+        "records": NONNEGATIVE_INTEGER_SCHEMA,
+    },
+    ["path", "bytes", "sha256"],
+    title="Portable component",
+)
+
+PUBLIC_COUNT_KEYS = (
+    "runs",
+    "runs_succeeded",
+    "runs_failed",
+    "runs_running",
+    "preprocessing_plans",
+    "promoted_models",
+    "attempts",
+    "annotations",
+    "annotated_attempts",
+    "unannotated_attempts",
+    "sessions",
+    "detections",
+    "segments",
+    "referenced_segments",
+    "orphan_segments",
+)
+PUBLIC_COUNTS_SCHEMA: JsonObject = _object_schema(
+    {key: NONNEGATIVE_INTEGER_SCHEMA for key in PUBLIC_COUNT_KEYS},
+    list(PUBLIC_COUNT_KEYS),
+    title="Public export counts",
+)
+
+PRIVATE_COUNT_KEYS = (
+    "attempts",
+    "annotations",
+    "annotated_attempts",
+    "unannotated_attempts",
+    "sessions",
+    "detections",
+    "segments",
+    "referenced_segments",
+    "orphan_segments",
+    "promoted_models",
+    "quarantine_objects",
+)
+PRIVATE_COUNTS_SCHEMA: JsonObject = _object_schema(
+    {key: NONNEGATIVE_INTEGER_SCHEMA for key in PRIVATE_COUNT_KEYS},
+    list(PRIVATE_COUNT_KEYS),
+    title="Private quarantine counts",
+)
+
+PUBLIC_MANIFEST_SCHEMA: JsonObject = _root_schema(
+    {
+        "schema_version": {"const": FORMAT_VERSION},
+        "kind": {"const": PUBLIC_KIND},
+        "source": _object_schema(
+            {
+                "head_commit": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+                "tree_object": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+                "audit_sha256": SHA256_SCHEMA,
+            },
+            ["head_commit", "tree_object", "audit_sha256"],
+            title="Legacy source anchor",
+        ),
+        "policy": _object_schema(
+            {
+                "data_role": {"const": DATA_ROLE},
+                "eligible_for_locked_test": {"const": False},
+                "contains_private_artifacts": {"const": False},
+                "durability": {"const": "local-only-pending-private-remote"},
+            },
+            [
+                "data_role",
+                "eligible_for_locked_test",
+                "contains_private_artifacts",
+                "durability",
+            ],
+            title="Legacy evidence policy",
+        ),
+        "counts": PUBLIC_COUNTS_SCHEMA,
+        "components": {"type": "array", "items": PORTABLE_COMPONENT_SCHEMA},
+    },
+    ["schema_version", "kind", "source", "policy", "counts", "components"],
+    title="SignLab public legacy export manifest",
+)
+
+ARTIFACT_LOCATOR_SCHEMA: JsonObject = _object_schema(
+    {
+        "registered_locator": PORTABLE_LOCATOR_SCHEMA,
+        "resolved_locator": PORTABLE_LOCATOR_SCHEMA,
+        "availability": {
+            "enum": ["available", "ambiguous", "missing", "not-recorded"],
+        },
+    },
+    ["registered_locator", "resolved_locator", "availability"],
+    title="Historical artifact locator",
+)
+
+RUN_CONFIGURATION_SCHEMA: JsonObject = _object_schema(
+    {
+        "model_settings": {"type": ["object", "null"]},
+        "global_settings": {"type": ["object", "null"]},
+        "data_locator": PORTABLE_LOCATOR_SCHEMA,
+        "sequence_length": NULLABLE_NONNEGATIVE_INTEGER_SCHEMA,
+        "test_fraction": {"type": ["number", "null"], "minimum": 0, "maximum": 1},
+        "validation_fraction": {
+            "type": ["number", "null"],
+            "minimum": 0,
+            "maximum": 1,
+        },
+        "batch_size": NULLABLE_NONNEGATIVE_INTEGER_SCHEMA,
+        "epochs": NULLABLE_NONNEGATIVE_INTEGER_SCHEMA,
+    },
+    [
+        "model_settings",
+        "global_settings",
+        "data_locator",
+        "sequence_length",
+        "test_fraction",
+        "validation_fraction",
+        "batch_size",
+        "epochs",
+    ],
+    title="Historical run configuration",
+)
+
+RUN_METRICS_SCHEMA: JsonObject = _object_schema(
+    {
+        "quick": {"type": ["object", "null"]},
+        "test_loss": NULLABLE_NUMBER_SCHEMA,
+        "test_accuracy": NULLABLE_NUMBER_SCHEMA,
+        "samples_train": NULLABLE_NONNEGATIVE_INTEGER_SCHEMA,
+        "samples_validation": NULLABLE_NONNEGATIVE_INTEGER_SCHEMA,
+        "samples_test": NULLABLE_NONNEGATIVE_INTEGER_SCHEMA,
+    },
+    [
+        "quick",
+        "test_loss",
+        "test_accuracy",
+        "samples_train",
+        "samples_validation",
+        "samples_test",
+    ],
+    title="Historical run metrics",
+)
+
+RUN_ARTIFACT_KEYS = (
+    "directory",
+    "model",
+    "label_map",
+    "configuration",
+    "history",
+    "predictions",
+    "metrics",
+)
+RUN_ARTIFACTS_SCHEMA: JsonObject = _object_schema(
+    {role: ARTIFACT_LOCATOR_SCHEMA for role in RUN_ARTIFACT_KEYS},
+    list(RUN_ARTIFACT_KEYS),
+    title="Historical run artifacts",
+)
+
+RUN_VALIDITY_SCHEMA: JsonObject = _object_schema(
+    {
+        "data_role": {"const": DATA_ROLE},
+        "eligible_for_locked_test": {"const": False},
+        "notes": {"type": "array", "minItems": 1, "items": {"type": "string"}},
+        "legacy_notes_present": {"type": "boolean"},
+        "legacy_error_present": {"type": "boolean"},
+    },
+    [
+        "data_role",
+        "eligible_for_locked_test",
+        "notes",
+        "legacy_notes_present",
+        "legacy_error_present",
+    ],
+    title="Historical run validity",
+)
+
+RUN_RECORD_KEYS = (
+    "record_id",
+    "run_name",
+    "source_run_id",
+    "started_at",
+    "finished_at",
+    "status",
+    "model_key",
+    "configuration",
+    "metrics",
+    "artifacts",
+    "validity",
+)
+RUN_RECORD_SCHEMA: JsonObject = _object_schema(
+    {
+        "record_id": {"type": "string", "pattern": "^run-[0-9]{6}$"},
+        "run_name": {"type": "string", "minLength": 1, "maxLength": 160},
+        "source_run_id": {"type": "string", "minLength": 1, "maxLength": 321},
+        "started_at": {"type": "string", "minLength": 1, "maxLength": 64},
+        "finished_at": {"type": ["string", "null"], "maxLength": 64},
+        "status": {"enum": ["succeeded", "failed", "running"]},
+        "model_key": {"type": "string", "minLength": 1, "maxLength": 160},
+        "configuration": RUN_CONFIGURATION_SCHEMA,
+        "metrics": RUN_METRICS_SCHEMA,
+        "artifacts": RUN_ARTIFACTS_SCHEMA,
+        "validity": RUN_VALIDITY_SCHEMA,
+    },
+    list(RUN_RECORD_KEYS),
+    title="Historical run record",
+)
+
+RUN_SHARD_SCHEMA: JsonObject = _root_schema(
+    {
+        "schema_version": {"const": FORMAT_VERSION},
+        "kind": {"const": "signlab.legacy-run-index"},
+        "shard": NONNEGATIVE_INTEGER_SCHEMA,
+        "records": {"type": "array", "items": RUN_RECORD_SCHEMA},
+    },
+    ["schema_version", "kind", "shard", "records"],
+    title="Legacy run-index shard",
+)
+
+PROMOTED_VALIDITY_SCHEMA: JsonObject = _object_schema(
+    {
+        "data_role": {"const": DATA_ROLE},
+        "eligible_for_locked_test": {"const": False},
+        "notes": {"type": "array", "minItems": 1, "items": {"type": "string"}},
+    },
+    ["data_role", "eligible_for_locked_test", "notes"],
+    title="Promoted artifact validity",
+)
+
+PROMOTED_MODEL_SCHEMA: JsonObject = _object_schema(
+    {
+        "bytes": NONNEGATIVE_INTEGER_SCHEMA,
+        "sha256": SHA256_SCHEMA,
+        "quarantine_uri": QUARANTINE_URI_SCHEMA,
+        "storage_status": {"const": "local-quarantine"},
+    },
+    ["bytes", "sha256", "quarantine_uri", "storage_status"],
+    title="Promoted model identity",
+)
+
+PROMOTED_LABEL_MAP_SCHEMA: JsonObject = _object_schema(
+    {
+        "bytes": NONNEGATIVE_INTEGER_SCHEMA,
+        "sha256": SHA256_SCHEMA,
+        "quarantine_uri": QUARANTINE_URI_SCHEMA,
+        "labels": {
+            "type": "object",
+            "propertyNames": {"pattern": "^[0-9]+$"},
+            "additionalProperties": {
+                "enum": ["hello", "no", "please", "thank you", "yes"],
+            },
+        },
+    },
+    ["bytes", "sha256", "quarantine_uri", "labels"],
+    title="Promoted label-map identity",
+)
+
+PROMOTED_ARTIFACT_ITEM_SCHEMA: JsonObject = _object_schema(
+    {
+        "run_id": {"type": "string", "minLength": 1, "maxLength": 160},
+        "model_key": {"type": "string", "minLength": 1, "maxLength": 160},
+        "preprocessing_plan": {"type": "string", "minLength": 1, "maxLength": 160},
+        "model": PROMOTED_MODEL_SCHEMA,
+        "label_map": PROMOTED_LABEL_MAP_SCHEMA,
+        "validity": PROMOTED_VALIDITY_SCHEMA,
+    },
+    ["run_id", "model_key", "preprocessing_plan", "model", "label_map", "validity"],
+    title="Promoted legacy artifact",
+)
+
+PROMOTED_ARTIFACT_SCHEMA: JsonObject = _root_schema(
+    {
+        "schema_version": {"const": FORMAT_VERSION},
+        "kind": {"const": "signlab.legacy-promoted-artifacts"},
+        "artifacts": {"type": "array", "items": PROMOTED_ARTIFACT_ITEM_SCHEMA},
+    },
+    ["schema_version", "kind", "artifacts"],
+    title="Promoted legacy artifacts",
+)
+
+PLAN_STEP_SCHEMA: JsonObject = _object_schema(
+    {
+        "key": {"type": "string", "minLength": 1},
+        "params": {"type": "object"},
+    },
+    ["key", "params"],
+    title="Historical preprocessing step",
+)
+
+PLAN_SCHEMA: JsonObject = _object_schema(
+    {
+        "name": {"type": "string", "minLength": 1},
+        "description": {"type": "string"},
+        "created_at": {"type": "string", "minLength": 1},
+        "updated_at": {"type": "string", "minLength": 1},
+        "steps": {"type": "array", "minItems": 1, "items": PLAN_STEP_SCHEMA},
+    },
+    ["name", "description", "created_at", "updated_at", "steps"],
+    title="Historical preprocessing plan",
+)
+
+PREPROCESSING_PLAN_SCHEMA: JsonObject = _root_schema(
+    {
+        "schema_version": {"const": FORMAT_VERSION},
+        "kind": {"const": "signlab.legacy-preprocessing-plans"},
+        "source_sha256": SHA256_SCHEMA,
+        "quarantine_uri": QUARANTINE_URI_SCHEMA,
+        "plans": {
+            "type": "object",
+            "minProperties": 1,
+            "additionalProperties": PLAN_SCHEMA,
+        },
+    },
+    ["schema_version", "kind", "source_sha256", "quarantine_uri", "plans"],
+    title="Historical preprocessing plans",
+)
+
+QUARANTINE_RECEIPT_POLICY_SCHEMA: JsonObject = _object_schema(
+    {
+        "data_role": {"const": DATA_ROLE},
+        "eligible_for_locked_test": {"const": False},
+        "publishable": {"const": False},
+        "durability": {"const": "local-only-pending-private-remote"},
+        "contains_individual_object_hashes": {"const": False},
+    },
+    [
+        "data_role",
+        "eligible_for_locked_test",
+        "publishable",
+        "durability",
+        "contains_individual_object_hashes",
+    ],
+    title="Public quarantine-receipt policy",
+)
+
+QUARANTINE_RECEIPT_SCHEMA: JsonObject = _root_schema(
+    {
+        "schema_version": {"const": FORMAT_VERSION},
+        "kind": {"const": "signlab.legacy-quarantine-receipt"},
+        "policy": QUARANTINE_RECEIPT_POLICY_SCHEMA,
+        "counts": PRIVATE_COUNTS_SCHEMA,
+        "components": {"type": "array", "items": PORTABLE_COMPONENT_SCHEMA},
+    },
+    ["schema_version", "kind", "policy", "counts", "components"],
+    title="Private quarantine receipt",
+)
+
+QUARANTINE_POLICY_SCHEMA: JsonObject = _object_schema(
+    {
+        "data_role": {"const": DATA_ROLE},
+        "eligible_for_locked_test": {"const": False},
+        "contains_private_artifacts": {"const": True},
+        "publishable": {"const": False},
+        "identifiers": {"const": "pseudonymized-ordinal"},
+        "timestamps": {"const": "live-records-relative-offsets-only"},
+    },
+    [
+        "data_role",
+        "eligible_for_locked_test",
+        "contains_private_artifacts",
+        "publishable",
+        "identifiers",
+        "timestamps",
+    ],
+    title="Private quarantine policy",
+)
+
+QUARANTINE_OBJECT_SCHEMA: JsonObject = _object_schema(
+    {
+        "uri": QUARANTINE_URI_SCHEMA,
+        "storage_key": {
+            "type": "string",
+            "pattern": "^objects/sha256/[0-9a-f]{64}\\.(json|keras|npz)$",
+        },
+        "bytes": NONNEGATIVE_INTEGER_SCHEMA,
+        "sha256": SHA256_SCHEMA,
+        "roles": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": True,
+            "items": {"type": "string", "minLength": 1},
+        },
+    },
+    ["uri", "storage_key", "bytes", "sha256", "roles"],
+    title="Content-addressed quarantine object",
+)
+
+QUARANTINE_MANIFEST_SCHEMA: JsonObject = _root_schema(
+    {
+        "schema_version": {"const": FORMAT_VERSION},
+        "kind": {"const": QUARANTINE_KIND},
+        "policy": QUARANTINE_POLICY_SCHEMA,
+        "counts": PRIVATE_COUNTS_SCHEMA,
+        "record_components": {"type": "array", "items": PORTABLE_COMPONENT_SCHEMA},
+        "objects": {"type": "array", "items": QUARANTINE_OBJECT_SCHEMA},
+    },
+    ["schema_version", "kind", "policy", "counts", "record_components", "objects"],
+    title="Private legacy quarantine manifest",
+)
+
+ATTEMPT_SCHEMA: JsonObject = _root_schema(
+    {
+        "record_id": {"type": "string", "pattern": "^attempt-[0-9]{6}$"},
+        "data_role": {"const": DATA_ROLE},
+        "start_offset_ms": NONNEGATIVE_INTEGER_SCHEMA,
+        "duration_ms": NULLABLE_NONNEGATIVE_INTEGER_SCHEMA,
+        "detected": {"type": "boolean"},
+        "intended_label": {
+            "anyOf": [
+                {"enum": ["hello", "no", "please", "thank you", "yes"]},
+                {"type": "null"},
+            ]
+        },
+        "predicted_label": {
+            "enum": ["NONE", "hello", "no", "nothing", "please", "thank you", "yes"],
+        },
+        "correct": {"type": ["boolean", "null"]},
+        "confidence": {"type": ["number", "null"], "minimum": 0, "maximum": 1},
+        "latency_ms": NULLABLE_NONNEGATIVE_INTEGER_SCHEMA,
+        "segment_frames": NULLABLE_NONNEGATIVE_INTEGER_SCHEMA,
+        "model_run_id": {"type": "string", "minLength": 1},
+        "segmentation": {"type": "object"},
+        "segment_uri": {"anyOf": [QUARANTINE_URI_SCHEMA, {"type": "null"}]},
+    },
+    [
+        "record_id",
+        "data_role",
+        "start_offset_ms",
+        "duration_ms",
+        "detected",
+        "intended_label",
+        "predicted_label",
+        "correct",
+        "confidence",
+        "latency_ms",
+        "segment_frames",
+        "model_run_id",
+        "segmentation",
+        "segment_uri",
+    ],
+    title="Sanitized live attempt",
+)
+
+ANNOTATION_SCHEMA: JsonObject = _root_schema(
+    {
+        "record_id": {"type": "string", "pattern": "^annotation-[0-9]{6}$"},
+        "attempt_ref": {"type": "string", "pattern": "^attempt-[0-9]{6}$"},
+        "data_role": {"const": DATA_ROLE},
+        "offset_ms": NONNEGATIVE_INTEGER_SCHEMA,
+        "feedback_type": {"enum": ["confirm", "missed", "wrong"]},
+        "corrected_label": {
+            "anyOf": [
+                {"enum": ["hello", "no", "please", "thank you", "yes"]},
+                {"type": "null"},
+            ]
+        },
+        "freeform_note_present": {"type": "boolean"},
+    },
+    [
+        "record_id",
+        "attempt_ref",
+        "data_role",
+        "offset_ms",
+        "feedback_type",
+        "corrected_label",
+        "freeform_note_present",
+    ],
+    title="Sanitized feedback annotation",
+)
+
+SESSION_SCHEMA: JsonObject = _root_schema(
+    {
+        "record_id": {"type": "string", "pattern": "^session-[0-9]{4}$"},
+        "data_role": {"const": DATA_ROLE},
+        "model_run_id": {"type": "string", "minLength": 1},
+        "start_offset_ms": NONNEGATIVE_INTEGER_SCHEMA,
+        "duration_ms": NULLABLE_NONNEGATIVE_INTEGER_SCHEMA,
+    },
+    ["record_id", "data_role", "model_run_id", "start_offset_ms", "duration_ms"],
+    title="Sanitized legacy feedback session",
+)
+
+DETECTION_SCHEMA: JsonObject = _root_schema(
+    {
+        "record_id": {"type": "string", "pattern": "^detection-[0-9]{6}$"},
+        "session_ref": {"type": "string", "pattern": "^session-[0-9]{4}$"},
+        "data_role": {"const": DATA_ROLE},
+        "offset_ms": NONNEGATIVE_INTEGER_SCHEMA,
+        "predicted_label": {
+            "anyOf": [
+                {"enum": ["hello", "no", "please", "thank you", "yes"]},
+                {"type": "null"},
+            ]
+        },
+        "actual_label": {
+            "anyOf": [
+                {"enum": ["hello", "no", "please", "thank you", "yes"]},
+                {"type": "null"},
+            ]
+        },
+        "confidence": {"type": ["number", "null"], "minimum": 0, "maximum": 1},
+        "correct": {"type": ["boolean", "null"]},
+    },
+    [
+        "record_id",
+        "session_ref",
+        "data_role",
+        "offset_ms",
+        "predicted_label",
+        "actual_label",
+        "confidence",
+        "correct",
+    ],
+    title="Sanitized legacy detection",
+)
+
+SCHEMAS: Final[dict[str, JsonObject]] = {
+    "annotation.schema.json": ANNOTATION_SCHEMA,
+    "detection.schema.json": DETECTION_SCHEMA,
+    "live-attempt.schema.json": ATTEMPT_SCHEMA,
+    "preprocessing-plans.schema.json": PREPROCESSING_PLAN_SCHEMA,
+    "promoted-artifacts.schema.json": PROMOTED_ARTIFACT_SCHEMA,
+    "public-manifest.schema.json": PUBLIC_MANIFEST_SCHEMA,
+    "quarantine-manifest.schema.json": QUARANTINE_MANIFEST_SCHEMA,
+    "quarantine-receipt.schema.json": QUARANTINE_RECEIPT_SCHEMA,
+    "run-index.schema.json": RUN_SHARD_SCHEMA,
+    "session.schema.json": SESSION_SCHEMA,
+}

--- a/src/signlab/legacy/validator.py
+++ b/src/signlab/legacy/validator.py
@@ -1,0 +1,734 @@
+"""Standalone validation for public legacy evidence and private quarantine bundles."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any, cast
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError, ValidationError
+
+from signlab.legacy.exporter import SENSITIVE_KEYS, LegacyExportError
+from signlab.legacy.schemas import (
+    DATA_ROLE,
+    FORMAT_VERSION,
+    PUBLIC_KIND,
+    QUARANTINE_KIND,
+    SCHEMAS,
+)
+
+type JsonObject = dict[str, object]
+
+MACHINE_PATH_PATTERNS = (
+    re.compile(rb"(?i)(?<![a-z0-9])[a-z]:[\\/]"),
+    re.compile(rb"(?i)(?:^|[\s\"'=(])/(?:users|home)/[^/\s]+(?:/|\\)"),
+    re.compile(rb"(?i)(?:\"|:\s*)/(?!/)[^\"\r\n]*"),
+    re.compile(rb"(?i)file:///(?:[a-z]:|users/|home/)"),
+    re.compile(rb"\\\\[^\\\s]+\\[^\\\s]+"),
+)
+RAW_UUID_PATTERN = re.compile(
+    rb"(?i)(?<![0-9a-f])(?:[0-9a-f]{32}|[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12})(?![0-9a-f])"
+)
+ABSOLUTE_TIMESTAMP_PATTERN = re.compile(rb"20[0-9]{2}-[0-9]{2}-[0-9]{2}T")
+FORBIDDEN_RECORD_KEYS = SENSITIVE_KEYS | {
+    "absolute_path",
+    "attempt_id",
+    "error",
+    "freeform_note",
+}
+
+
+@dataclass(frozen=True)
+class ValidationSummary:
+    """Counts proven by a successful export validation."""
+
+    runs: int
+    attempts: int
+    annotations: int
+    detections: int
+    sessions: int
+    quarantine_verified: bool
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _read_object(path: Path) -> JsonObject:
+    try:
+        value: Any = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise LegacyExportError("A legacy-export JSON component is unreadable.") from error
+    if not isinstance(value, dict) or not all(isinstance(key, str) for key in value):
+        raise LegacyExportError("A legacy-export JSON component is not an object.")
+    return cast(JsonObject, value)
+
+
+def _object(value: object, label: str) -> JsonObject:
+    if not isinstance(value, dict) or not all(isinstance(key, str) for key in value):
+        raise LegacyExportError(f"The legacy export has an invalid {label} object.")
+    return cast(JsonObject, value)
+
+
+def _array(value: object, label: str) -> list[object]:
+    if not isinstance(value, list):
+        raise LegacyExportError(f"The legacy export has an invalid {label} array.")
+    return cast(list[object], value)
+
+
+def _exact_keys(value: Mapping[str, object], expected: set[str], label: str) -> None:
+    if set(value) != expected:
+        raise LegacyExportError(f"The legacy export has unsupported {label} fields.")
+
+
+def _safe_relative(root: Path, value: object) -> Path:
+    if not isinstance(value, str):
+        raise LegacyExportError("A component path is not a string.")
+    portable = PurePosixPath(value)
+    if portable.is_absolute() or not portable.parts or ".." in portable.parts:
+        raise LegacyExportError("A component path is not portable.")
+    resolved_root = root.resolve()
+    candidate = (resolved_root / Path(portable.as_posix())).resolve()
+    try:
+        candidate.relative_to(resolved_root)
+    except ValueError as error:
+        raise LegacyExportError("A component path escapes its export root.") from error
+    return candidate
+
+
+def _validate_component(root: Path, raw: object) -> tuple[str, int | None]:
+    component = _object(raw, "component")
+    allowed = {"path", "bytes", "sha256", "records"}
+    if not set(component).issubset(allowed) or not {"path", "bytes", "sha256"}.issubset(component):
+        raise LegacyExportError("A legacy-export component has unsupported fields.")
+    path = _safe_relative(root, component["path"])
+    expected_bytes = component["bytes"]
+    expected_sha = component["sha256"]
+    if not isinstance(expected_bytes, int) or expected_bytes < 0:
+        raise LegacyExportError("A component byte count is invalid.")
+    if not isinstance(expected_sha, str) or re.fullmatch(r"[0-9a-f]{64}", expected_sha) is None:
+        raise LegacyExportError("A component digest is invalid.")
+    if not path.is_file():
+        raise LegacyExportError("A declared legacy-export component is missing.")
+    if path.stat().st_size != expected_bytes or _sha256(path) != expected_sha:
+        raise LegacyExportError("A legacy-export component failed its integrity check.")
+    records = component.get("records")
+    if records is not None and (not isinstance(records, int) or records < 0):
+        raise LegacyExportError("A component record count is invalid.")
+    return cast(str, component["path"]), records
+
+
+def _scan_portability(path: Path, *, reject_timestamps: bool) -> None:
+    content = path.read_bytes()
+    if any(pattern.search(content) for pattern in MACHINE_PATH_PATTERNS):
+        raise LegacyExportError("A legacy export exposes an absolute machine path.")
+    if RAW_UUID_PATTERN.search(content):
+        raise LegacyExportError("A legacy export exposes a raw UUID-like identifier.")
+    if reject_timestamps and ABSOLUTE_TIMESTAMP_PATTERN.search(content):
+        raise LegacyExportError("A quarantine record exposes an absolute timestamp.")
+
+
+def _walk_keys(value: object) -> Iterable[str]:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            yield str(key)
+            yield from _walk_keys(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _walk_keys(child)
+
+
+def _has_forbidden_record_key(value: object) -> bool:
+    return bool(FORBIDDEN_RECORD_KEYS & {key.casefold() for key in _walk_keys(value)})
+
+
+def _schema_is_closed(value: object) -> bool:
+    if isinstance(value, dict):
+        if (
+            value.get("type") == "object"
+            and "properties" in value
+            and value.get("additionalProperties") is not False
+        ):
+            return False
+        return all(_schema_is_closed(child) for child in value.values())
+    if isinstance(value, list):
+        return all(_schema_is_closed(child) for child in value)
+    return True
+
+
+def _validate_schema_instance(value: object, schema_name: str, label: str) -> None:
+    schema = SCHEMAS[schema_name]
+    try:
+        Draft202012Validator.check_schema(schema)
+        Draft202012Validator(schema).validate(value)
+    except (SchemaError, ValidationError) as error:
+        raise LegacyExportError(f"The legacy export has an invalid {label} contract.") from error
+
+
+def _read_jsonl(path: Path) -> list[JsonObject]:
+    records: list[JsonObject] = []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+        for line in lines:
+            value: Any = json.loads(line)
+            if not isinstance(value, dict) or not all(isinstance(key, str) for key in value):
+                raise LegacyExportError("A quarantine JSON Lines record is not an object.")
+            records.append(cast(JsonObject, value))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise LegacyExportError("A quarantine JSON Lines component is unreadable.") from error
+    return records
+
+
+def _validate_public(
+    public_root: Path,
+) -> tuple[JsonObject, JsonObject, JsonObject, JsonObject, int, dict[str, str]]:
+    manifest = _read_object(public_root / "manifest.json")
+    _validate_schema_instance(manifest, "public-manifest.schema.json", "public manifest")
+    _exact_keys(
+        manifest,
+        {"schema_version", "kind", "source", "policy", "counts", "components"},
+        "public manifest",
+    )
+    if manifest["schema_version"] != FORMAT_VERSION or manifest["kind"] != PUBLIC_KIND:
+        raise LegacyExportError("The public legacy-export format is unsupported.")
+    policy = _object(manifest["policy"], "public policy")
+    if policy.get("data_role") != DATA_ROLE or policy.get("eligible_for_locked_test") is not False:
+        raise LegacyExportError("The public legacy evidence has an unsafe data policy.")
+    if policy.get("contains_private_artifacts") is not False:
+        raise LegacyExportError("The public legacy evidence claims private artifact content.")
+
+    component_paths: set[str] = set()
+    component_records: dict[str, int | None] = {}
+    public_documents: list[JsonObject] = [manifest]
+    run_ids: list[object] = []
+    source_runs: dict[str, str] = {}
+    shard_numbers: list[object] = []
+    run_count = 0
+    status_counts: dict[str, int] = {"succeeded": 0, "failed": 0, "running": 0}
+    for raw_component in _array(manifest["components"], "public components"):
+        relative, declared_records = _validate_component(public_root, raw_component)
+        if relative in component_paths:
+            raise LegacyExportError("The public manifest declares a component twice.")
+        component_paths.add(relative)
+        component_records[relative] = declared_records
+        component_path = public_root / relative
+        _scan_portability(component_path, reject_timestamps=False)
+        if relative.startswith("runs/"):
+            shard = _read_object(component_path)
+            public_documents.append(shard)
+            _validate_schema_instance(shard, "run-index.schema.json", "run index")
+            _exact_keys(shard, {"schema_version", "kind", "shard", "records"}, "run shard")
+            if shard["schema_version"] != FORMAT_VERSION or shard["kind"] != (
+                "signlab.legacy-run-index"
+            ):
+                raise LegacyExportError("A run-index shard has an unsupported format.")
+            shard_number = shard["shard"]
+            if (
+                not isinstance(shard_number, int)
+                or relative != f"runs/runs-{shard_number:03d}.json"
+            ):
+                raise LegacyExportError("A run-index shard has an inconsistent identity.")
+            shard_numbers.append(shard_number)
+            records = _array(shard["records"], "run records")
+            if declared_records != len(records):
+                raise LegacyExportError("A run shard count does not match its manifest.")
+            for raw_record in records:
+                record = _object(raw_record, "run record")
+                _exact_keys(
+                    record,
+                    {
+                        "record_id",
+                        "run_name",
+                        "source_run_id",
+                        "started_at",
+                        "finished_at",
+                        "status",
+                        "model_key",
+                        "configuration",
+                        "metrics",
+                        "artifacts",
+                        "validity",
+                    },
+                    "run record",
+                )
+                status = record["status"]
+                if not isinstance(status, str):
+                    raise LegacyExportError("A run status is invalid.")
+                status_counts[status] = status_counts.get(status, 0) + 1
+                run_ids.append(record["record_id"])
+                source_run_id = record["source_run_id"]
+                if not isinstance(source_run_id, str):
+                    raise LegacyExportError("A source run identity is invalid.")
+                model_key = record["model_key"]
+                if not isinstance(model_key, str):
+                    raise LegacyExportError("A run model key is invalid.")
+                if source_run_id in source_runs:
+                    raise LegacyExportError("The run-index source identities are not unique.")
+                source_runs[source_run_id] = model_key
+            run_count += len(records)
+
+    if shard_numbers != list(range(len(shard_numbers))):
+        raise LegacyExportError("The run-index shard sequence is incomplete or unordered.")
+    expected_run_ids = [f"run-{index:06d}" for index in range(1, run_count + 1)]
+    if run_ids != expected_run_ids:
+        raise LegacyExportError("The run-index record sequence is incomplete or unordered.")
+    actual_files = {
+        path.relative_to(public_root).as_posix()
+        for path in public_root.rglob("*")
+        if path.is_file()
+    }
+    if actual_files != component_paths | {"manifest.json"}:
+        raise LegacyExportError("The public export has undeclared or missing files.")
+    _scan_portability(public_root / "manifest.json", reject_timestamps=False)
+    for name, expected_schema in SCHEMAS.items():
+        schema_path = public_root / "schemas" / name
+        schema = _read_object(schema_path)
+        try:
+            Draft202012Validator.check_schema(schema)
+        except SchemaError as error:
+            raise LegacyExportError("A legacy-export schema is invalid.") from error
+        if schema != expected_schema or not _schema_is_closed(schema):
+            raise LegacyExportError("A legacy-export schema is open or has drifted.")
+
+    counts = _object(manifest["counts"], "public counts")
+    expected_status_counts = {
+        "runs_succeeded": status_counts.get("succeeded", 0),
+        "runs_failed": status_counts.get("failed", 0),
+        "runs_running": status_counts.get("running", 0),
+    }
+    if counts.get("runs") != run_count or any(
+        counts.get(key) != value for key, value in expected_status_counts.items()
+    ):
+        raise LegacyExportError("The public run counts do not reconcile.")
+    receipt = _read_object(public_root / "quarantine-receipt.json")
+    public_documents.append(receipt)
+    _validate_schema_instance(receipt, "quarantine-receipt.schema.json", "quarantine receipt")
+    if receipt.get("kind") != "signlab.legacy-quarantine-receipt":
+        raise LegacyExportError("The quarantine receipt has an unsupported format.")
+    promoted = _read_object(public_root / "promoted-artifacts.json")
+    public_documents.append(promoted)
+    _validate_schema_instance(
+        promoted,
+        "promoted-artifacts.schema.json",
+        "promoted artifacts",
+    )
+    plans = _read_object(public_root / "preprocessing-plans.json")
+    public_documents.append(plans)
+    _validate_schema_instance(
+        plans,
+        "preprocessing-plans.schema.json",
+        "preprocessing plans",
+    )
+    plans_uri = plans.get("quarantine_uri")
+    plans_digest = plans.get("source_sha256")
+    if not isinstance(plans_uri, str) or not isinstance(plans_digest, str):
+        raise LegacyExportError("The preprocessing-plan identity is invalid.")
+    if plans_uri != f"quarantine://sha256/{plans_digest}.json":
+        raise LegacyExportError("The preprocessing-plan URI does not match its digest.")
+    plan_names = set(_object(plans["plans"], "preprocessing plans"))
+    promoted_artifacts = _array(promoted["artifacts"], "promoted artifacts")
+    promoted_run_ids: set[str] = set()
+    promoted_model_keys: set[str] = set()
+    for raw_artifact in promoted_artifacts:
+        artifact = _object(raw_artifact, "promoted artifact")
+        run_id = artifact.get("run_id")
+        model_key = artifact.get("model_key")
+        if not isinstance(run_id, str) or not isinstance(model_key, str):
+            raise LegacyExportError("A promoted model identity is invalid.")
+        if run_id in promoted_run_ids or model_key in promoted_model_keys:
+            raise LegacyExportError("A promoted model identity is duplicated.")
+        promoted_run_ids.add(run_id)
+        promoted_model_keys.add(model_key)
+        if source_runs.get(run_id) != model_key:
+            raise LegacyExportError("A promoted model does not match its indexed run.")
+        if artifact.get("preprocessing_plan") not in plan_names:
+            raise LegacyExportError("A promoted model references an unknown preprocessing plan.")
+        for role in ("model", "label_map"):
+            identity = _object(artifact[role], f"promoted {role}")
+            digest = identity.get("sha256")
+            uri = identity.get("quarantine_uri")
+            if not isinstance(digest, str) or not isinstance(uri, str):
+                raise LegacyExportError("A promoted artifact identity is invalid.")
+            suffix = "keras" if role == "model" else "json"
+            if uri != f"quarantine://sha256/{digest}.{suffix}":
+                raise LegacyExportError("A promoted artifact URI does not match its digest.")
+    if component_records.get("promoted-artifacts.json") != len(promoted_artifacts):
+        raise LegacyExportError("The promoted-artifact component count does not reconcile.")
+    if component_records.get("preprocessing-plans.json") != len(plan_names):
+        raise LegacyExportError("The preprocessing-plan component count does not reconcile.")
+    if counts.get("promoted_models") != len(promoted_artifacts) or counts.get(
+        "preprocessing_plans"
+    ) != len(plan_names):
+        raise LegacyExportError("The public artifact counts do not reconcile.")
+
+    receipt_counts = _object(receipt["counts"], "receipt counts")
+    for key, value in receipt_counts.items():
+        if key != "quarantine_objects" and counts.get(key) != value:
+            raise LegacyExportError("The public manifest and quarantine receipt disagree.")
+    receipt_paths = {
+        _object(raw, "receipt component").get("path")
+        for raw in _array(receipt["components"], "receipt components")
+    }
+    expected_receipt_paths = {
+        "manifest.json",
+        "records/attempts.jsonl",
+        "records/annotations.jsonl",
+        "records/sessions.jsonl",
+        "records/detections.jsonl",
+    }
+    if receipt_paths != expected_receipt_paths:
+        raise LegacyExportError("The quarantine receipt component set is incomplete.")
+    for document in public_documents:
+        if _has_forbidden_record_key(document):
+            raise LegacyExportError("The public export exposes a forbidden private field.")
+    return manifest, receipt, promoted, plans, run_count, source_runs
+
+
+def _validate_record_keys(record: JsonObject, kind: str) -> None:
+    expected = {
+        "attempt": {
+            "record_id",
+            "data_role",
+            "start_offset_ms",
+            "duration_ms",
+            "detected",
+            "intended_label",
+            "predicted_label",
+            "correct",
+            "confidence",
+            "latency_ms",
+            "segment_frames",
+            "model_run_id",
+            "segmentation",
+            "segment_uri",
+        },
+        "annotation": {
+            "record_id",
+            "attempt_ref",
+            "data_role",
+            "offset_ms",
+            "feedback_type",
+            "corrected_label",
+            "freeform_note_present",
+        },
+        "session": {
+            "record_id",
+            "data_role",
+            "model_run_id",
+            "start_offset_ms",
+            "duration_ms",
+        },
+        "detection": {
+            "record_id",
+            "session_ref",
+            "data_role",
+            "offset_ms",
+            "predicted_label",
+            "actual_label",
+            "confidence",
+            "correct",
+        },
+    }[kind]
+    _exact_keys(record, expected, kind)
+    if record.get("data_role") != DATA_ROLE:
+        raise LegacyExportError("A quarantine record has an unsafe data role.")
+
+
+def _validate_quarantine(
+    quarantine_root: Path,
+    receipt: JsonObject,
+    promoted: JsonObject,
+    plans: JsonObject,
+    source_runs: dict[str, str],
+) -> tuple[int, int, int, int]:
+    _validate_schema_instance(receipt, "quarantine-receipt.schema.json", "quarantine receipt")
+    receipt_components = _array(receipt.get("components"), "receipt components")
+    receipt_by_path: dict[str, JsonObject] = {}
+    for raw_component in receipt_components:
+        relative, _ = _validate_component(quarantine_root, raw_component)
+        component = _object(raw_component, "receipt component")
+        if relative in receipt_by_path:
+            raise LegacyExportError("The quarantine receipt declares a component twice.")
+        receipt_by_path[relative] = component
+    manifest = _read_object(quarantine_root / "manifest.json")
+    _validate_schema_instance(
+        manifest,
+        "quarantine-manifest.schema.json",
+        "quarantine manifest",
+    )
+    _exact_keys(
+        manifest,
+        {"schema_version", "kind", "policy", "counts", "record_components", "objects"},
+        "quarantine manifest",
+    )
+    if manifest["schema_version"] != FORMAT_VERSION or manifest["kind"] != QUARANTINE_KIND:
+        raise LegacyExportError("The private quarantine format is unsupported.")
+    policy = _object(manifest["policy"], "quarantine policy")
+    if policy.get("data_role") != DATA_ROLE or policy.get("eligible_for_locked_test") is not False:
+        raise LegacyExportError("The private quarantine has an unsafe data policy.")
+    if policy.get("publishable") is not False:
+        raise LegacyExportError("The private quarantine is incorrectly marked publishable.")
+    if receipt_by_path.get("manifest.json") is None:
+        raise LegacyExportError("The quarantine receipt does not anchor its manifest.")
+
+    component_records: dict[str, list[JsonObject]] = {}
+    declared_record_files: set[str] = set()
+    for raw_component in _array(manifest["record_components"], "record components"):
+        relative, declared_count = _validate_component(quarantine_root, raw_component)
+        declared_record_files.add(relative)
+        path = quarantine_root / relative
+        _scan_portability(path, reject_timestamps=True)
+        records = _read_jsonl(path)
+        if declared_count != len(records):
+            raise LegacyExportError("A quarantine record count does not match its manifest.")
+        component_records[relative] = records
+
+    expected_record_files = {
+        "records/attempts.jsonl",
+        "records/annotations.jsonl",
+        "records/sessions.jsonl",
+        "records/detections.jsonl",
+    }
+    if declared_record_files != expected_record_files:
+        raise LegacyExportError("The quarantine record set is incomplete.")
+    if set(receipt_by_path) != expected_record_files | {"manifest.json"}:
+        raise LegacyExportError("The quarantine receipt component set is incomplete.")
+    for raw_component in _array(manifest["record_components"], "record components"):
+        component = _object(raw_component, "record component")
+        record_path_value = component.get("path")
+        if (
+            not isinstance(record_path_value, str)
+            or receipt_by_path.get(record_path_value) != component
+        ):
+            raise LegacyExportError("The quarantine receipt and manifest disagree.")
+    attempts = component_records["records/attempts.jsonl"]
+    annotations = component_records["records/annotations.jsonl"]
+    sessions = component_records["records/sessions.jsonl"]
+    detections = component_records["records/detections.jsonl"]
+    for record in attempts:
+        _validate_schema_instance(record, "live-attempt.schema.json", "live attempt")
+        _validate_record_keys(record, "attempt")
+    for record in annotations:
+        _validate_schema_instance(record, "annotation.schema.json", "annotation")
+        _validate_record_keys(record, "annotation")
+    for record in sessions:
+        _validate_schema_instance(record, "session.schema.json", "session")
+        _validate_record_keys(record, "session")
+    for record in detections:
+        _validate_schema_instance(record, "detection.schema.json", "detection")
+        _validate_record_keys(record, "detection")
+    if any(record.get("model_run_id") not in source_runs for record in [*attempts, *sessions]):
+        raise LegacyExportError("A live record references an unknown model run.")
+    if any(
+        _has_forbidden_record_key(record)
+        for record in [*attempts, *annotations, *sessions, *detections]
+    ):
+        raise LegacyExportError("A quarantine record exposes a forbidden private field.")
+    record_sequences = (
+        (attempts, "attempt", 6),
+        (annotations, "annotation", 6),
+        (sessions, "session", 4),
+        (detections, "detection", 6),
+    )
+    for records, prefix, width in record_sequences:
+        expected_ids = [f"{prefix}-{index:0{width}d}" for index in range(1, len(records) + 1)]
+        if [record.get("record_id") for record in records] != expected_ids:
+            raise LegacyExportError("A quarantine record sequence is incomplete or unordered.")
+    attempt_ids = {record.get("record_id") for record in attempts}
+    if len(attempt_ids) != len(attempts) or any(
+        record.get("attempt_ref") not in attempt_ids for record in annotations
+    ):
+        raise LegacyExportError("Quarantine annotations do not reconcile to attempts.")
+    session_ids = {record.get("record_id") for record in sessions}
+    if len(session_ids) != len(sessions) or any(
+        record.get("session_ref") not in session_ids for record in detections
+    ):
+        raise LegacyExportError("Quarantine detections do not reconcile to sessions.")
+
+    object_paths: set[str] = set()
+    object_uris: set[str] = set()
+    objects_by_uri: dict[str, JsonObject] = {}
+    for raw_object in _array(manifest["objects"], "quarantine objects"):
+        item = _object(raw_object, "quarantine object")
+        _exact_keys(item, {"uri", "storage_key", "bytes", "sha256", "roles"}, "object")
+        uri = item["uri"]
+        digest = item["sha256"]
+        if not isinstance(uri, str) or not isinstance(digest, str):
+            raise LegacyExportError("A quarantine object identity is invalid.")
+        if re.fullmatch(r"quarantine://sha256/[0-9a-f]{64}\.(json|keras|npz)", uri) is None:
+            raise LegacyExportError("A quarantine object URI is invalid.")
+        path = _safe_relative(quarantine_root, item["storage_key"])
+        expected_bytes = item["bytes"]
+        if not isinstance(expected_bytes, int) or expected_bytes < 0:
+            raise LegacyExportError("A quarantine object byte count is invalid.")
+        if (
+            not isinstance(digest, str)
+            or uri != (f"quarantine://sha256/{digest}{path.suffix}")
+            or path.name != f"{digest}{path.suffix}"
+        ):
+            raise LegacyExportError("A quarantine object identity is inconsistent.")
+        if not path.is_file() or path.stat().st_size != expected_bytes or _sha256(path) != digest:
+            raise LegacyExportError("A quarantine object failed its integrity check.")
+        object_paths.add(path.relative_to(quarantine_root).as_posix())
+        object_uris.add(uri)
+        objects_by_uri[uri] = item
+    if len(objects_by_uri) != len(_array(manifest["objects"], "quarantine objects")):
+        raise LegacyExportError("The quarantine manifest declares a duplicate object.")
+    quarantined_json: dict[str, JsonObject] = {}
+    for uri, item in objects_by_uri.items():
+        if not uri.endswith(".json"):
+            continue
+        path = _safe_relative(quarantine_root, item["storage_key"])
+        _scan_portability(path, reject_timestamps=False)
+        document = _read_object(path)
+        if _has_forbidden_record_key(document):
+            raise LegacyExportError("A quarantined JSON object exposes a private field.")
+        quarantined_json[uri] = document
+    referenced_uris = {
+        cast(str, record["segment_uri"])
+        for record in attempts
+        if record.get("segment_uri") is not None
+    }
+    if not referenced_uris.issubset(object_uris):
+        raise LegacyExportError("A live attempt references a missing quarantine object.")
+    for uri in referenced_uris:
+        roles = _array(objects_by_uri[uri].get("roles"), "quarantine roles")
+        if "live-attempt-segment" not in roles:
+            raise LegacyExportError("A live segment object has an inconsistent role.")
+
+    expected_public_objects: list[tuple[str, str, int | None, str]] = []
+    for raw_artifact in _array(promoted["artifacts"], "promoted artifacts"):
+        artifact = _object(raw_artifact, "promoted artifact")
+        model_key = artifact["model_key"]
+        if not isinstance(model_key, str):
+            raise LegacyExportError("A promoted artifact model key is invalid.")
+        for role in ("model", "label_map"):
+            identity = _object(artifact[role], f"promoted {role}")
+            uri = identity["quarantine_uri"]
+            digest = identity["sha256"]
+            byte_count = identity["bytes"]
+            if not isinstance(uri, str) or not isinstance(digest, str):
+                raise LegacyExportError("A promoted artifact identity is invalid.")
+            if not isinstance(byte_count, int):
+                raise LegacyExportError("A promoted artifact byte count is invalid.")
+            quarantine_role = "promoted-model" if role == "model" else "promoted-label-map"
+            expected_public_objects.append(
+                (uri, digest, byte_count, f"{quarantine_role}:{model_key}")
+            )
+    plan_uri = plans["quarantine_uri"]
+    plan_digest = plans["source_sha256"]
+    if not isinstance(plan_uri, str) or not isinstance(plan_digest, str):
+        raise LegacyExportError("The preprocessing-plan identity is invalid.")
+    expected_public_objects.append((plan_uri, plan_digest, None, "preprocessing-plan-registry"))
+    for uri, digest, byte_count, role in expected_public_objects:
+        stored_object = objects_by_uri.get(uri)
+        if stored_object is None or stored_object.get("sha256") != digest:
+            raise LegacyExportError("A public artifact is absent from the private quarantine.")
+        if byte_count is not None and stored_object.get("bytes") != byte_count:
+            raise LegacyExportError("A public artifact byte count does not match quarantine.")
+        if role not in _array(stored_object.get("roles"), "quarantine roles"):
+            raise LegacyExportError("A public artifact has an inconsistent quarantine role.")
+    public_plans = _object(plans["plans"], "preprocessing plans")
+    if quarantined_json.get(plan_uri) != public_plans:
+        raise LegacyExportError("The public preprocessing plans do not match quarantine.")
+    for raw_artifact in _array(promoted["artifacts"], "promoted artifacts"):
+        artifact = _object(raw_artifact, "promoted artifact")
+        label_map = _object(artifact["label_map"], "promoted label map")
+        label_uri = label_map["quarantine_uri"]
+        if not isinstance(label_uri, str) or quarantined_json.get(label_uri) != label_map.get(
+            "labels"
+        ):
+            raise LegacyExportError("A public label map does not match quarantine.")
+
+    actual_files = {
+        path.relative_to(quarantine_root).as_posix()
+        for path in quarantine_root.rglob("*")
+        if path.is_file()
+    }
+    expected_files = {"manifest.json"} | declared_record_files | object_paths
+    if actual_files != expected_files:
+        raise LegacyExportError("The quarantine has undeclared or missing files.")
+    _scan_portability(quarantine_root / "manifest.json", reject_timestamps=True)
+
+    counts = _object(manifest["counts"], "quarantine counts")
+    object_items = list(objects_by_uri.values())
+    segment_objects = [item for item in object_items if cast(str, item["uri"]).endswith(".npz")]
+    referenced_segment_objects = [
+        item
+        for item in segment_objects
+        if "live-attempt-segment" in _array(item.get("roles"), "quarantine roles")
+    ]
+    orphan_segment_objects = [
+        item
+        for item in segment_objects
+        if "orphan-live-segment" in _array(item.get("roles"), "quarantine roles")
+    ]
+    if len(segment_objects) != len(referenced_segment_objects) + len(orphan_segment_objects):
+        raise LegacyExportError("The quarantined segment roles do not reconcile.")
+    expected_counts = {
+        "attempts": len(attempts),
+        "annotations": len(annotations),
+        "sessions": len(sessions),
+        "detections": len(detections),
+        "annotated_attempts": len({record["attempt_ref"] for record in annotations}),
+        "unannotated_attempts": len(attempts)
+        - len({record["attempt_ref"] for record in annotations}),
+        "quarantine_objects": len(object_uris),
+        "segments": len(segment_objects),
+        "referenced_segments": len(referenced_segment_objects),
+        "orphan_segments": len(orphan_segment_objects),
+        "promoted_models": len(_array(promoted["artifacts"], "promoted artifacts")),
+    }
+    if any(counts.get(key) != value for key, value in expected_counts.items()):
+        raise LegacyExportError("The quarantine aggregate counts do not reconcile.")
+    receipt_counts = _object(receipt.get("counts"), "receipt counts")
+    if receipt_counts != counts:
+        raise LegacyExportError("The public receipt does not match the private quarantine.")
+    return len(attempts), len(annotations), len(detections), len(sessions)
+
+
+def validate_legacy_export(
+    *,
+    public_root: Path,
+    quarantine_root: Path | None = None,
+) -> ValidationSummary:
+    """Validate a committed public export and, optionally, its private quarantine."""
+    if not public_root.is_dir():
+        raise LegacyExportError("The public legacy export is unavailable.")
+    manifest, receipt, promoted, plans, runs, source_runs = _validate_public(public_root.resolve())
+    counts = _object(manifest["counts"], "public counts")
+    attempts = cast(int, counts.get("attempts", 0))
+    annotations = cast(int, counts.get("annotations", 0))
+    detections = cast(int, counts.get("detections", 0))
+    sessions = cast(int, counts.get("sessions", 0))
+    quarantine_verified = False
+    if quarantine_root is not None:
+        if not quarantine_root.is_dir():
+            raise LegacyExportError("The private legacy quarantine is unavailable.")
+        private_counts = _validate_quarantine(
+            quarantine_root.resolve(),
+            receipt,
+            promoted,
+            plans,
+            source_runs,
+        )
+        if private_counts != (attempts, annotations, detections, sessions):
+            raise LegacyExportError("Public and private legacy counts do not reconcile.")
+        quarantine_verified = True
+    return ValidationSummary(
+        runs=runs,
+        attempts=attempts,
+        annotations=annotations,
+        detections=detections,
+        sessions=sessions,
+        quarantine_verified=quarantine_verified,
+    )

--- a/tests/test_legacy_cli.py
+++ b/tests/test_legacy_cli.py
@@ -1,0 +1,184 @@
+"""CLI behavior for exporting and validating legacy evidence."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from signlab import cli
+from signlab.commands import data
+from signlab.legacy.exporter import ExportSummary, LegacyExportError
+from signlab.legacy.validator import ValidationSummary
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner(env={"NO_COLOR": "1"})
+
+
+@pytest.fixture
+def export_arguments(tmp_path: Path) -> tuple[list[str], dict[str, Path]]:
+    legacy_root = tmp_path / "legacy"
+    legacy_root.mkdir()
+    audit_snapshot = tmp_path / "legacy-state.json"
+    audit_snapshot.write_text("{}\n", encoding="utf-8")
+    paths = {
+        "legacy_root": legacy_root,
+        "audit_snapshot": audit_snapshot,
+        "public_output": tmp_path / "public",
+        "quarantine_output": tmp_path / "private",
+    }
+    arguments = [
+        "data",
+        "export-legacy",
+        "--legacy-root",
+        str(legacy_root),
+        "--audit-snapshot",
+        str(audit_snapshot),
+        "--public-output",
+        str(paths["public_output"]),
+        "--quarantine-output",
+        str(paths["quarantine_output"]),
+    ]
+    return arguments, paths
+
+
+def test_export_legacy_reports_counts_and_passes_resolved_paths(
+    runner: CliRunner,
+    export_arguments: tuple[list[str], dict[str, Path]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    arguments, expected_paths = export_arguments
+    received: dict[str, Path] = {}
+
+    def fake_export(
+        *,
+        legacy_root: Path,
+        audit_snapshot: Path,
+        public_output: Path,
+        quarantine_output: Path,
+    ) -> ExportSummary:
+        received.update(
+            legacy_root=legacy_root,
+            audit_snapshot=audit_snapshot,
+            public_output=public_output,
+            quarantine_output=quarantine_output,
+        )
+        return ExportSummary(
+            runs=464,
+            attempts=532,
+            annotations=408,
+            detections=45,
+            sessions=5,
+            promoted_models=4,
+            quarantined_segments=529,
+            quarantine_objects=535,
+        )
+
+    monkeypatch.setattr(data, "export_legacy_evidence", fake_export)
+
+    result = runner.invoke(cli.app, arguments)
+
+    assert result.exit_code == 0
+    assert received == {name: path.resolve() for name, path in expected_paths.items()}
+    assert result.output.strip() == (
+        "Legacy export complete: 464 runs, 532 attempts, 4 promoted models, "
+        "529 quarantined segments."
+    )
+
+
+def test_export_legacy_returns_a_stable_failure(
+    runner: CliRunner,
+    export_arguments: tuple[list[str], dict[str, Path]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    arguments, _ = export_arguments
+
+    def fail_export(**_kwargs: Path) -> ExportSummary:
+        raise LegacyExportError("The audited source changed.")
+
+    monkeypatch.setattr(data, "export_legacy_evidence", fail_export)
+
+    result = runner.invoke(cli.app, arguments)
+
+    assert result.exit_code == 1
+    assert result.output.strip() == "Legacy export failed: The audited source changed."
+    assert result.exception is not None
+
+
+@pytest.mark.parametrize("with_quarantine", [False, True])
+def test_validate_legacy_reports_public_and_optional_private_verification(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    with_quarantine: bool,
+) -> None:
+    public_root = tmp_path / "public"
+    public_root.mkdir()
+    quarantine_root = tmp_path / "private"
+    quarantine_root.mkdir()
+    received: dict[str, Path | None] = {}
+
+    def fake_validate(
+        *,
+        public_root: Path,
+        quarantine_root: Path | None,
+    ) -> ValidationSummary:
+        received.update(public_root=public_root, quarantine_root=quarantine_root)
+        return ValidationSummary(
+            runs=464,
+            attempts=532,
+            annotations=408,
+            detections=45,
+            sessions=5,
+            quarantine_verified=quarantine_root is not None,
+        )
+
+    monkeypatch.setattr(data, "validate_legacy_export", fake_validate)
+    arguments = ["data", "validate-legacy", "--public-root", str(public_root)]
+    if with_quarantine:
+        arguments.extend(["--quarantine-root", str(quarantine_root)])
+
+    result = runner.invoke(cli.app, arguments)
+
+    expected_quarantine = quarantine_root.resolve() if with_quarantine else None
+    assert result.exit_code == 0
+    assert received == {
+        "public_root": public_root.resolve(),
+        "quarantine_root": expected_quarantine,
+    }
+    suffix = " and private quarantine" if with_quarantine else ""
+    assert result.output.strip() == f"Validated 464 runs and 532 attempts{suffix}."
+
+
+def test_validate_legacy_returns_a_stable_failure(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    public_root = tmp_path / "public"
+    public_root.mkdir()
+
+    def fail_validation(
+        *,
+        public_root: Path,
+        quarantine_root: Path | None,
+    ) -> ValidationSummary:
+        del public_root, quarantine_root
+        raise LegacyExportError("A declared component failed its integrity check.")
+
+    monkeypatch.setattr(data, "validate_legacy_export", fail_validation)
+
+    result = runner.invoke(
+        cli.app,
+        ["data", "validate-legacy", "--public-root", str(public_root)],
+    )
+
+    assert result.exit_code == 1
+    assert result.output.strip() == (
+        "Legacy export validation failed: A declared component failed its integrity check."
+    )
+    assert result.exception is not None

--- a/tests/test_legacy_defensive.py
+++ b/tests/test_legacy_defensive.py
@@ -1,0 +1,410 @@
+"""Defensive-path tests for legacy export trust boundaries."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime
+from pathlib import Path, PurePosixPath
+from typing import cast
+
+import pytest
+
+from signlab.legacy import exporter, validator
+from signlab.legacy.exporter import LegacyExportError
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, None),
+        ("", None),
+        ("data/results/run/model.keras", "legacy://data/results/run/model.keras"),
+        ("relative/folder", "legacy-relative://relative/folder"),
+        (
+            "orientation/scale is intentionally plain prose",
+            "orientation/scale is intentionally plain prose",
+        ),
+        ("plain-token", "plain-token"),
+        ("/opt/private/model.keras", "redacted://nonportable-path"),
+        ("../private/model.keras", "redacted://nonportable-path"),
+    ],
+)
+def test_portable_locator_classifies_historical_values(
+    value: str | None,
+    expected: str | None,
+) -> None:
+    assert exporter._portable_locator(value) == expected
+
+
+def test_portable_locator_recognizes_windows_paths_without_leaking_them() -> None:
+    known = "D" + ":" + r"\archive\data\results\run\model.keras"
+    private = "D" + ":" + r"\private\model.keras"
+
+    assert exporter._portable_locator(known) == "legacy://data/results/run/model.keras"
+    assert exporter._portable_locator(private) == "redacted://machine-path"
+
+
+def test_sanitizer_redacts_sensitive_and_freeform_values_recursively() -> None:
+    class Marker:
+        def __str__(self) -> str:
+            return "marker"
+
+    source = {
+        "participant_id": "private-person",
+        "notes": "operator prose",
+        "nested": ["data/results/run", {"email": "private@example.invalid"}],
+        "description": "input/output",
+        "data_path": "relative/folder",
+        "marker": Marker(),
+        "enabled": True,
+    }
+
+    assert exporter._sanitize(source) == {
+        "participant_id_redacted": True,
+        "notes_present": True,
+        "nested": ["legacy://data/results/run", {"email_redacted": True}],
+        "description": "input/output",
+        "data_path": "legacy-relative://relative/folder",
+        "marker": "marker",
+        "enabled": True,
+    }
+
+
+def test_json_field_parser_handles_empty_and_sanitized_values() -> None:
+    assert exporter._parse_json_value(None) is None
+    assert exporter._parse_json_value("") is None
+    assert exporter._parse_json_value('{"error": "details"}') == {"error_present": True}
+
+
+@pytest.mark.parametrize("value", [3, [], object()])
+def test_json_field_parser_rejects_non_strings(value: object) -> None:
+    with pytest.raises(LegacyExportError, match="invalid type"):
+        exporter._parse_json_value(value)
+
+
+def test_json_field_parser_rejects_malformed_json() -> None:
+    with pytest.raises(LegacyExportError, match="field is invalid"):
+        exporter._parse_json_value("{")
+
+
+def test_safe_tokens_and_historical_labels_have_bounded_behavior() -> None:
+    assert exporter._safe_token(None, fallback="fallback") == "fallback"
+    assert exporter._safe_token("safe-token", fallback="fallback") == "safe-token"
+    assert exporter._safe_token("unsafe token", fallback="fallback").startswith("redacted-")
+    assert exporter._legacy_label(None, fallback="NONE") == "NONE"
+    assert exporter._legacy_label("thank you", fallback="NONE") == "thank you"
+
+
+@pytest.mark.parametrize("value", [7, "not-a-legacy-label"])
+def test_historical_label_rejects_values_outside_the_audited_vocabulary(value: object) -> None:
+    with pytest.raises(LegacyExportError, match="outside the audited vocabulary"):
+        exporter._legacy_label(value, fallback="NONE")
+
+
+def test_timestamp_helpers_normalize_and_bound_relative_time() -> None:
+    origin = datetime.fromisoformat("2025-01-01T10:00:00")
+
+    assert exporter._normalized_run_timestamp(None, fallback="unknown") == "unknown"
+    assert exporter._normalized_run_timestamp("2025-01-01T10:00:00Z", fallback="unknown") == (
+        "2025-01-01T10:00:00+00:00"
+    )
+    assert exporter._parse_time(None) is None
+    assert exporter._parse_time("") is None
+    assert exporter._offset_ms(None, origin) == 0
+    assert exporter._offset_ms("2025-01-01T09:59:00", origin) == 0
+    assert exporter._offset_ms("2025-01-01T10:00:01", origin) == 1000
+    assert exporter._duration_ms(None, None) is None
+    assert exporter._duration_ms("2025-01-01T10:00:02", "2025-01-01T10:00:01") == 0
+    assert exporter._duration_ms("2025-01-01T10:00:00", "2025-01-01T10:00:01") == 1000
+
+
+@pytest.mark.parametrize("value", [7, "not-a-timestamp"])
+def test_run_timestamp_normalizer_rejects_invalid_values(value: object) -> None:
+    with pytest.raises(LegacyExportError, match="run timestamp"):
+        exporter._normalized_run_timestamp(value, fallback="unknown")
+
+
+def test_relative_timestamp_parser_rejects_invalid_values() -> None:
+    with pytest.raises(LegacyExportError, match="timestamp is invalid"):
+        exporter._parse_time("not-a-timestamp")
+
+
+def test_safe_source_accepts_only_descendants(tmp_path: Path) -> None:
+    root = tmp_path / "legacy"
+    source = root / "data" / "file.json"
+    source.parent.mkdir(parents=True)
+    source.write_text("{}\n", encoding="utf-8")
+
+    assert exporter._safe_source(root, "data/file.json") == source.resolve()
+    with pytest.raises(LegacyExportError, match="not portable"):
+        exporter._safe_source(root, "../outside.json")
+    with pytest.raises(LegacyExportError, match="not portable"):
+        exporter._safe_source(root, "/outside.json")
+
+
+def test_immutable_database_rejects_an_active_wal(tmp_path: Path) -> None:
+    database = tmp_path / "source.db"
+    with sqlite3.connect(database) as connection:
+        connection.execute("CREATE TABLE evidence (id INTEGER)")
+    database.with_name("source.db-wal").write_bytes(b"active")
+
+    with pytest.raises(LegacyExportError, match="active WAL"):
+        exporter._open_immutable_database(database)
+
+
+def test_expected_container_helpers_reject_wrong_shapes() -> None:
+    assert exporter._expected_mapping({"key": "value"}, "fixture") == {"key": "value"}
+    assert exporter._expected_sequence([1], "fixture") == [1]
+    with pytest.raises(LegacyExportError, match="invalid fixture section"):
+        exporter._expected_mapping([], "fixture")
+    with pytest.raises(LegacyExportError, match="invalid fixture section"):
+        exporter._expected_sequence({}, "fixture")
+
+
+def test_artifact_entry_distinguishes_available_ambiguous_missing_and_directory(
+    tmp_path: Path,
+) -> None:
+    legacy = tmp_path / "legacy"
+    first = legacy / "data" / "results" / "run"
+    second = legacy / "data" / "results_old" / "run"
+    first.mkdir(parents=True)
+    second.mkdir(parents=True)
+    (first / "model.keras").write_bytes(b"first")
+    (second / "model.keras").write_bytes(b"second")
+    discovered = (PurePosixPath("data/results/run"), PurePosixPath("data/results_old/run"))
+
+    assert exporter._artifact_entry(legacy, None, discovered_directories=discovered) == {
+        "registered_locator": None,
+        "resolved_locator": None,
+        "availability": "not-recorded",
+    }
+    with pytest.raises(LegacyExportError, match="invalid type"):
+        exporter._artifact_entry(legacy, 3, discovered_directories=discovered)
+    assert (
+        exporter._artifact_entry(legacy, "model.keras", discovered_directories=discovered)[
+            "availability"
+        ]
+        == "ambiguous"
+    )
+    assert (
+        exporter._artifact_entry(
+            legacy,
+            "missing.keras",
+            discovered_directories=discovered,
+        )["availability"]
+        == "missing"
+    )
+    directory = exporter._artifact_entry(
+        legacy,
+        "retired-location/run",
+        discovered_directories=(PurePosixPath("data/results/run"),),
+        directory_role=True,
+    )
+    assert directory["availability"] == "available"
+    assert directory["resolved_locator"] == "legacy://data/results/run"
+
+
+def test_run_validity_records_known_historical_limitations() -> None:
+    succeeded = exporter._run_validity(
+        "succeeded",
+        "causal_gru",
+        notes_present=False,
+        error_present=False,
+    )
+    failed = exporter._run_validity(
+        "failed",
+        "mamba",
+        notes_present=True,
+        error_present=True,
+    )
+    running = exporter._run_validity(
+        "running",
+        "causal_tcn",
+        notes_present=False,
+        error_present=False,
+    )
+
+    assert "failed-run" in cast(list[str], failed["notes"])
+    assert "misleading-legacy-mamba-name" in cast(list[str], failed["notes"])
+    assert "stale-running-run" in cast(list[str], running["notes"])
+    assert "failed-run" not in cast(list[str], succeeded["notes"])
+
+
+def test_content_addressed_store_deduplicates_objects_and_roles(tmp_path: Path) -> None:
+    source = tmp_path / "source.json"
+    source.write_text("{}\n", encoding="utf-8")
+    store = exporter._ObjectStore(tmp_path / "store")
+
+    first_uri = store.add(source, role="z-role")
+    second_uri = store.add(source, role="a-role")
+
+    assert first_uri == second_uri
+    assert store.entries()[0]["roles"] == ["a-role", "z-role"]
+    with pytest.raises(LegacyExportError, match="unavailable"):
+        store.add(tmp_path / "missing.json", role="missing")
+    unsupported = tmp_path / "source.txt"
+    unsupported.write_text("private", encoding="utf-8")
+    with pytest.raises(LegacyExportError, match="unsupported type"):
+        store.add(unsupported, role="unsupported")
+
+
+def test_segment_resolution_rejects_unportable_or_missing_inputs(tmp_path: Path) -> None:
+    legacy = tmp_path / "legacy"
+    segments = legacy / "data" / "live_eval" / "segments"
+    segments.mkdir(parents=True)
+    existing = segments / "event.npz"
+    existing.write_bytes(b"event")
+
+    assert exporter._resolve_segment_path(legacy, None) is None
+    assert exporter._resolve_segment_path(legacy, "") is None
+    assert (
+        exporter._resolve_segment_path(
+            legacy,
+            "data/live_eval/segments/event.npz",
+        )
+        == existing.resolve()
+    )
+    with pytest.raises(LegacyExportError, match="invalid type"):
+        exporter._resolve_segment_path(legacy, 7)
+    with pytest.raises(LegacyExportError, match="cannot be sanitized"):
+        exporter._resolve_segment_path(legacy, "unknown/location.npz")
+    with pytest.raises(LegacyExportError, match="referenced legacy segment is missing"):
+        exporter._resolve_segment_path(legacy, "data/live_eval/segments/missing.npz")
+
+
+def test_segment_inventory_requires_a_directory(tmp_path: Path) -> None:
+    with pytest.raises(LegacyExportError, match="segment directory is missing"):
+        exporter._all_segment_files(tmp_path)
+
+
+def test_target_nonempty_classification(tmp_path: Path) -> None:
+    missing = tmp_path / "missing"
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    file_path = tmp_path / "file"
+    file_path.write_text("content", encoding="utf-8")
+    populated = tmp_path / "populated"
+    populated.mkdir()
+    (populated / "entry").write_text("content", encoding="utf-8")
+
+    assert exporter._target_is_nonempty(missing) is False
+    assert exporter._target_is_nonempty(empty) is False
+    assert exporter._target_is_nonempty(file_path) is True
+    assert exporter._target_is_nonempty(populated) is True
+
+
+def test_json_readers_reject_malformed_or_non_object_values(tmp_path: Path) -> None:
+    malformed = tmp_path / "malformed.json"
+    malformed.write_text("{", encoding="utf-8")
+    array = tmp_path / "array.json"
+    array.write_text("[]\n", encoding="utf-8")
+
+    with pytest.raises(json.JSONDecodeError):
+        exporter._read_json_object(malformed)
+    with pytest.raises(LegacyExportError, match="not an object"):
+        exporter._read_json_object(array)
+    with pytest.raises(LegacyExportError, match="component is unreadable"):
+        validator._read_object(malformed)
+    with pytest.raises(LegacyExportError, match="not an object"):
+        validator._read_object(array)
+
+
+def test_validator_shape_helpers_reject_wrong_types() -> None:
+    assert validator._object({"key": 1}, "fixture") == {"key": 1}
+    assert validator._array([1], "fixture") == [1]
+    validator._exact_keys({"key": 1}, {"key"}, "fixture")
+    with pytest.raises(LegacyExportError, match="invalid fixture object"):
+        validator._object([], "fixture")
+    with pytest.raises(LegacyExportError, match="invalid fixture array"):
+        validator._array({}, "fixture")
+    with pytest.raises(LegacyExportError, match="unsupported fixture fields"):
+        validator._exact_keys({"extra": 1}, {"key"}, "fixture")
+
+
+def test_validator_rejects_unsafe_component_paths(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    with pytest.raises(LegacyExportError, match="not a string"):
+        validator._safe_relative(root, 7)
+    with pytest.raises(LegacyExportError, match="not portable"):
+        validator._safe_relative(root, "../escape.json")
+    with pytest.raises(LegacyExportError, match="not portable"):
+        validator._safe_relative(root, "/escape.json")
+
+
+def test_component_validator_checks_shape_identity_and_record_count(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    component = root / "component.json"
+    component.write_text("{}\n", encoding="utf-8")
+    valid: dict[str, object] = {
+        "path": "component.json",
+        "bytes": component.stat().st_size,
+        "sha256": exporter._sha256(component),
+        "records": 1,
+    }
+    assert validator._validate_component(root, valid) == ("component.json", 1)
+
+    cases = [
+        ({**valid, "extra": True}, "unsupported fields"),
+        ({**valid, "bytes": -1}, "byte count"),
+        ({**valid, "sha256": "invalid"}, "digest"),
+        ({**valid, "path": "missing.json"}, "component is missing"),
+        ({**valid, "bytes": 999}, "integrity check"),
+        ({**valid, "records": -1}, "record count"),
+    ]
+    for raw, message in cases:
+        with pytest.raises(LegacyExportError, match=message):
+            validator._validate_component(root, raw)
+
+
+@pytest.mark.parametrize(
+    ("value", "reject_timestamps", "message"),
+    [
+        ("D" + ":" + r"\private\file.json", False, "absolute machine path"),
+        ("/" + "home/private/file.json", False, "absolute machine path"),
+        (r"\\server\share\file.json", False, "absolute machine path"),
+        ("123e4567e89b12d3" + "a456426614174000", False, "raw UUID-like"),
+        ("2025-01-01T10:00:00", True, "absolute timestamp"),
+    ],
+)
+def test_portability_scanner_rejects_private_values(
+    tmp_path: Path,
+    value: str,
+    reject_timestamps: bool,
+    message: str,
+) -> None:
+    path = tmp_path / "component.json"
+    path.write_text(value, encoding="utf-8")
+
+    with pytest.raises(LegacyExportError, match=message):
+        validator._scan_portability(path, reject_timestamps=reject_timestamps)
+
+
+def test_schema_closure_and_instance_validation_reject_open_or_invalid_contracts() -> None:
+    assert validator._schema_is_closed({"type": "array", "items": {"type": "string"}})
+    assert not validator._schema_is_closed(
+        {"type": "object", "properties": {"key": {"type": "string"}}}
+    )
+    assert validator._schema_is_closed(
+        {
+            "type": "object",
+            "properties": {"key": {"type": "string"}},
+            "additionalProperties": False,
+        }
+    )
+    with pytest.raises(LegacyExportError, match="invalid live attempt contract"):
+        validator._validate_schema_instance({}, "live-attempt.schema.json", "live attempt")
+
+
+def test_json_lines_reader_rejects_malformed_and_non_object_records(tmp_path: Path) -> None:
+    malformed = tmp_path / "malformed.jsonl"
+    malformed.write_text("{\n", encoding="utf-8")
+    non_object = tmp_path / "array.jsonl"
+    non_object.write_text("[]\n", encoding="utf-8")
+
+    with pytest.raises(LegacyExportError, match="component is unreadable"):
+        validator._read_jsonl(malformed)
+    with pytest.raises(LegacyExportError, match="record is not an object"):
+        validator._read_jsonl(non_object)

--- a/tests/test_legacy_export_contract.py
+++ b/tests/test_legacy_export_contract.py
@@ -1,0 +1,698 @@
+"""Regression tests for the portable legacy-evidence export."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+from collections import Counter
+from collections.abc import Iterator, Mapping
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from signlab.legacy.exporter import SENSITIVE_KEYS, LegacyExportError
+from signlab.legacy.schemas import DATA_ROLE, FORMAT_VERSION, PUBLIC_KIND, SCHEMAS
+from signlab.legacy.validator import ValidationSummary, validate_legacy_export
+
+type JsonObject = dict[str, object]
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+PUBLIC_EXPORT_ROOT = REPOSITORY_ROOT / "docs" / "legacy" / "export" / "v1"
+EXPECTED_COUNTS = {
+    "runs": 464,
+    "runs_succeeded": 457,
+    "runs_failed": 6,
+    "runs_running": 1,
+    "attempts": 532,
+    "annotations": 408,
+    "annotated_attempts": 401,
+    "unannotated_attempts": 131,
+    "detections": 45,
+    "sessions": 5,
+    "segments": 529,
+    "referenced_segments": 525,
+    "orphan_segments": 4,
+    "promoted_models": 4,
+    "preprocessing_plans": 3,
+}
+EXPECTED_MODELS = {
+    "causal_gru": (2428032, "f69c07838a477df0853a6cdb71b1acb9a933e0de1491359da0cae5462584e46c"),
+    "causal_lstm": (3210098, "b175174c2daa4ccd33bb9fb49120d7399a61aab95c3bdfa378ba40aa57ace7ee"),
+    "causal_tcn": (2458533, "d5e3d15cead7436342c15229e94a6becdfd41b1254f3caa5332cf64ad9cf3f0c"),
+    "mamba": (467230, "89647b516068950818bffabb9c269f31bef924bdcce0230ea509af9fea17559e"),
+}
+MACHINE_PATH_PATTERNS = (
+    re.compile(r"(?i)(?<![a-z0-9])[a-z]:[\\/]"),
+    re.compile(r"(?i)(?:^|[\s\"'=(])/(?:users|home)/[^/\s]+(?:/|\\)"),
+    re.compile(r"(?i)file:///(?:[a-z]:|users/|home/)"),
+    re.compile(r"\\\\[^\\\s]+\\[^\\\s]+"),
+)
+RAW_UUID_PATTERN = re.compile(r"(?i)(?<![0-9a-f])[0-9a-f]{32}(?![0-9a-f])")
+FORBIDDEN_PRIVATE_KEYS = {
+    "absolute_path",
+    "attempt_id",
+    "email",
+    "error",
+    "freeform_note",
+    "participant",
+    "participant_id",
+    "subject",
+    "subject_id",
+    "user_id",
+    "username",
+}
+SENSITIVE_KEY_FORMS = tuple(
+    sorted(
+        SENSITIVE_KEYS
+        | {variant for key in SENSITIVE_KEYS for variant in (key.upper(), key.title())}
+    )
+)
+
+
+def _read_object(path: Path) -> JsonObject:
+    value: Any = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return cast(JsonObject, value)
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _write_object(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, indent=2, sort_keys=True, ensure_ascii=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _component(path: Path, root: Path, *, records: int | None = None) -> JsonObject:
+    result: JsonObject = {
+        "path": path.relative_to(root).as_posix(),
+        "bytes": path.stat().st_size,
+        "sha256": _sha256(path),
+    }
+    if records is not None:
+        result["records"] = records
+    return result
+
+
+def _walk(value: object) -> Iterator[object]:
+    yield value
+    if isinstance(value, Mapping):
+        for child in value.values():
+            yield from _walk(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _walk(child)
+
+
+def _run_records(root: Path = PUBLIC_EXPORT_ROOT) -> list[JsonObject]:
+    records: list[JsonObject] = []
+    for path in sorted((root / "runs").glob("runs-*.json")):
+        shard = _read_object(path)
+        raw_records = shard["records"]
+        assert isinstance(raw_records, list)
+        records.extend(cast(list[JsonObject], raw_records))
+    return records
+
+
+def _synthetic_run(*, configuration: JsonObject | None = None) -> JsonObject:
+    artifact = {
+        "availability": "not-recorded",
+        "registered_locator": None,
+        "resolved_locator": None,
+    }
+    run_configuration: JsonObject = {
+        "model_settings": {},
+        "global_settings": {},
+        "data_locator": "legacy-relative://data/landmarks/synthetic",
+        "sequence_length": 30,
+        "test_fraction": 0.2,
+        "validation_fraction": 0.2,
+        "batch_size": 8,
+        "epochs": 2,
+    }
+    if configuration is not None:
+        run_configuration.update(configuration)
+    return {
+        "record_id": "run-000001",
+        "run_name": "synthetic-run",
+        "source_run_id": "synthetic-run",
+        "started_at": "redacted-0000000000000000",
+        "finished_at": "redacted-0000000000000000",
+        "status": "succeeded",
+        "model_key": "synthetic",
+        "configuration": run_configuration,
+        "metrics": {
+            "quick": {},
+            "test_loss": 0.2,
+            "test_accuracy": 0.8,
+            "samples_train": 8,
+            "samples_validation": 2,
+            "samples_test": 2,
+        },
+        "artifacts": {
+            name: dict(artifact)
+            for name in (
+                "configuration",
+                "directory",
+                "history",
+                "label_map",
+                "metrics",
+                "model",
+                "predictions",
+            )
+        },
+        "validity": {
+            "data_role": DATA_ROLE,
+            "eligible_for_locked_test": False,
+            "legacy_error_present": False,
+            "legacy_notes_present": False,
+            "notes": [DATA_ROLE],
+        },
+    }
+
+
+def _build_synthetic_public_export(
+    root: Path,
+    *,
+    configuration: JsonObject | None = None,
+) -> Path:
+    run_path = root / "runs" / "runs-000.json"
+    _write_object(
+        run_path,
+        {
+            "schema_version": FORMAT_VERSION,
+            "kind": "signlab.legacy-run-index",
+            "shard": 0,
+            "records": [_synthetic_run(configuration=configuration)],
+        },
+    )
+    _write_object(
+        root / "promoted-artifacts.json",
+        {
+            "schema_version": FORMAT_VERSION,
+            "kind": "signlab.legacy-promoted-artifacts",
+            "artifacts": [],
+        },
+    )
+    zero_digest = "0" * 64
+    _write_object(
+        root / "preprocessing-plans.json",
+        {
+            "schema_version": FORMAT_VERSION,
+            "kind": "signlab.legacy-preprocessing-plans",
+            "source_sha256": zero_digest,
+            "quarantine_uri": f"quarantine://sha256/{zero_digest}.json",
+            "plans": {
+                "synthetic-plan": {
+                    "name": "synthetic-plan",
+                    "description": "Synthetic contract fixture.",
+                    "created_at": "2025-01-01T10:00:00",
+                    "updated_at": "2025-01-01T10:05:00",
+                    "steps": [{"key": "center_wrist", "params": {}}],
+                }
+            },
+        },
+    )
+    counts = {
+        "runs": 1,
+        "runs_succeeded": 1,
+        "runs_failed": 0,
+        "runs_running": 0,
+        "attempts": 0,
+        "annotations": 0,
+        "annotated_attempts": 0,
+        "unannotated_attempts": 0,
+        "detections": 0,
+        "sessions": 0,
+        "segments": 0,
+        "referenced_segments": 0,
+        "orphan_segments": 0,
+        "promoted_models": 0,
+        "preprocessing_plans": 1,
+    }
+    private_counts = {
+        "attempts": 0,
+        "annotations": 0,
+        "annotated_attempts": 0,
+        "unannotated_attempts": 0,
+        "sessions": 0,
+        "detections": 0,
+        "segments": 0,
+        "referenced_segments": 0,
+        "orphan_segments": 0,
+        "promoted_models": 0,
+        "quarantine_objects": 0,
+    }
+    private_receipt_components = [
+        {
+            "path": path,
+            "bytes": 0,
+            "sha256": zero_digest,
+            **({"records": 0} if path.startswith("records/") else {}),
+        }
+        for path in (
+            "manifest.json",
+            "records/attempts.jsonl",
+            "records/annotations.jsonl",
+            "records/sessions.jsonl",
+            "records/detections.jsonl",
+        )
+    ]
+    _write_object(
+        root / "quarantine-receipt.json",
+        {
+            "schema_version": FORMAT_VERSION,
+            "kind": "signlab.legacy-quarantine-receipt",
+            "policy": {
+                "contains_individual_object_hashes": False,
+                "data_role": DATA_ROLE,
+                "durability": "local-only-pending-private-remote",
+                "eligible_for_locked_test": False,
+                "publishable": False,
+            },
+            "counts": private_counts,
+            "components": private_receipt_components,
+        },
+    )
+    for name, schema in SCHEMAS.items():
+        _write_object(root / "schemas" / name, schema)
+
+    components = []
+    record_counts = {
+        "runs/runs-000.json": 1,
+        "promoted-artifacts.json": 0,
+        "preprocessing-plans.json": 1,
+    }
+    for path in sorted(root.rglob("*.json")):
+        relative = path.relative_to(root).as_posix()
+        records = record_counts.get(relative)
+        components.append(_component(path, root, records=records))
+    _write_object(
+        root / "manifest.json",
+        {
+            "schema_version": FORMAT_VERSION,
+            "kind": PUBLIC_KIND,
+            "source": {
+                "head_commit": "0" * 40,
+                "tree_object": "1" * 40,
+                "audit_sha256": "2" * 64,
+            },
+            "policy": {
+                "data_role": DATA_ROLE,
+                "eligible_for_locked_test": False,
+                "contains_private_artifacts": False,
+                "durability": "local-only-pending-private-remote",
+            },
+            "counts": counts,
+            "components": components,
+        },
+    )
+    return root
+
+
+def _refresh_public_component(root: Path, relative: str) -> None:
+    manifest = _read_object(root / "manifest.json")
+    components = cast(list[JsonObject], manifest["components"])
+    path = root / relative
+    component = next(item for item in components if item["path"] == relative)
+    component["bytes"] = path.stat().st_size
+    component["sha256"] = _sha256(path)
+    _write_object(root / "manifest.json", manifest)
+
+
+def test_committed_public_export_validates_without_legacy_dependencies() -> None:
+    summary = validate_legacy_export(public_root=PUBLIC_EXPORT_ROOT)
+
+    assert summary == ValidationSummary(
+        runs=464,
+        attempts=532,
+        annotations=408,
+        detections=45,
+        sessions=5,
+        quarantine_verified=False,
+    )
+
+
+def test_public_manifest_and_run_index_reconcile() -> None:
+    manifest = _read_object(PUBLIC_EXPORT_ROOT / "manifest.json")
+    assert manifest["counts"] == EXPECTED_COUNTS
+    assert manifest["policy"] == {
+        "contains_private_artifacts": False,
+        "data_role": DATA_ROLE,
+        "durability": "local-only-pending-private-remote",
+        "eligible_for_locked_test": False,
+    }
+
+    components = cast(list[JsonObject], manifest["components"])
+    declared_paths = [cast(str, item["path"]) for item in components]
+    actual_paths = sorted(
+        path.relative_to(PUBLIC_EXPORT_ROOT).as_posix()
+        for path in PUBLIC_EXPORT_ROOT.rglob("*")
+        if path.is_file() and path.name != "manifest.json"
+    )
+    assert sorted(declared_paths) == actual_paths
+    assert len(declared_paths) == len(set(declared_paths))
+    for item in components:
+        path = PUBLIC_EXPORT_ROOT / cast(str, item["path"])
+        assert item["bytes"] == path.stat().st_size
+        assert item["sha256"] == _sha256(path)
+
+    records = _run_records()
+    assert [record["record_id"] for record in records] == [
+        f"run-{index:06d}" for index in range(1, 465)
+    ]
+    assert Counter(record["status"] for record in records) == {
+        "succeeded": 457,
+        "failed": 6,
+        "running": 1,
+    }
+    for record in records:
+        assert isinstance(record["configuration"], dict)
+        assert isinstance(record["metrics"], dict)
+        configuration = cast(JsonObject, record["configuration"])
+        data_locator = configuration["data_locator"]
+        if isinstance(data_locator, str) and "data/landmarks" in data_locator:
+            assert data_locator.startswith(("legacy://", "legacy-relative://"))
+        validity = cast(JsonObject, record["validity"])
+        assert validity["data_role"] == DATA_ROLE
+        assert validity["eligible_for_locked_test"] is False
+
+    relocated_directories: list[JsonObject] = []
+    for record in records:
+        artifacts = cast(JsonObject, record["artifacts"])
+        directory = cast(JsonObject, artifacts["directory"])
+        if (
+            directory["registered_locator"] != directory["resolved_locator"]
+            and directory["availability"] == "available"
+        ):
+            relocated_directories.append(directory)
+    assert relocated_directories
+    assert all(item["resolved_locator"] is not None for item in relocated_directories)
+
+
+def test_promoted_models_label_maps_and_plans_are_hash_anchored() -> None:
+    promoted = _read_object(PUBLIC_EXPORT_ROOT / "promoted-artifacts.json")
+    artifacts = cast(list[JsonObject], promoted["artifacts"])
+    assert {cast(str, item["model_key"]) for item in artifacts} == set(EXPECTED_MODELS)
+
+    for artifact in artifacts:
+        key = cast(str, artifact["model_key"])
+        model = cast(JsonObject, artifact["model"])
+        label_map = cast(JsonObject, artifact["label_map"])
+        validity = cast(JsonObject, artifact["validity"])
+        expected_bytes, expected_digest = EXPECTED_MODELS[key]
+        assert (model["bytes"], model["sha256"]) == (expected_bytes, expected_digest)
+        assert model["quarantine_uri"] == f"quarantine://sha256/{expected_digest}.keras"
+        assert model["storage_status"] == "local-quarantine"
+        assert label_map["sha256"] == (
+            "c0a1e624ee1d6353d6377c2391030df15106ec2bea193323c07f0da1a4c9499d"
+        )
+        assert label_map["labels"] == {
+            "0": "hello",
+            "1": "no",
+            "2": "please",
+            "3": "thank you",
+            "4": "yes",
+        }
+        assert validity["data_role"] == DATA_ROLE
+        assert validity["eligible_for_locked_test"] is False
+
+    plans = _read_object(PUBLIC_EXPORT_ROOT / "preprocessing-plans.json")
+    assert set(cast(JsonObject, plans["plans"])) == {
+        "baseline_pos_handscale_30f",
+        "pos_vel_handscale_smooth_30f",
+        "shape_motion_angles_robust_30f",
+    }
+    assert plans["source_sha256"] == (
+        "5a727cc6218dcc2f82cb72cdec00bd7348f1f9d924677011548e2200d32cea0d"
+    )
+    assert plans["quarantine_uri"] == (
+        "quarantine://sha256/5a727cc6218dcc2f82cb72cdec00bd7348f1f9d924677011548e2200d32cea0d.json"
+    )
+    robust_plan = cast(
+        JsonObject,
+        cast(JsonObject, plans["plans"])["shape_motion_angles_robust_30f"],
+    )
+    description = cast(str, robust_plan["description"])
+    assert "orientation/scale" in description
+    assert not description.startswith(("legacy://", "legacy-relative://"))
+
+
+def test_public_export_is_portable_and_contains_no_private_payloads() -> None:
+    files = [path for path in PUBLIC_EXPORT_ROOT.rglob("*") if path.is_file()]
+    assert files
+    assert all(path.suffix == ".json" for path in files)
+    assert max(path.stat().st_size for path in files) < 1024 * 1024
+
+    for path in files:
+        text = path.read_text(encoding="utf-8")
+        assert not any(pattern.search(text) for pattern in MACHINE_PATH_PATTERNS), path
+        assert RAW_UUID_PATTERN.search(text) is None, path
+        assert "sb128" not in text.casefold(), path
+        assert "peterbucci" not in text.casefold(), path
+        value: Any = json.loads(text)
+        keys = {cast(str, key) for node in _walk(value) if isinstance(node, dict) for key in node}
+        assert keys.isdisjoint(FORBIDDEN_PRIVATE_KEYS), path
+
+
+def test_committed_schemas_match_code_and_close_required_objects() -> None:
+    for name, expected in SCHEMAS.items():
+        schema = _read_object(PUBLIC_EXPORT_ROOT / "schemas" / name)
+        assert schema == expected
+        for node in _walk(schema):
+            if not isinstance(node, dict):
+                continue
+            if "required" in node:
+                assert "properties" in node
+                required = set(cast(list[str], node["required"]))
+                properties = cast(JsonObject, node["properties"])
+                assert required.issubset(properties)
+            if node.get("type") == "object" and "properties" in node:
+                assert node.get("additionalProperties") is False
+
+
+def test_synthetic_public_export_validates_without_legacy_sources(tmp_path: Path) -> None:
+    root = _build_synthetic_public_export(tmp_path / "portable-export")
+
+    assert validate_legacy_export(public_root=root) == ValidationSummary(
+        runs=1,
+        attempts=0,
+        annotations=0,
+        detections=0,
+        sessions=0,
+        quarantine_verified=False,
+    )
+
+
+@pytest.mark.parametrize("sensitive_key", SENSITIVE_KEY_FORMS)
+def test_public_export_rejects_every_nested_sensitive_key(
+    tmp_path: Path,
+    sensitive_key: str,
+) -> None:
+    root = _build_synthetic_public_export(tmp_path / "sensitive-public")
+    run_path = root / "runs" / "runs-000.json"
+    shard = _read_object(run_path)
+    record = cast(list[JsonObject], shard["records"])[0]
+    configuration = cast(JsonObject, record["configuration"])
+    model_settings = cast(JsonObject, configuration["model_settings"])
+    model_settings["nested"] = {sensitive_key: "opaque-identifier"}
+    _write_object(run_path, shard)
+    _refresh_public_component(root, "runs/runs-000.json")
+
+    with pytest.raises(LegacyExportError):
+        validate_legacy_export(public_root=root)
+
+
+def test_public_export_rejects_a_canonical_hyphenated_uuid(tmp_path: Path) -> None:
+    root = _build_synthetic_public_export(tmp_path / "uuid-public")
+    run_path = root / "runs" / "runs-000.json"
+    shard = _read_object(run_path)
+    record = cast(list[JsonObject], shard["records"])[0]
+    configuration = cast(JsonObject, record["configuration"])
+    model_settings = cast(JsonObject, configuration["model_settings"])
+    model_settings["trace_token"] = "123e4567-e89b" + "-12d3-a456-426614174000"
+    _write_object(run_path, shard)
+    _refresh_public_component(root, "runs/runs-000.json")
+
+    with pytest.raises(LegacyExportError, match="raw UUID-like"):
+        validate_legacy_export(public_root=root)
+
+
+def test_all_five_public_run_shards_are_visible_to_git() -> None:
+    shards = sorted((PUBLIC_EXPORT_ROOT / "runs").glob("runs-*.json"))
+    assert [path.name for path in shards] == [f"runs-{index:03d}.json" for index in range(5)]
+
+    for path in shards:
+        result = subprocess.run(
+            ["git", "check-ignore", "--quiet", str(path)],
+            cwd=REPOSITORY_ROOT,
+            check=False,
+        )
+        assert result.returncode == 1, f"Git ignores required run shard {path.name}"
+
+
+@pytest.mark.parametrize(
+    ("configuration", "message"),
+    [
+        ({"data_locator": "C" + ":" + r"\Users\person\private"}, "absolute machine path"),
+        (
+            {"data_locator": "123e4567e89b12d3" + "a456426614174000"},
+            "raw UUID-like",
+        ),
+    ],
+)
+def test_synthetic_export_rejects_private_machine_data(
+    tmp_path: Path,
+    configuration: JsonObject,
+    message: str,
+) -> None:
+    root = _build_synthetic_public_export(
+        tmp_path / "unsafe-export",
+        configuration=configuration,
+    )
+
+    with pytest.raises(LegacyExportError, match=message):
+        validate_legacy_export(public_root=root)
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "run-id-sequence",
+        "shard-identity",
+        "shard-record-count",
+        "undeclared-file",
+        "plan-uri",
+        "promoted-plan",
+        "promoted-uri",
+        "promoted-count",
+        "receipt-count",
+        "receipt-components",
+        "forbidden-key",
+        "schema-drift",
+    ],
+)
+def test_synthetic_public_validator_rejects_contract_tampering(
+    tmp_path: Path,
+    case: str,
+) -> None:
+    root = _build_synthetic_public_export(tmp_path / "tampered-export")
+    manifest = _read_object(root / "manifest.json")
+    run_path = root / "runs" / "runs-000.json"
+    run_shard = _read_object(run_path)
+    records = cast(list[JsonObject], run_shard["records"])
+    promoted_path = root / "promoted-artifacts.json"
+    promoted = _read_object(promoted_path)
+    plans_path = root / "preprocessing-plans.json"
+    plans = _read_object(plans_path)
+    receipt_path = root / "quarantine-receipt.json"
+    receipt = _read_object(receipt_path)
+
+    if case == "run-id-sequence":
+        records[0]["record_id"] = "run-000002"
+        _write_object(run_path, run_shard)
+        _refresh_public_component(root, "runs/runs-000.json")
+    elif case == "shard-identity":
+        run_shard["shard"] = 1
+        _write_object(run_path, run_shard)
+        _refresh_public_component(root, "runs/runs-000.json")
+    elif case == "shard-record-count":
+        components = cast(list[JsonObject], manifest["components"])
+        run_component = next(item for item in components if item["path"] == "runs/runs-000.json")
+        run_component["records"] = 2
+        _write_object(root / "manifest.json", manifest)
+    elif case == "undeclared-file":
+        _write_object(root / "undeclared.json", {})
+    elif case == "plan-uri":
+        plans["quarantine_uri"] = f"quarantine://sha256/{'1' * 64}.json"
+        _write_object(plans_path, plans)
+        _refresh_public_component(root, "preprocessing-plans.json")
+    elif case == "promoted-plan":
+        promoted["artifacts"] = [
+            {
+                "run_id": "synthetic-run",
+                "model_key": "synthetic",
+                "preprocessing_plan": "unknown-plan",
+                "model": {
+                    "bytes": 1,
+                    "sha256": "3" * 64,
+                    "quarantine_uri": f"quarantine://sha256/{'3' * 64}.keras",
+                    "storage_status": "local-quarantine",
+                },
+                "label_map": {
+                    "bytes": 1,
+                    "sha256": "4" * 64,
+                    "quarantine_uri": f"quarantine://sha256/{'4' * 64}.json",
+                    "labels": {"0": "hello"},
+                },
+                "validity": {
+                    "data_role": DATA_ROLE,
+                    "eligible_for_locked_test": False,
+                    "notes": [DATA_ROLE],
+                },
+            }
+        ]
+        _write_object(promoted_path, promoted)
+        _refresh_public_component(root, "promoted-artifacts.json")
+    elif case == "promoted-uri":
+        artifact = {
+            "run_id": "synthetic-run",
+            "model_key": "synthetic",
+            "preprocessing_plan": "synthetic-plan",
+            "model": {
+                "bytes": 1,
+                "sha256": "3" * 64,
+                "quarantine_uri": f"quarantine://sha256/{'4' * 64}.keras",
+                "storage_status": "local-quarantine",
+            },
+            "label_map": {
+                "bytes": 1,
+                "sha256": "4" * 64,
+                "quarantine_uri": f"quarantine://sha256/{'4' * 64}.json",
+                "labels": {"0": "hello"},
+            },
+            "validity": {
+                "data_role": DATA_ROLE,
+                "eligible_for_locked_test": False,
+                "notes": [DATA_ROLE],
+            },
+        }
+        promoted["artifacts"] = [artifact]
+        _write_object(promoted_path, promoted)
+        _refresh_public_component(root, "promoted-artifacts.json")
+    elif case == "promoted-count":
+        components = cast(list[JsonObject], manifest["components"])
+        component = next(item for item in components if item["path"] == "promoted-artifacts.json")
+        component["records"] = 1
+        _write_object(root / "manifest.json", manifest)
+    elif case == "receipt-count":
+        counts = cast(JsonObject, receipt["counts"])
+        counts["attempts"] = 1
+        _write_object(receipt_path, receipt)
+        _refresh_public_component(root, "quarantine-receipt.json")
+    elif case == "receipt-components":
+        receipt["components"] = cast(list[JsonObject], receipt["components"])[1:]
+        _write_object(receipt_path, receipt)
+        _refresh_public_component(root, "quarantine-receipt.json")
+    elif case == "forbidden-key":
+        configuration = cast(JsonObject, records[0]["configuration"])
+        settings = cast(JsonObject, configuration["model_settings"])
+        settings["participant_id"] = "redacted-value"
+        _write_object(run_path, run_shard)
+        _refresh_public_component(root, "runs/runs-000.json")
+    else:
+        schema_path = root / "schemas" / "session.schema.json"
+        schema = _read_object(schema_path)
+        schema["title"] = "Drifted schema"
+        _write_object(schema_path, schema)
+        _refresh_public_component(root, "schemas/session.schema.json")
+
+    with pytest.raises(LegacyExportError):
+        validate_legacy_export(public_root=root)

--- a/tests/test_legacy_exporter.py
+++ b/tests/test_legacy_exporter.py
@@ -1,0 +1,891 @@
+"""End-to-end tests for the read-only legacy exporter."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import sqlite3
+import subprocess
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from signlab.legacy.exporter import (
+    SENSITIVE_KEYS,
+    ExportSummary,
+    LegacyExportError,
+    export_legacy_evidence,
+)
+from signlab.legacy.validator import ValidationSummary, validate_legacy_export
+
+type JsonObject = dict[str, object]
+
+SENSITIVE_KEY_FORMS = tuple(
+    sorted(
+        SENSITIVE_KEYS
+        | {variant for key in SENSITIVE_KEYS for variant in (key.upper(), key.title())}
+    )
+)
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _read_json(path: Path) -> JsonObject:
+    value: Any = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return cast(JsonObject, value)
+
+
+def _write_jsonl(path: Path, records: list[JsonObject]) -> None:
+    path.write_text(
+        "".join(
+            json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n" for record in records
+        ),
+        encoding="utf-8",
+    )
+
+
+def _read_jsonl(path: Path) -> list[JsonObject]:
+    values: list[JsonObject] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        value: Any = json.loads(line)
+        assert isinstance(value, dict)
+        values.append(cast(JsonObject, value))
+    return values
+
+
+def _tree_bytes(root: Path) -> dict[str, bytes]:
+    return {
+        path.relative_to(root).as_posix(): path.read_bytes()
+        for path in root.rglob("*")
+        if path.is_file()
+    }
+
+
+def _git(repository: Path, *arguments: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repository), *arguments],
+        check=True,
+        capture_output=True,
+        encoding="utf-8",
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _create_run_database(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    schema = """
+        CREATE TABLE runs (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          run_name TEXT,
+          started_at TEXT NOT NULL,
+          finished_at TEXT,
+          status TEXT NOT NULL,
+          model_key TEXT NOT NULL,
+          model_settings_json TEXT NOT NULL,
+          global_settings_json TEXT NOT NULL,
+          data_root TEXT NOT NULL,
+          seq_len INTEGER NOT NULL,
+          test_frac REAL NOT NULL,
+          val_frac REAL NOT NULL,
+          batch_size INTEGER NOT NULL,
+          epochs INTEGER NOT NULL,
+          artifacts_dir TEXT NOT NULL,
+          model_path TEXT,
+          label_map_path TEXT,
+          config_path TEXT,
+          history_path TEXT,
+          predictions_path TEXT,
+          metrics_path TEXT,
+          quick_metrics_json TEXT,
+          test_loss REAL,
+          test_accuracy REAL,
+          samples_train INTEGER,
+          samples_val INTEGER,
+          samples_test INTEGER,
+          error TEXT,
+          notes TEXT
+        )
+    """
+    columns = (
+        "run_name, started_at, finished_at, status, model_key, "
+        "model_settings_json, global_settings_json, data_root, seq_len, "
+        "test_frac, val_frac, batch_size, epochs, artifacts_dir, model_path, "
+        "label_map_path, config_path, history_path, predictions_path, metrics_path, "
+        "quick_metrics_json, test_loss, test_accuracy, samples_train, samples_val, "
+        "samples_test, error, notes"
+    )
+    placeholder = ", ".join("?" for _ in range(28))
+    stale_root = "Z" + ":" + r"\retired-machine\archive\run-relocated"
+    rows: list[tuple[Any, ...]] = [
+        (
+            "run-good",
+            "2025-01-01T10:00:00",
+            "2025-01-01T10:01:00",
+            "succeeded",
+            "causal_gru",
+            json.dumps({"hidden": 32, "participant_id": "private"}),
+            json.dumps({"notes": "reviewed", "data_root": "data/landmarks/v1"}),
+            "data/landmarks/v1",
+            30,
+            0.2,
+            0.2,
+            8,
+            2,
+            "data/results/run-good",
+            "data/results/run-good/model.keras",
+            "data/results/run-good/label_map.json",
+            "data/results/run-good/config.json",
+            None,
+            None,
+            None,
+            json.dumps({"accuracy": 0.8}),
+            0.4,
+            0.8,
+            8,
+            2,
+            2,
+            None,
+            "reviewed",
+        ),
+        (
+            "run-relocated",
+            "2025-01-02T10:00:00",
+            "2025-01-02T10:01:00",
+            "failed",
+            "mamba",
+            "{}",
+            "{}",
+            "data/landmarks/v1",
+            30,
+            0.2,
+            0.2,
+            8,
+            2,
+            stale_root,
+            stale_root + r"\sign_model_best.keras",
+            stale_root + r"\label_map.json",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            "training stopped",
+            None,
+        ),
+        (
+            "run-shared",
+            "2025-01-03T10:00:00",
+            None,
+            "running",
+            "causal_tcn",
+            "{}",
+            "{}",
+            "data/landmarks/v1",
+            30,
+            0.2,
+            0.2,
+            8,
+            2,
+            "run-shared",
+            "model.keras",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ),
+    ]
+    with sqlite3.connect(path) as connection:
+        connection.execute(schema)
+        connection.executemany(f"INSERT INTO runs ({columns}) VALUES ({placeholder})", rows)
+
+
+def _create_live_evaluation_database(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(path) as connection:
+        connection.execute(
+            """
+            CREATE TABLE attempts (
+              attempt_id TEXT PRIMARY KEY,
+              timestamp_start TEXT NOT NULL,
+              timestamp_end TEXT NOT NULL,
+              intended_label TEXT,
+              detected INTEGER NOT NULL,
+              predicted_label TEXT NOT NULL,
+              correct INTEGER,
+              confidence REAL,
+              latency_ms INTEGER,
+              segment_frames INTEGER,
+              model_run_id TEXT NOT NULL,
+              seg_params_json TEXT NOT NULL,
+              segment_path TEXT
+            )
+            """
+        )
+        connection.executemany(
+            "INSERT INTO attempts VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                (
+                    "raw-attempt-one",
+                    "2025-01-04T10:00:00",
+                    "2025-01-04T10:00:01",
+                    "hello",
+                    1,
+                    "hello",
+                    1,
+                    0.91,
+                    12,
+                    30,
+                    "run-good",
+                    json.dumps({"threshold": 0.5}),
+                    "data/live_eval/segments/referenced.npz",
+                ),
+                (
+                    "raw-attempt-two",
+                    "2025-01-04T10:00:02",
+                    "2025-01-04T10:00:03",
+                    None,
+                    0,
+                    "NONE",
+                    None,
+                    None,
+                    None,
+                    None,
+                    "run-good",
+                    "{}",
+                    None,
+                ),
+            ],
+        )
+
+
+def _create_feedback_database(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(path) as connection:
+        connection.executescript(
+            """
+            CREATE TABLE sessions (
+              id INTEGER PRIMARY KEY,
+              model_name TEXT NOT NULL,
+              started_at TEXT NOT NULL,
+              ended_at TEXT
+            );
+            CREATE TABLE detections (
+              id INTEGER PRIMARY KEY,
+              session_id INTEGER NOT NULL,
+              ts TEXT NOT NULL,
+              sign_label TEXT NOT NULL,
+              confidence REAL,
+              predicted_label TEXT,
+              actual_label TEXT,
+              is_correct INTEGER
+            );
+            CREATE TABLE feedback (
+              feedback_id INTEGER PRIMARY KEY,
+              attempt_id TEXT NOT NULL,
+              feedback_type TEXT NOT NULL,
+              corrected_label TEXT,
+              freeform_note TEXT,
+              timestamp TEXT NOT NULL
+            );
+            """
+        )
+        connection.execute(
+            "INSERT INTO sessions VALUES (?, ?, ?, ?)",
+            (7, "run-good", "2025-01-04T09:59:00", "2025-01-04T10:05:00"),
+        )
+        connection.execute(
+            "INSERT INTO detections VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (1, 7, "2025-01-04T10:00:00", "hello", 0.91, "hello", "hello", 1),
+        )
+        connection.executemany(
+            "INSERT INTO feedback VALUES (?, ?, ?, ?, ?, ?)",
+            [
+                (1, "raw-attempt-one", "confirm", None, None, "2025-01-04T10:01:00"),
+                (
+                    2,
+                    "raw-attempt-one",
+                    "wrong",
+                    "no",
+                    "operator correction",
+                    "2025-01-04T10:02:00",
+                ),
+            ],
+        )
+
+
+def _file_evidence(repository: Path, relative: str) -> dict[str, object]:
+    path = repository / relative
+    return {
+        "logical_path": relative,
+        "bytes": path.stat().st_size,
+        "sha256": _sha256(path),
+    }
+
+
+def _create_synthetic_legacy_repository(root: Path, audit_path: Path) -> None:
+    label_map = {"0": "hello", "1": "no"}
+    plans = {
+        "synthetic-plan": {
+            "name": "synthetic-plan",
+            "description": "Synthetic contract fixture.",
+            "created_at": "2025-01-01T10:00:00",
+            "updated_at": "2025-01-01T10:05:00",
+            "steps": [{"key": "center_wrist", "params": {}}],
+        }
+    }
+    for relative in (
+        "data/results/run-good/model.keras",
+        "data/results/run-relocated/sign_model_best.keras",
+        "data/results/run-shared/model.keras",
+        "data/results_old/run-shared/model.keras",
+    ):
+        path = root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(f"model:{relative}".encode())
+    for relative in (
+        "data/results/run-good/label_map.json",
+        "data/results/run-relocated/label_map.json",
+    ):
+        _write_json(root / relative, label_map)
+    _write_json(root / "data/results/run-good/config.json", {"batch_size": 8})
+    _write_json(root / "data/plans/plans.json", plans)
+    segments = root / "data/live_eval/segments"
+    segments.mkdir(parents=True)
+    (segments / "referenced.npz").write_bytes(b"referenced-segment")
+    (segments / "orphan.npz").write_bytes(b"orphan-segment")
+    _create_run_database(root / "data/models/runs.db")
+    _create_feedback_database(root / "data/models/live_feedback.db")
+    _create_live_evaluation_database(root / "data/live_eval/live_eval.db")
+
+    subprocess.run(["git", "init", "-b", "main", str(root)], check=True, capture_output=True)
+    _git(root, "config", "user.name", "SignLab Tests")
+    _git(root, "config", "user.email", "tests@example.invalid")
+    _git(root, "add", ".")
+    _git(root, "commit", "-m", "Synthetic immutable legacy source")
+
+    promoted_model = "data/results/run-relocated/sign_model_best.keras"
+    promoted_label_map = "data/results/run-relocated/label_map.json"
+    audit = {
+        "schema_version": 2,
+        "repository": {
+            "head_commit": _git(root, "rev-parse", "HEAD"),
+            "tree_object": _git(root, "rev-parse", "HEAD^{tree}"),
+        },
+        "dataset_snapshot": {"selected_representation": "synthetic-plan"},
+        "live_state": {
+            "run_database": {"runs": 3},
+            "feedback_database": {"feedback_records": 2},
+            "live_evaluation_database": {"attempts": 2},
+        },
+        "integrity": [
+            _file_evidence(root, "data/models/runs.db"),
+            _file_evidence(root, "data/models/live_feedback.db"),
+            _file_evidence(root, "data/live_eval/live_eval.db"),
+            _file_evidence(root, "data/plans/plans.json"),
+        ],
+        "reported_runs": [
+            {
+                "run_id": "run-relocated",
+                "model_key": "mamba",
+                "model_logical_path": promoted_model,
+                "model_bytes": (root / promoted_model).stat().st_size,
+                "model_sha256": _sha256(root / promoted_model),
+                "source_evidence": [_file_evidence(root, promoted_label_map)],
+            }
+        ],
+    }
+    _write_json(audit_path, audit)
+
+
+@pytest.fixture(scope="module")
+def pristine_export(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> tuple[Path, Path]:
+    root = tmp_path_factory.mktemp("validated-legacy-export")
+    legacy_root = root / "legacy"
+    audit_snapshot = root / "legacy-state.json"
+    public_root = root / "public"
+    quarantine_root = root / "quarantine"
+    _create_synthetic_legacy_repository(legacy_root, audit_snapshot)
+    export_legacy_evidence(
+        legacy_root=legacy_root,
+        audit_snapshot=audit_snapshot,
+        public_output=public_root,
+        quarantine_output=quarantine_root,
+    )
+    return public_root, quarantine_root
+
+
+@pytest.fixture
+def export_copy(
+    tmp_path: Path,
+    pristine_export: tuple[Path, Path],
+) -> tuple[Path, Path]:
+    source_public, source_quarantine = pristine_export
+    public_root = tmp_path / "public"
+    quarantine_root = tmp_path / "quarantine"
+    shutil.copytree(source_public, public_root)
+    shutil.copytree(source_quarantine, quarantine_root)
+    return public_root, quarantine_root
+
+
+def _refresh_public_component(public_root: Path, relative: str) -> None:
+    manifest_path = public_root / "manifest.json"
+    manifest = _read_json(manifest_path)
+    components = cast(list[JsonObject], manifest["components"])
+    component = next(item for item in components if item["path"] == relative)
+    path = public_root / relative
+    component["bytes"] = path.stat().st_size
+    component["sha256"] = _sha256(path)
+    _write_json(manifest_path, manifest)
+
+
+def _refresh_private_chain(
+    public_root: Path,
+    quarantine_root: Path,
+    *,
+    record_path: str | None = None,
+) -> None:
+    manifest_path = quarantine_root / "manifest.json"
+    if record_path is not None:
+        manifest = _read_json(manifest_path)
+        components = cast(list[JsonObject], manifest["record_components"])
+        component = next(item for item in components if item["path"] == record_path)
+        path = quarantine_root / record_path
+        component["bytes"] = path.stat().st_size
+        component["sha256"] = _sha256(path)
+        component["records"] = len(path.read_text(encoding="utf-8").splitlines())
+        _write_json(manifest_path, manifest)
+
+    receipt_path = public_root / "quarantine-receipt.json"
+    receipt = _read_json(receipt_path)
+    receipt_components = cast(list[JsonObject], receipt["components"])
+    for component in receipt_components:
+        relative = cast(str, component["path"])
+        path = quarantine_root / relative
+        component["bytes"] = path.stat().st_size
+        component["sha256"] = _sha256(path)
+        if relative.startswith("records/"):
+            component["records"] = len(path.read_text(encoding="utf-8").splitlines())
+    _write_json(receipt_path, receipt)
+    _refresh_public_component(public_root, "quarantine-receipt.json")
+
+
+def test_exporter_builds_and_validates_a_portable_bundle_without_mutating_source(
+    tmp_path: Path,
+) -> None:
+    legacy_root = tmp_path / "legacy"
+    audit_snapshot = tmp_path / "legacy-state.json"
+    public_root = tmp_path / "public"
+    quarantine_root = tmp_path / "quarantine"
+    _create_synthetic_legacy_repository(legacy_root, audit_snapshot)
+    head_before = _git(legacy_root, "rev-parse", "HEAD")
+    tree_before = _git(legacy_root, "rev-parse", "HEAD^{tree}")
+
+    summary = export_legacy_evidence(
+        legacy_root=legacy_root,
+        audit_snapshot=audit_snapshot,
+        public_output=public_root,
+        quarantine_output=quarantine_root,
+    )
+
+    assert summary == ExportSummary(
+        runs=3,
+        attempts=2,
+        annotations=2,
+        detections=1,
+        sessions=1,
+        promoted_models=1,
+        quarantined_segments=2,
+        quarantine_objects=5,
+    )
+    assert validate_legacy_export(
+        public_root=public_root,
+        quarantine_root=quarantine_root,
+    ) == ValidationSummary(
+        runs=3,
+        attempts=2,
+        annotations=2,
+        detections=1,
+        sessions=1,
+        quarantine_verified=True,
+    )
+    assert _git(legacy_root, "rev-parse", "HEAD") == head_before
+    assert _git(legacy_root, "rev-parse", "HEAD^{tree}") == tree_before
+    assert _git(legacy_root, "status", "--short") == ""
+
+    run_shard = _read_json(public_root / "runs" / "runs-000.json")
+    run_records = cast(list[JsonObject], run_shard["records"])
+    relocated_artifacts = cast(JsonObject, run_records[1]["artifacts"])
+    relocated_directory = cast(JsonObject, relocated_artifacts["directory"])
+    relocated_model = cast(JsonObject, relocated_artifacts["model"])
+    ambiguous_artifacts = cast(JsonObject, run_records[2]["artifacts"])
+    ambiguous_model = cast(JsonObject, ambiguous_artifacts["model"])
+    assert relocated_directory["availability"] == "available"
+    assert relocated_directory["resolved_locator"] == "legacy://data/results/run-relocated"
+    assert relocated_model["availability"] == "available"
+    assert ambiguous_model["availability"] == "ambiguous"
+
+    source_run_ids = {cast(str, record["source_run_id"]) for record in run_records}
+    promoted = _read_json(public_root / "promoted-artifacts.json")
+    promoted_artifacts = cast(list[JsonObject], promoted["artifacts"])
+    assert {cast(str, artifact["run_id"]) for artifact in promoted_artifacts}.issubset(
+        source_run_ids
+    )
+    attempt_records = _read_jsonl(quarantine_root / "records" / "attempts.jsonl")
+    session_records = _read_jsonl(quarantine_root / "records" / "sessions.jsonl")
+    assert {cast(str, record["model_run_id"]) for record in attempt_records}.issubset(
+        source_run_ids
+    )
+    assert {cast(str, record["model_run_id"]) for record in session_records}.issubset(
+        source_run_ids
+    )
+
+    private_manifest = _read_json(quarantine_root / "manifest.json")
+    private_policy = cast(JsonObject, private_manifest["policy"])
+    assert private_policy["timestamps"] == "live-records-relative-offsets-only"
+    private_objects = cast(list[JsonObject], private_manifest["objects"])
+    public_label_map = cast(JsonObject, promoted_artifacts[0]["label_map"])
+    label_uri = public_label_map["quarantine_uri"]
+    label_object = next(item for item in private_objects if item["uri"] == label_uri)
+    quarantined_labels = _read_json(quarantine_root / cast(str, label_object["storage_key"]))
+    assert public_label_map["labels"] == quarantined_labels
+
+    public_plans = _read_json(public_root / "preprocessing-plans.json")
+    plan_object = next(
+        item for item in private_objects if item["uri"] == public_plans["quarantine_uri"]
+    )
+    quarantined_plans = _read_json(quarantine_root / cast(str, plan_object["storage_key"]))
+    historical_plan = cast(JsonObject, quarantined_plans["synthetic-plan"])
+    assert historical_plan["created_at"] == "2025-01-01T10:00:00"
+    assert historical_plan["updated_at"] == "2025-01-01T10:05:00"
+
+    attempts = (quarantine_root / "records/attempts.jsonl").read_text(encoding="utf-8")
+    annotations = (quarantine_root / "records/annotations.jsonl").read_text(encoding="utf-8")
+    assert "raw-attempt" not in attempts
+    assert "operator correction" not in annotations
+    assert "2025-01" not in attempts + annotations
+
+    second_public = tmp_path / "public-second"
+    second_quarantine = tmp_path / "quarantine-second"
+    assert (
+        export_legacy_evidence(
+            legacy_root=legacy_root,
+            audit_snapshot=audit_snapshot,
+            public_output=second_public,
+            quarantine_output=second_quarantine,
+        )
+        == summary
+    )
+    assert _tree_bytes(second_public) == _tree_bytes(public_root)
+    assert _tree_bytes(second_quarantine) == _tree_bytes(quarantine_root)
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "duplicate-receipt-component",
+        "receipt-manifest-disagreement",
+        "attempt-sequence",
+        "annotation-reference",
+        "detection-reference",
+        "segment-reference",
+        "segment-role",
+        "missing-public-artifact",
+        "public-artifact-role",
+        "undeclared-file",
+        "unclassified-segment",
+        "aggregate-count",
+        "receipt-count",
+        "unknown-promoted-run",
+        "unknown-attempt-model",
+        "unknown-session-model",
+        "label-map-content",
+        "duplicate-promoted-run",
+        "duplicate-promoted-model",
+        "promoted-model-key-mismatch",
+    ],
+)
+def test_private_validator_rejects_integrity_and_relationship_tampering(
+    export_copy: tuple[Path, Path],
+    case: str,
+) -> None:
+    public_root, quarantine_root = export_copy
+    receipt_path = public_root / "quarantine-receipt.json"
+    private_manifest_path = quarantine_root / "manifest.json"
+    receipt = _read_json(receipt_path)
+    private_manifest = _read_json(private_manifest_path)
+
+    if case == "duplicate-receipt-component":
+        components = cast(list[JsonObject], receipt["components"])
+        components.append(dict(components[0]))
+        _write_json(receipt_path, receipt)
+        _refresh_public_component(public_root, "quarantine-receipt.json")
+    elif case == "receipt-manifest-disagreement":
+        components = cast(list[JsonObject], receipt["components"])
+        record_component = next(
+            item for item in components if item["path"] == "records/attempts.jsonl"
+        )
+        del record_component["records"]
+        _write_json(receipt_path, receipt)
+        _refresh_public_component(public_root, "quarantine-receipt.json")
+    elif case in {"attempt-sequence", "annotation-reference", "detection-reference"}:
+        relative = {
+            "attempt-sequence": "records/attempts.jsonl",
+            "annotation-reference": "records/annotations.jsonl",
+            "detection-reference": "records/detections.jsonl",
+        }[case]
+        path = quarantine_root / relative
+        records = _read_jsonl(path)
+        if case == "attempt-sequence":
+            records[0]["record_id"] = "attempt-000003"
+        elif case == "annotation-reference":
+            records[0]["attempt_ref"] = "attempt-999999"
+        else:
+            records[0]["session_ref"] = "session-9999"
+        _write_jsonl(path, records)
+        _refresh_private_chain(public_root, quarantine_root, record_path=relative)
+    elif case in {"segment-reference", "segment-role"}:
+        attempts_path = quarantine_root / "records" / "attempts.jsonl"
+        attempts = _read_jsonl(attempts_path)
+        segment_uri = cast(str, attempts[0]["segment_uri"])
+        if case == "segment-reference":
+            attempts[0]["segment_uri"] = f"quarantine://sha256/{'0' * 64}.npz"
+            _write_jsonl(attempts_path, attempts)
+            _refresh_private_chain(
+                public_root,
+                quarantine_root,
+                record_path="records/attempts.jsonl",
+            )
+        else:
+            objects = cast(list[JsonObject], private_manifest["objects"])
+            segment = next(item for item in objects if item["uri"] == segment_uri)
+            segment["roles"] = ["orphan-live-segment"]
+            _write_json(private_manifest_path, private_manifest)
+            _refresh_private_chain(public_root, quarantine_root)
+    elif case in {"missing-public-artifact", "public-artifact-role"}:
+        promoted = _read_json(public_root / "promoted-artifacts.json")
+        artifact = cast(list[JsonObject], promoted["artifacts"])[0]
+        model = cast(JsonObject, artifact["model"])
+        model_uri = cast(str, model["quarantine_uri"])
+        objects = cast(list[JsonObject], private_manifest["objects"])
+        model_object = next(item for item in objects if item["uri"] == model_uri)
+        if case == "missing-public-artifact":
+            objects.remove(model_object)
+        else:
+            model_object["roles"] = ["unrelated-role"]
+        _write_json(private_manifest_path, private_manifest)
+        _refresh_private_chain(public_root, quarantine_root)
+    elif case == "undeclared-file":
+        (quarantine_root / "undeclared.json").write_text("{}\n", encoding="utf-8")
+    elif case == "unclassified-segment":
+        objects = cast(list[JsonObject], private_manifest["objects"])
+        orphan = next(
+            item for item in objects if "orphan-live-segment" in cast(list[str], item["roles"])
+        )
+        orphan["roles"] = ["unclassified-segment"]
+        _write_json(private_manifest_path, private_manifest)
+        _refresh_private_chain(public_root, quarantine_root)
+    elif case == "aggregate-count":
+        counts = cast(JsonObject, private_manifest["counts"])
+        counts["sessions"] = cast(int, counts["sessions"]) + 1
+        _write_json(private_manifest_path, private_manifest)
+        _refresh_private_chain(public_root, quarantine_root)
+    elif case == "receipt-count":
+        public_manifest = _read_json(public_root / "manifest.json")
+        public_counts = cast(JsonObject, public_manifest["counts"])
+        receipt_counts = cast(JsonObject, receipt["counts"])
+        public_counts["attempts"] = cast(int, public_counts["attempts"]) + 1
+        receipt_counts["attempts"] = cast(int, receipt_counts["attempts"]) + 1
+        _write_json(receipt_path, receipt)
+        _write_json(public_root / "manifest.json", public_manifest)
+        _refresh_public_component(public_root, "quarantine-receipt.json")
+    elif case in {
+        "unknown-promoted-run",
+        "label-map-content",
+        "duplicate-promoted-run",
+        "duplicate-promoted-model",
+        "promoted-model-key-mismatch",
+    }:
+        promoted_path = public_root / "promoted-artifacts.json"
+        promoted = _read_json(promoted_path)
+        artifacts = cast(list[JsonObject], promoted["artifacts"])
+        artifact = artifacts[0]
+        if case == "unknown-promoted-run":
+            artifact["run_id"] = "missing-run"
+        elif case == "label-map-content":
+            label_map = cast(JsonObject, artifact["label_map"])
+            label_map["labels"] = {"0": "tampered-label"}
+        elif case == "promoted-model-key-mismatch":
+            artifact["model_key"] = "causal_gru"
+        else:
+            duplicate = cast(JsonObject, json.loads(json.dumps(artifact)))
+            if case == "duplicate-promoted-run":
+                duplicate["model_key"] = "causal_gru"
+            else:
+                duplicate["run_id"] = "run-good"
+            artifacts.append(duplicate)
+        _write_json(promoted_path, promoted)
+        _refresh_public_component(public_root, "promoted-artifacts.json")
+    else:
+        relative = (
+            "records/attempts.jsonl"
+            if case == "unknown-attempt-model"
+            else "records/sessions.jsonl"
+        )
+        path = quarantine_root / relative
+        records = _read_jsonl(path)
+        records[0]["model_run_id"] = "missing-run"
+        _write_jsonl(path, records)
+        _refresh_private_chain(public_root, quarantine_root, record_path=relative)
+
+    with pytest.raises(LegacyExportError):
+        validate_legacy_export(
+            public_root=public_root,
+            quarantine_root=quarantine_root,
+        )
+
+
+@pytest.mark.parametrize("sensitive_key", SENSITIVE_KEY_FORMS)
+def test_private_live_records_reject_every_nested_sensitive_key(
+    export_copy: tuple[Path, Path],
+    sensitive_key: str,
+) -> None:
+    public_root, quarantine_root = export_copy
+    attempts_path = quarantine_root / "records" / "attempts.jsonl"
+    attempts = _read_jsonl(attempts_path)
+    attempts[0]["segmentation"] = {"nested": {sensitive_key: "opaque-identifier"}}
+    _write_jsonl(attempts_path, attempts)
+    _refresh_private_chain(
+        public_root,
+        quarantine_root,
+        record_path="records/attempts.jsonl",
+    )
+
+    with pytest.raises(LegacyExportError):
+        validate_legacy_export(
+            public_root=public_root,
+            quarantine_root=quarantine_root,
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        (
+            "trace_token",
+            "123e4567-e89b" + "-12d3-a456-426614174000",
+            "raw UUID-like",
+        ),
+        ("observed_at", "2025-01-01T10:00:00", "absolute timestamp"),
+    ],
+)
+def test_private_live_records_reject_raw_identifiers_and_absolute_timestamps(
+    export_copy: tuple[Path, Path],
+    field: str,
+    value: str,
+    message: str,
+) -> None:
+    public_root, quarantine_root = export_copy
+    attempts_path = quarantine_root / "records" / "attempts.jsonl"
+    attempts = _read_jsonl(attempts_path)
+    attempts[0]["segmentation"] = {field: value}
+    _write_jsonl(attempts_path, attempts)
+    _refresh_private_chain(
+        public_root,
+        quarantine_root,
+        record_path="records/attempts.jsonl",
+    )
+
+    with pytest.raises(LegacyExportError, match=message):
+        validate_legacy_export(
+            public_root=public_root,
+            quarantine_root=quarantine_root,
+        )
+
+
+def test_validator_rejects_missing_public_or_private_roots(
+    tmp_path: Path,
+    pristine_export: tuple[Path, Path],
+) -> None:
+    public_root, _ = pristine_export
+    with pytest.raises(LegacyExportError, match="public legacy export is unavailable"):
+        validate_legacy_export(public_root=tmp_path / "missing-public")
+    with pytest.raises(LegacyExportError, match="private legacy quarantine is unavailable"):
+        validate_legacy_export(
+            public_root=public_root,
+            quarantine_root=tmp_path / "missing-private",
+        )
+
+
+@pytest.mark.parametrize("boundary", ["same", "nested", "inside-source", "nonempty"])
+def test_exporter_rejects_unsafe_output_boundaries(tmp_path: Path, boundary: str) -> None:
+    legacy_root = tmp_path / "legacy"
+    legacy_root.mkdir()
+    audit_snapshot = tmp_path / "audit.json"
+    audit_snapshot.write_text("{}\n", encoding="utf-8")
+    public_root = tmp_path / "public"
+    quarantine_root = tmp_path / "private"
+    if boundary == "same":
+        quarantine_root = public_root
+    elif boundary == "nested":
+        quarantine_root = public_root / "private"
+    elif boundary == "inside-source":
+        public_root = legacy_root / "public"
+    else:
+        public_root.mkdir()
+        (public_root / "existing.json").write_text("{}\n", encoding="utf-8")
+
+    with pytest.raises(LegacyExportError):
+        export_legacy_evidence(
+            legacy_root=legacy_root,
+            audit_snapshot=audit_snapshot,
+            public_output=public_root,
+            quarantine_output=quarantine_root,
+        )
+
+
+def test_exporter_rolls_back_staging_when_the_audit_is_invalid(tmp_path: Path) -> None:
+    legacy_root = tmp_path / "legacy"
+    legacy_root.mkdir()
+    audit_snapshot = tmp_path / "audit.json"
+    audit_snapshot.write_text("not-json\n", encoding="utf-8")
+    public_root = tmp_path / "public"
+    quarantine_root = tmp_path / "private"
+
+    with pytest.raises(LegacyExportError, match="could not complete safely"):
+        export_legacy_evidence(
+            legacy_root=legacy_root,
+            audit_snapshot=audit_snapshot,
+            public_output=public_root,
+            quarantine_output=quarantine_root,
+        )
+
+    assert not public_root.exists()
+    assert not quarantine_root.exists()
+    assert list(tmp_path.glob(".signlab-*-*")) == []

--- a/uv.lock
+++ b/uv.lock
@@ -56,6 +56,15 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
 name = "build"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -161,6 +170,33 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
 ]
 
 [[package]]
@@ -378,6 +414,20 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "rich"
 version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -388,6 +438,29 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051, upload-time = "2026-06-30T07:17:53.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/be/2e8974163072e7bab7df1a5acd54c4498e75e35d6d18b864d3a9d5dadc92/rpds_py-2026.6.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a0811d33247c3d6128a3001d763f2aa056bb3425204335400ac54f89eec3a0d0", size = 343691, upload-time = "2026-06-30T07:15:14.96Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/73/319dfa745dd668efe89309141ded489126461fcecd2b8f3a3cda185129b6/rpds_py-2026.6.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:538949e262e46caa31ac01bdb3c1e8f642622922cacbabbae6a8445d9dc33eaf", size = 338542, upload-time = "2026-06-30T07:15:16.267Z" },
+    { url = "https://files.pythonhosted.org/packages/21/63/4239893be1c4d09b709b1a8f6be4188f0870084ff547f46606b8a75f1b03/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55927d532399c2c646100ff7feb48eaa940ad70f42cd68e1328f3ded9f81ca24", size = 368180, upload-time = "2026-06-30T07:15:17.62Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/ca/9c5de382225234ceb37b1844ebdb140db12b2a278bb9efe2fcd19f6c82ce/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f56f1695bc5c0871cbc33dc0130fcf503aab0c57dcc5a6700a4f49eba4f2652e", size = 375067, upload-time = "2026-06-30T07:15:18.952Z" },
+    { url = "https://files.pythonhosted.org/packages/87/dc/863f69d1bf04ade34b7fe0d59b9fdf6f0135fe2d7cbca74f1d665589559d/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:270b293dae9058fc9fcedab50f13cebf46fb8ed1d1d54e0521a9da5d6b211975", size = 490509, upload-time = "2026-06-30T07:15:20.434Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ef/eac16a12048b45ec7c7fa94f2be3438a5f26bf9cc8580b18a1cfd609b7f6/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:127565fead0a10943b282957bd5447804ff3160ad79f2ad2635e6d249e380680", size = 382754, upload-time = "2026-06-30T07:15:21.831Z" },
+    { url = "https://files.pythonhosted.org/packages/04/8f/d2f3f532616be4d06c316ef119683e832bd3d41e112bf3a88f4151c95b17/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecabd69db66de867690f9797f2f8fa27ba501bbc24540cbdbdc649cd15888ba6", size = 366189, upload-time = "2026-06-30T07:15:23.371Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/29/41a7b0e98a4b44cd676ab7598419623373eb43b20be68c084935c1a8cf88/rpds_py-2026.6.3-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:58eadac9cd119677b60e1cf8ac4052f35949d71b8a9e5556efccbe82533cf22a", size = 377750, upload-time = "2026-06-30T07:15:24.659Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/05/ecda0bec46f9a1565090bcdc941d023f6a25aff85fda28f89f8d19878152/rpds_py-2026.6.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7491ee23305ac3eb59e492b6945881f5cd77a6f731061a3f25b77fd40f9e99a4", size = 395576, upload-time = "2026-06-30T07:15:25.987Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a8/6ed52f03ee6cb854ce78785cc9a9a672eb880e83fd7224d471f667d151f1/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2c99f7e8ccb3dd6e3e4bfeac657a7b208c9bac8075f4b078c02d7404c34107fa", size = 543807, upload-time = "2026-06-30T07:15:27.356Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/d6/156c0d3eea27ba09b92562ba2364ba124c0a061b199e17eac637cd25a5e2/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:62698275682bf121181861295c9181e789030a2d516071f5b8f3c23c170cd0fc", size = 611187, upload-time = "2026-06-30T07:15:28.931Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/31/774212ed989c62f7f310220089f9b0a3fb8f40f5443d1727abd5d9f52bc9/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a214c993455f99a89aaeadc9b21241900037adc9d97203e374d75513c5911822", size = 573030, upload-time = "2026-06-30T07:15:30.553Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/50/22f73127a41f1ce4f87fe39aadfb9a126345801c274aa93ae88456249327/rpds_py-2026.6.3-cp312-cp312-win32.whl", hash = "sha256:501f9f04a588d6a09179368c57071301445191767c64e4b52a6aa9871f1ef5ed", size = 202185, upload-time = "2026-06-30T07:15:32.027Z" },
+    { url = "https://files.pythonhosted.org/packages/04/3a/f0ee4d4dde9d3b69dedf1b5f74e7a40017046d55052d173e418c6a94f960/rpds_py-2026.6.3-cp312-cp312-win_amd64.whl", hash = "sha256:2c958bf94822e9290a40aaf2a822d4bc5c88099093e3948ad6c571eca9272e5f", size = 220394, upload-time = "2026-06-30T07:15:33.359Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/83/3382fe37f809b59f02aac04dbc4e765b480b46ee0227ed516e3bdc4d3dfc/rpds_py-2026.6.3-cp312-cp312-win_arm64.whl", hash = "sha256:22bffe6042b9bcb0822bcd1955ec00e245daf17b4344e4ed8e9551b976b63e96", size = 215753, upload-time = "2026-06-30T07:15:34.778Z" },
 ]
 
 [[package]]
@@ -428,6 +501,7 @@ wheels = [
 name = "signlab"
 source = { editable = "." }
 dependencies = [
+    { name = "jsonschema" },
     { name = "typer" },
 ]
 
@@ -440,10 +514,14 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "types-jsonschema" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "typer", specifier = ">=0.27.1,<0.28" }]
+requires-dist = [
+    { name = "jsonschema", specifier = ">=4.26,<5" },
+    { name = "typer", specifier = ">=0.27.1,<0.28" },
+]
 
 [package.metadata.requires-dev]
 dev = [
@@ -454,6 +532,7 @@ dev = [
     { name = "pytest", specifier = ">=9.1.1,<10" },
     { name = "pytest-cov", specifier = ">=7,<8" },
     { name = "ruff", specifier = "==0.16.3" },
+    { name = "types-jsonschema", specifier = "==4.26.0.20260518" },
 ]
 
 [[package]]
@@ -487,6 +566,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ae/40/4a3db7990d1f62a53182aa96eaef57aeb2886a27f90a195bc66713565d31/typer-0.27.1.tar.gz", hash = "sha256:a79bef8469a79c45498e7b814ecf8d603cc7644e9acbd9e19cac0334240b18df", size = 203994, upload-time = "2026-08-03T14:41:03.438Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/43/89/9518bc0c3929bee36b3a4a8e3daddd6e03f92f9961c66d4983b837160543/typer-0.27.1-py3-none-any.whl", hash = "sha256:53150287edd11baeb4e4722c8e394fcdf8181c0ae89485cba8d25c778d5edd56", size = 122874, upload-time = "2026-08-03T14:41:04.391Z" },
+]
+
+[[package]]
+name = "types-jsonschema"
+version = "4.26.0.20260518"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/46/73b6a5d61a61015c4248030a8cb07e5bdddb4041430fae9e585a68692578/types_jsonschema-4.26.0.20260518.tar.gz", hash = "sha256:e1dd53dc97a64f5eccdd6fa9839666e09bb500a8ebba2db6fdaf1789faea81a6", size = 16638, upload-time = "2026-05-18T06:06:44.106Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/d5/134f8a147dcecda10db7f60cfc6af0578a25a5c53c87b3907a64385e0184/types_jsonschema-4.26.0.20260518-py3-none-any.whl", hash = "sha256:30b30a518c7fe335df85c919fcbcc631b69c03d4a4b5b632fa916bea03065307", size = 16072, upload-time = "2026-05-18T06:06:43.264Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Outcome

Exports the useful legacy evidence into two deliberately separate layers:

- a committed, portable public index with all 464 run records, closed JSON Schemas, promoted-model/label-map/plan hashes, and a private-quarantine receipt;
- an ignored, content-addressed private quarantine with 529 segment objects and sanitized live records.

The exporter verifies the immutable legacy audit before and after generation, opens SQLite sources read-only/immutable, never deserializes models or NPZ files, and publishes atomically. The standalone validator applies Draft 2020-12 contracts and reconciles paths, hashes, counts, source-run/model provenance, joins, privacy fields, and public/private artifact contents.

## Evidence

- 464 runs: 457 succeeded, 6 failed, 1 stale-running
- 532 attempts, 408 annotations, 45 detections, 5 sessions
- 529 segments: 525 referenced, 4 orphaned
- 4 promoted models and 3 preprocessing plans
- all historical `thank you` labels preserved; `nothing` remains a historical/quarantined token
- public and private regenerations are byte-for-byte deterministic
- legacy Git/database/artifact fingerprints still match the immutable audit

## Verification

- `uv run --locked pytest` — 191 passed, 91.35% branch-aware coverage
- Ruff, formatting, and strict mypy
- repository hygiene and pre-commit
- source/wheel build and isolated installed-wheel verification
- `signlab doctor check`
- public-only and public+private legacy validation
- two independent review rounds; no remaining P0/P1/P2 findings

The private quarantine remains local-only and is not a durable backup; later private-DVC work must provide authenticated off-machine storage.

Closes #8