### PR TITLE
Define immutable gesture taxonomy and product claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 # SignLab
 
-SignLab is a reproducible research and deployment project for a small-vocabulary,
-continuous hand-gesture recognition system. It replaces an earlier Streamlit
-prototype with a UI-independent ML pipeline, leakage-resistant evaluation, and
-a privacy-preserving browser demo.
+SignLab is a research prototype for recognizing isolated performances of five
+predefined hand gestures within continuous webcam video. It separates non-target
+events (`other`) from no active event (`inactive`) and uncertain decisions
+(`abstain`); no sign-language or translation capability is claimed.
+
+The project replaces an earlier Streamlit prototype with a UI-independent ML
+pipeline, leakage-resistant evaluation, and a privacy-preserving browser demo.
 
 ## Project goals
 
@@ -62,6 +65,10 @@ uv run python scripts/verify_distribution.py dist
 See [docs/development.md](docs/development.md) for directory ownership, dependency
 updates, generated-file policy, and the Python-version decision.
 
+The [gesture taxonomy and claim boundary](docs/gesture-taxonomy.md) define the
+versioned six-output classifier vocabulary and the evidence required before making
+any named-language claim.
+
 The [legacy audit](docs/legacy-audit.md) and
 [portable evidence export](docs/legacy-export.md) document what was retained from
 the school project, why it is development-only, and how to validate it without any
@@ -92,10 +99,10 @@ implementation backlog.
 
 ## Repository status
 
-The immutable legacy audit, reproducible developer foundation, and sanitized legacy
-evidence export are established. Taxonomy and core contracts are still under
-construction; no headline model result is considered valid until the grouped
-evaluation foundations are complete.
+The immutable legacy audit, reproducible developer foundation, sanitized legacy
+evidence export, and versioned gesture taxonomy are established. The remaining core
+contracts are still under construction; no headline model result is considered
+valid until the grouped evaluation foundations are complete.
 
 ## Data and privacy
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -28,6 +28,12 @@ versioned and evaluated separately.
 
 ## Data contracts
 
+Every collection, annotation, training, evaluation, bundle, and public-copy
+contract embeds the same immutable taxonomy reference: `signlab-five@1.0.0` plus
+the canonical SHA-256. The [taxonomy](gesture-taxonomy.md) is authoritative for
+label order, event boundaries, negative examples, legacy aliases, and the public
+claim. Downstream contracts may add fields but cannot reinterpret its identifiers.
+
 The sample manifest will include stable identifiers for clips, signers, sessions,
 source recordings, devices, capture conditions, handedness, mirroring, consent,
 and checksums. Derived samples inherit the source recording and split.

--- a/docs/PROJECT_CHARTER.md
+++ b/docs/PROJECT_CHARTER.md
@@ -10,13 +10,18 @@ drift from training, and idle/unknown behavior was underspecified.
 
 ## Product claim
 
-Until validated by fluent signers and a documented language source, SignLab is:
+Until the gestures are reviewed by a qualified signer against documented lexical
+sources, SignLab's approved claim is:
 
-> A five-class isolated hand-gesture recognition system with continuous webcam
-> segmentation and calibrated rejection.
+> SignLab is a research prototype for recognizing isolated performances of five
+> predefined hand gestures within continuous webcam video. It separates non-target
+> events (`other`) from no active event (`inactive`) and uncertain decisions
+> (`abstain`); no sign-language or translation capability is claimed.
 
-It is not described as sign-language translation, a complete accessibility
-solution, or a system that understands a sign language.
+The five targets plus learned `other` produce six classifier outputs. `inactive`
+belongs to event detection and `abstain` to the decision policy; neither is a class.
+SignLab is not described as a complete accessibility solution or as understanding
+a named sign language.
 
 ## Primary outcome
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -61,6 +61,19 @@ scans complete pull-request history for secrets.
 
 ## Generated and private state
 
+Pydantic models in `src/signlab/contracts/` are authoritative. Reviewable JSON
+Schemas under `src/signlab/resources/schemas/` are generated package data. After a
+taxonomy-model change, run:
+
+```shell
+uv run python scripts/generate_taxonomy_schemas.py
+```
+
+Tests compare every committed schema byte-for-byte at the JSON-document level and
+verify that the wheel contains both schemas and immutable taxonomy instances. A
+semantic change to a published taxonomy requires a new versioned artifact and a new
+golden digest, not an in-place edit.
+
 The Git ignore rules cover local environments, caches, coverage, builds, DVC cache,
 tracking databases, datasets, videos, features, checkpoints, and model bundles. The
 repository guard independently rejects ignored high-risk path families, artifact

--- a/docs/gesture-taxonomy.md
+++ b/docs/gesture-taxonomy.md
@@ -1,0 +1,115 @@
+# Gesture taxonomy and claim boundary
+
+SignLab taxonomy `signlab-five@1.0.0` defines five target gestures and one learned
+negative class. The authoritative machine-readable artifact is packaged at
+`src/signlab/resources/taxonomies/signlab-five-1.0.0.json`; its validated canonical
+content digest is
+`sha256:c0f6cbddfe43e3a6eb3de01dbbbbc1ceebcb83d50cc197999776f58e3d9ce20d`.
+
+## Approved product claim
+
+> SignLab is a research prototype for recognizing isolated performances of five
+> predefined hand gestures within continuous webcam video. It separates non-target
+> events (`other`) from no active event (`inactive`) and uncertain decisions
+> (`abstain`); no sign-language or translation capability is claimed.
+
+The English display names describe this project's gesture prompts. They are not a
+claim that the forms are validated lexical items in American Sign Language or any
+other named language. A named-language claim requires a qualified reviewer, an
+identified lexical source entry for every gesture, review scope and date, variant
+notes, and an evidence digest. Version 1 rejects every named-language claim; after
+human review, support requires a new bounded claim profile and taxonomy release.
+
+## Learned outputs
+
+The output order is immutable for version `1.0.0`:
+
+| Index | Stable ID | Role | Operational definition |
+| ---: | --- | --- | --- |
+| 0 | `hello` | target | Open hand near the temple or upper face with a short outward or side-to-side wave. |
+| 1 | `no` | target | Thumb closes toward extended index and middle fingertips one or more times. |
+| 2 | `please` | target | Flat or open palm at the upper chest with a small circular stroke. |
+| 3 | `thank_you` | target | Flat or open hand begins at the chin or lower face and moves outward in one stroke. |
+| 4 | `yes` | target | Closed fist near the upper torso performs one or more wrist-driven vertical nods. |
+| 5 | `other` | learned negative | A complete candidate event confidently outside the five-target vocabulary. |
+
+Each class has positive, clear-negative, ambiguous, and transition-boundary
+examples in the machine-readable taxonomy. Those examples—not the English mnemonic
+alone—define annotation eligibility.
+
+## Detector state, class, and decision
+
+These concepts belong to different layers and must never share a classifier index:
+
+1. No finalized candidate event exists: the event detector emits `inactive`.
+2. A target score meets its acceptance policy: the decision is that target ID.
+3. A non-target score meets its acceptance policy: the learned class is `other`.
+4. No class can be accepted at the declared risk: the policy emits `abstain`.
+
+`ambiguous` and `ignore` are annotation dispositions, not runtime classes.
+Ambiguous events require adjudication before use. Ignore regions require a recorded
+reason and are excluded according to the evaluator's predeclared overlap rule.
+
+## Edge-case rules
+
+- Either hand is accepted only after handedness normalization is recorded.
+- An incidental second hand is allowed only when it does not contact, occlude, or
+  alter the active hand. Coordinated two-hand activity is `other` in this version.
+- A clearly incomplete target attempt is `other/partial_target`; insufficient
+  visibility is `ambiguous`.
+- A complete out-of-vocabulary candidate is `other/oov_gesture`.
+- Target transitions do not automatically become training examples. Derived
+  `other/transition_fragment` examples are allowed only on train or development
+  splits.
+- Poor segmentation does not change source truth. Continuous evaluation must still
+  record detector misses, truncation, and fragmentation.
+- Ignore reasons include consent exclusion, camera setup, third-party presence,
+  unresolved annotation conflict, and unusable occlusion.
+
+The broad `other` class retains `other_kind` metadata: `partial_target`,
+`transition_fragment`, `oov_gesture`, `incidental_activity`, or
+`two_hand_non_target`. These are analysis subtypes, not extra classifier outputs.
+
+## Legacy migration
+
+The historical spelling `thank you` has one explicit import alias to `thank_you`.
+Core manifests reject the alias. The legacy token `nothing` is not equivalent to
+`other`: it mixed idle footage, transitions, and unrelated activity, so it remains
+quarantined for reannotation.
+
+## Contract propagation
+
+Collection, annotation, training, evaluation, model-bundle, and public-copy
+contracts must embed the same `TaxonomyRef` (`id`, semantic version, and canonical
+SHA-256). Closed JSON Schemas for all six bindings are generated from Pydantic and
+shipped with the package. The training binding additionally requires the exact
+six-output label map and a positive observed count for every output. Both Python
+and standalone JSON Schema reject a missing or empty `other` class.
+
+Validate the packaged artifact with:
+
+```shell
+uv run signlab taxonomy validate
+uv run signlab taxonomy validate-resources
+uv run signlab train validate-taxonomy path/to/training-taxonomy-binding.json
+```
+
+Regenerate schemas with `uv run python scripts/generate_taxonomy_schemas.py`. Tests
+fail if the generated output, packaged taxonomy, or golden digest drifts. Semantic
+changes require a new taxonomy version and artifact; an existing version is never
+edited in place. The wire-level schemas enumerate every registered immutable
+release, so adding a new taxonomy version does not invalidate manifests that still
+reference an older supported release.
+
+## Research basis
+
+- The [National Association of the Deaf](https://nad.org/knowledge-hub/american-sign-language/what-is-american-sign-language/)
+  describes ASL as a language with its own grammar whose forms depend on handshape,
+  movement, placement, face, and body. English word labels alone are not validation.
+- The [ASL Citizen datasheet](https://www.microsoft.com/en-us/research/project/asl-citizen/datasheet/)
+  documents lexical and regional variation and the involvement of Deaf researchers.
+- The [NIST AI Risk Management Framework](https://airc.nist.gov/airmf-resources/airmf/5-sec-core/)
+  calls for explicit intended scope, context, knowledge limits, and limitations.
+- Selective classification treats abstention as a reject decision with a measurable
+  risk/coverage tradeoff; see [El-Yaniv and Wiener (JMLR, 2010)](https://jmlr.csail.mit.edu/papers/v11/el-yaniv10a.html).
+- Portable schemas use [JSON Schema Draft 2020-12](https://json-schema.org/draft/2020-12).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
 ]
 dependencies = [
   "jsonschema>=4.26,<5",
+  "pydantic>=2.13.4,<2.14",
   "typer>=0.27.1,<0.28",
 ]
 

--- a/scripts/generate_taxonomy_schemas.py
+++ b/scripts/generate_taxonomy_schemas.py
@@ -1,0 +1,37 @@
+"""Regenerate committed taxonomy JSON Schemas from the Pydantic source of truth."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from signlab.contracts.taxonomy import generated_json_schemas
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_DIRECTORY = REPOSITORY_ROOT / "src" / "signlab" / "resources" / "schemas"
+
+
+def render_schema(schema: dict[str, object]) -> str:
+    """Return stable, reviewable JSON for one generated schema."""
+    return json.dumps(schema, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+
+
+def write_schemas(directory: Path = SCHEMA_DIRECTORY) -> tuple[Path, ...]:
+    """Write all generated schemas and return their paths in stable order."""
+    directory.mkdir(parents=True, exist_ok=True)
+    written: list[Path] = []
+    for filename, schema in sorted(generated_json_schemas().items()):
+        path = directory / filename
+        path.write_text(render_schema(schema), encoding="utf-8", newline="\n")
+        written.append(path)
+    return tuple(written)
+
+
+def main() -> None:
+    """Regenerate the taxonomy schemas."""
+    for path in write_schemas():
+        print(path.relative_to(REPOSITORY_ROOT).as_posix())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/verify_distribution.py
+++ b/scripts/verify_distribution.py
@@ -14,6 +14,16 @@ from collections.abc import Iterable, Sequence
 from pathlib import Path, PurePosixPath
 
 MAX_MEMBER_BYTES = 1_048_576
+EXPECTED_TAXONOMY_SCHEMAS = {
+    "annotation-taxonomy-binding-1.schema.json",
+    "bundle-taxonomy-binding-1.schema.json",
+    "collection-taxonomy-binding-1.schema.json",
+    "evaluation-taxonomy-binding-1.schema.json",
+    "gesture-taxonomy-1.schema.json",
+    "public-copy-taxonomy-binding-1.schema.json",
+    "taxonomy-reference-1.schema.json",
+    "training-taxonomy-binding-1.schema.json",
+}
 FORBIDDEN_REPOSITORY_ROOTS = {
     "artifacts",
     "data",
@@ -92,6 +102,20 @@ def _inspect_wheel(wheel: Path) -> tuple[str, ...]:
             errors.append("wheel is missing the typed-package marker")
         if not any(name.startswith("signlab/commands/") for name in names):
             errors.append("wheel is missing CLI command modules")
+        taxonomy_members = {
+            PurePosixPath(name).name
+            for name in names
+            if name.startswith("signlab/resources/taxonomies/") and name.endswith(".json")
+        }
+        if taxonomy_members != {"signlab-five-1.0.0.json"}:
+            errors.append("wheel is missing the built-in gesture taxonomy")
+        schema_members = {
+            PurePosixPath(name).name
+            for name in names
+            if name.startswith("signlab/resources/schemas/") and name.endswith(".json")
+        }
+        if schema_members != EXPECTED_TAXONOMY_SCHEMAS:
+            errors.append("wheel does not contain the exact generated taxonomy schema set")
         if not any(name.endswith(".dist-info/METADATA") for name in names):
             errors.append("wheel is missing distribution metadata")
         entry_point_members = [
@@ -170,13 +194,21 @@ def _install_and_smoke_test(wheel: Path) -> None:
             raise RuntimeError("isolated wheel did not expose a version")
         console_script = _venv_executable(virtual_environment, "signlab")
         _run([str(console_script), "--version"], environment=environment)
-        for command in ("data", "train", "evaluate", "export", "doctor"):
+        for command in ("data", "train", "evaluate", "export", "doctor", "taxonomy"):
             _run(
                 [str(console_script), command, "--help"],
                 environment=environment,
             )
         _run(
             [str(console_script), "doctor", "check"],
+            environment=environment,
+        )
+        _run(
+            [str(console_script), "taxonomy", "validate"],
+            environment=environment,
+        )
+        _run(
+            [str(console_script), "taxonomy", "validate-resources"],
             environment=environment,
         )
 

--- a/src/signlab/cli.py
+++ b/src/signlab/cli.py
@@ -7,7 +7,7 @@ from typing import Annotated
 import typer
 
 from signlab import __version__
-from signlab.commands import data, doctor, evaluate, export, train
+from signlab.commands import data, doctor, evaluate, export, taxonomy, train
 
 
 def _show_version(value: bool) -> None:
@@ -28,6 +28,7 @@ app.add_typer(train.app, name="train")
 app.add_typer(evaluate.app, name="evaluate")
 app.add_typer(export.app, name="export")
 app.add_typer(doctor.app, name="doctor")
+app.add_typer(taxonomy.app, name="taxonomy")
 
 
 @app.callback()

--- a/src/signlab/commands/taxonomy.py
+++ b/src/signlab/commands/taxonomy.py
@@ -1,0 +1,81 @@
+"""CLI adapter for inspecting and validating the gesture taxonomy."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+from signlab.contracts.taxonomy import (
+    GestureTaxonomy,
+    TaxonomyContractError,
+    load_builtin_taxonomy,
+    taxonomy_reference,
+    validate_packaged_taxonomy_resources,
+    validate_taxonomy,
+)
+
+app = typer.Typer(
+    help="Inspect and validate the immutable gesture vocabulary.",
+    no_args_is_help=True,
+)
+
+
+def _load(path: Path | None) -> tuple[str, GestureTaxonomy]:
+    if path is None:
+        return "built-in", load_builtin_taxonomy()
+    try:
+        return "external", validate_taxonomy(path.read_bytes())
+    except OSError as error:
+        raise TaxonomyContractError("taxonomy file could not be read") from error
+
+
+@app.command("validate")
+def validate_command(
+    path: Annotated[
+        Path | None,
+        typer.Argument(
+            help="Optional taxonomy JSON; omit to validate the packaged taxonomy.",
+        ),
+    ] = None,
+) -> None:
+    """Validate a taxonomy and print its portable identity."""
+    try:
+        source, taxonomy = _load(path)
+        reference = taxonomy_reference(taxonomy)
+    except TaxonomyContractError as error:
+        typer.echo(f"Taxonomy validation failed: {error}", err=True)
+        raise typer.Exit(code=1) from error
+    typer.echo(f"Taxonomy valid ({source}): {reference.id}@{reference.version} {reference.sha256}")
+
+
+@app.command("validate-resources")
+def validate_resources_command() -> None:
+    """Validate every packaged taxonomy and generated schema resource."""
+    try:
+        load_builtin_taxonomy()
+        validate_packaged_taxonomy_resources()
+    except TaxonomyContractError as error:
+        typer.echo(f"Taxonomy resource validation failed: {error}", err=True)
+        raise typer.Exit(code=1) from error
+    typer.echo("Packaged taxonomy and schemas are valid.")
+
+
+@app.command("show")
+def show_command() -> None:
+    """Print the packaged taxonomy as stable, reviewable JSON."""
+    try:
+        taxonomy = load_builtin_taxonomy()
+    except TaxonomyContractError as error:
+        typer.echo(f"Taxonomy validation failed: {error}", err=True)
+        raise typer.Exit(code=1) from error
+    typer.echo(
+        json.dumps(
+            taxonomy.model_dump(mode="json", round_trip=True),
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+    )

--- a/src/signlab/commands/train.py
+++ b/src/signlab/commands/train.py
@@ -1,5 +1,38 @@
 """Training command group."""
 
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
 from signlab.commands._group import create_group
+from signlab.contracts.taxonomy import (
+    TaxonomyContractError,
+    validate_training_taxonomy_binding,
+)
 
 app = create_group(help_text="Run reproducible training experiments from validated configurations.")
+
+
+@app.command("validate-taxonomy")
+def validate_taxonomy_command(
+    path: Annotated[
+        Path,
+        typer.Argument(help="Training taxonomy-binding JSON to validate before training."),
+    ],
+) -> None:
+    """Fail closed when training labels or learned negatives drift from the taxonomy."""
+    try:
+        binding = validate_training_taxonomy_binding(path.read_bytes())
+    except OSError as error:
+        typer.echo("Training taxonomy validation failed: input file could not be read", err=True)
+        raise typer.Exit(code=1) from error
+    except TaxonomyContractError as error:
+        typer.echo(f"Training taxonomy validation failed: {error}", err=True)
+        raise typer.Exit(code=1) from error
+    typer.echo(
+        "Training taxonomy valid: "
+        f"{binding.taxonomy.id}@{binding.taxonomy.version} with learned negative 'other'."
+    )

--- a/src/signlab/contracts/__init__.py
+++ b/src/signlab/contracts/__init__.py
@@ -1,0 +1,31 @@
+"""Versioned, UI-independent contracts shared across the SignLab pipeline."""
+
+from signlab.contracts.taxonomy import (
+    BUILTIN_TAXONOMY_DIGEST,
+    GestureTaxonomy,
+    TaxonomyContractError,
+    TaxonomyRef,
+    load_builtin_taxonomy,
+    normalize_legacy_label,
+    taxonomy_reference,
+    validate_packaged_taxonomy_resources,
+    validate_taxonomy,
+    validate_training_label_counts,
+    validate_training_label_map,
+    validate_training_taxonomy_binding,
+)
+
+__all__ = [
+    "BUILTIN_TAXONOMY_DIGEST",
+    "GestureTaxonomy",
+    "TaxonomyContractError",
+    "TaxonomyRef",
+    "load_builtin_taxonomy",
+    "normalize_legacy_label",
+    "taxonomy_reference",
+    "validate_packaged_taxonomy_resources",
+    "validate_taxonomy",
+    "validate_training_label_counts",
+    "validate_training_label_map",
+    "validate_training_taxonomy_binding",
+]

--- a/src/signlab/contracts/taxonomy.py
+++ b/src/signlab/contracts/taxonomy.py
@@ -1,0 +1,605 @@
+"""Authoritative taxonomy models, validation, and stable identity helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Mapping
+from importlib.resources import files
+from typing import Annotated, Any, Final, Literal, Self
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+from pydantic import (
+    BaseModel,
+    BeforeValidator,
+    ConfigDict,
+    Field,
+    StringConstraints,
+    ValidationError,
+    model_validator,
+)
+
+SCHEMA_BASE: Final = "https://signlab.dev/schemas/"
+APPROVED_PRODUCT_CLAIM: Final = (
+    "SignLab is a research prototype for recognizing isolated performances of five "
+    "predefined hand gestures within continuous webcam video. It separates non-target "
+    "events (`other`) from no active event (`inactive`) and uncertain decisions "
+    "(`abstain`); no sign-language or translation capability is claimed."
+)
+EXPECTED_TARGET_IDS: Final = ("hello", "no", "please", "thank_you", "yes")
+EXPECTED_CLASS_IDS: Final = (*EXPECTED_TARGET_IDS, "other")
+EXPECTED_CONSUMERS: Final = (
+    "collection",
+    "annotation",
+    "training",
+    "evaluation",
+    "bundle",
+    "public_copy",
+)
+EXPECTED_CONSUMER_SCHEMA_IDS: Final = {
+    consumer: f"{SCHEMA_BASE}{consumer.replace('_', '-')}-taxonomy-binding-1.schema.json"
+    for consumer in EXPECTED_CONSUMERS
+}
+EXPECTED_OTHER_KINDS: Final = (
+    "partial_target",
+    "transition_fragment",
+    "oov_gesture",
+    "incidental_activity",
+    "two_hand_non_target",
+)
+PUBLISHED_TAXONOMY_DIGESTS: Final = {
+    (
+        "signlab-five",
+        "1.0.0",
+    ): "sha256:c0f6cbddfe43e3a6eb3de01dbbbbc1ceebcb83d50cc197999776f58e3d9ce20d",
+}
+PUBLISHED_TAXONOMY_RESOURCES: Final = {
+    ("signlab-five", "1.0.0"): "signlab-five-1.0.0.json",
+}
+CURRENT_TAXONOMY: Final = ("signlab-five", "1.0.0")
+BUILTIN_TAXONOMY_DIGEST: Final = PUBLISHED_TAXONOMY_DIGESTS[CURRENT_TAXONOMY]
+
+NonEmptyText = Annotated[
+    str,
+    StringConstraints(min_length=1, pattern=r"^\S(?:.*\S)?$"),
+]
+StableId = Annotated[str, StringConstraints(pattern=r"^[a-z][a-z0-9_-]*$")]
+SemanticVersion = Annotated[
+    str,
+    StringConstraints(pattern=r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$"),
+]
+Sha256Digest = Annotated[str, StringConstraints(pattern=r"^sha256:[0-9a-f]{64}$")]
+ConsumerName = Literal[
+    "collection",
+    "annotation",
+    "training",
+    "evaluation",
+    "bundle",
+    "public_copy",
+]
+
+
+def _normalize_json_integer(value: object) -> object:
+    """Accept JSON Schema integral numbers while retaining strict non-coercion."""
+    if isinstance(value, bool):
+        raise ValueError("boolean values are not integers")
+    if isinstance(value, float) and math.isfinite(value) and value.is_integer():
+        return int(value)
+    return value
+
+
+JsonNonNegativeInteger = Annotated[
+    int,
+    Field(ge=0),
+    BeforeValidator(_normalize_json_integer),
+]
+JsonPositiveInteger = Annotated[
+    int,
+    Field(gt=0),
+    BeforeValidator(_normalize_json_integer),
+]
+JsonZero = Annotated[Literal[0], BeforeValidator(_normalize_json_integer)]
+JsonOne = Annotated[Literal[1], BeforeValidator(_normalize_json_integer)]
+JsonTwo = Annotated[Literal[2], BeforeValidator(_normalize_json_integer)]
+JsonThree = Annotated[Literal[3], BeforeValidator(_normalize_json_integer)]
+JsonFour = Annotated[Literal[4], BeforeValidator(_normalize_json_integer)]
+JsonFive = Annotated[Literal[5], BeforeValidator(_normalize_json_integer)]
+
+
+class TaxonomyContractError(ValueError):
+    """Raised when a taxonomy or one of its references violates the public contract."""
+
+
+def _contract_config(schema_name: str) -> ConfigDict:
+    return ConfigDict(
+        extra="forbid",
+        frozen=True,
+        strict=True,
+        validate_default=True,
+        json_schema_extra={"$id": f"{SCHEMA_BASE}{schema_name}"},
+    )
+
+
+class StrictFrozenModel(BaseModel):
+    """Closed, immutable base for governance and taxonomy contracts."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True, validate_default=True)
+
+
+class GestureExamples(StrictFrozenModel):
+    """Observable inclusion and boundary examples for one class."""
+
+    positive: tuple[NonEmptyText, ...] = Field(min_length=1)
+    negative: tuple[NonEmptyText, ...] = Field(min_length=1)
+    ambiguous: tuple[NonEmptyText, ...] = Field(min_length=1)
+    transition: tuple[NonEmptyText, ...] = Field(min_length=1)
+
+
+class GestureDefinition(StrictFrozenModel):
+    """One learned classifier output and its operational definition."""
+
+    index: JsonNonNegativeInteger
+    id: StableId
+    display_name: NonEmptyText
+    role: Literal["target", "learned_negative"]
+    description: NonEmptyText
+    examples: GestureExamples
+
+
+class RuntimeConcept(StrictFrozenModel):
+    """A state or outcome that must not be conflated with other pipeline layers."""
+
+    id: Literal["inactive", "other", "abstain"]
+    role: Literal["detector_state", "learned_class", "decision_outcome"]
+    description: NonEmptyText
+
+
+class AnnotationDisposition(StrictFrozenModel):
+    """A non-class annotation disposition and its handling rule."""
+
+    id: Literal["ambiguous", "ignore"]
+    description: NonEmptyText
+
+
+class TaxonomyRules(StrictFrozenModel):
+    """Cross-cutting decisions for edge cases and event boundaries."""
+
+    handedness: NonEmptyText
+    second_hand: NonEmptyText
+    partial_gesture: NonEmptyText
+    out_of_vocabulary: NonEmptyText
+    poor_segmentation: NonEmptyText
+    transitions: NonEmptyText
+    ignore_regions: NonEmptyText
+    ambiguous_annotations: NonEmptyText
+
+
+class LegacyAlias(StrictFrozenModel):
+    """One explicit, reviewable legacy spelling migration."""
+
+    source: NonEmptyText
+    target: StableId
+
+
+class LegacyImportPolicy(StrictFrozenModel):
+    """Explicit migration behavior for historical labels."""
+
+    aliases: tuple[LegacyAlias, ...]
+    quarantined: tuple[NonEmptyText, ...] = Field(min_length=1)
+
+
+class ProductClaim(StrictFrozenModel):
+    """The only public claim authorized for the current reviewed taxonomy."""
+
+    profile: Literal["predefined_gestures"]
+    statement: NonEmptyText
+
+    @model_validator(mode="after")
+    def _enforce_claim_boundary(self) -> Self:
+        if self.statement != APPROVED_PRODUCT_CLAIM:
+            raise ValueError("the predefined-gesture claim must use the approved statement")
+        return self
+
+
+class ConsumerReferenceRule(StrictFrozenModel):
+    """A domain contract that must embed an immutable taxonomy reference."""
+
+    consumer: ConsumerName
+    schema_id: Annotated[str, StringConstraints(pattern=r"^https://signlab\.dev/schemas/.+$")]
+    required: Literal[True]
+
+
+class GestureTaxonomy(StrictFrozenModel):
+    """The authoritative, versioned definition of SignLab's learned vocabulary."""
+
+    model_config = _contract_config("gesture-taxonomy-1.schema.json")
+
+    schema_version: Literal["gesture-taxonomy/1"]
+    taxonomy_id: Literal["signlab-five"]
+    version: SemanticVersion
+    claim: ProductClaim
+    labels: tuple[GestureDefinition, ...]
+    concepts: tuple[RuntimeConcept, ...]
+    annotation_dispositions: tuple[AnnotationDisposition, ...]
+    decision_precedence: tuple[Literal["inactive", "target", "other", "abstain"], ...]
+    other_kinds: tuple[StableId, ...]
+    rules: TaxonomyRules
+    legacy_import: LegacyImportPolicy
+    consumer_references: tuple[ConsumerReferenceRule, ...]
+
+    @model_validator(mode="after")
+    def _enforce_signlab_five_contract(self) -> Self:
+        label_ids = tuple(label.id for label in self.labels)
+        label_indices = tuple(label.index for label in self.labels)
+        label_roles = tuple(label.role for label in self.labels)
+        if label_ids != EXPECTED_CLASS_IDS:
+            raise ValueError(f"classifier labels must be ordered exactly as {EXPECTED_CLASS_IDS}")
+        if label_indices != tuple(range(len(EXPECTED_CLASS_IDS))):
+            raise ValueError("classifier indices must be contiguous and ordered from zero")
+        if label_roles != (*("target" for _ in EXPECTED_TARGET_IDS), "learned_negative"):
+            raise ValueError("five targets must be followed by the learned negative class 'other'")
+
+        concepts = {concept.id: concept.role for concept in self.concepts}
+        expected_concepts = {
+            "inactive": "detector_state",
+            "other": "learned_class",
+            "abstain": "decision_outcome",
+        }
+        if concepts != expected_concepts or len(self.concepts) != len(expected_concepts):
+            raise ValueError("inactive, other, and abstain must retain distinct layer ownership")
+
+        dispositions = tuple(disposition.id for disposition in self.annotation_dispositions)
+        if dispositions != ("ambiguous", "ignore"):
+            raise ValueError("annotation dispositions must be ordered as ambiguous, ignore")
+        if self.decision_precedence != ("inactive", "target", "other", "abstain"):
+            raise ValueError("decision precedence must be inactive, target, other, abstain")
+        if self.other_kinds != EXPECTED_OTHER_KINDS:
+            raise ValueError(f"other kinds must be ordered exactly as {EXPECTED_OTHER_KINDS}")
+
+        aliases = {(alias.source, alias.target) for alias in self.legacy_import.aliases}
+        if aliases != {("thank you", "thank_you")} or len(self.legacy_import.aliases) != 1:
+            raise ValueError("the only v1 legacy alias must map 'thank you' to 'thank_you'")
+        if self.legacy_import.quarantined != ("nothing",):
+            raise ValueError("legacy label 'nothing' must remain quarantined")
+
+        consumers = tuple(rule.consumer for rule in self.consumer_references)
+        if consumers != EXPECTED_CONSUMERS:
+            raise ValueError(f"consumer references must be ordered exactly as {EXPECTED_CONSUMERS}")
+        schema_ids = {rule.consumer: rule.schema_id for rule in self.consumer_references}
+        if schema_ids != EXPECTED_CONSUMER_SCHEMA_IDS:
+            raise ValueError("each taxonomy consumer must use its published binding schema")
+        return self
+
+
+class TaxonomyRef(StrictFrozenModel):
+    """Portable identity embedded in downstream manifests and bundles."""
+
+    model_config = _contract_config("taxonomy-reference-1.schema.json")
+
+    schema_version: Literal["taxonomy-reference/1"]
+    id: StableId
+    version: SemanticVersion
+    sha256: Sha256Digest
+
+    @model_validator(mode="after")
+    def _resolve_published_identity(self) -> Self:
+        expected_digest = PUBLISHED_TAXONOMY_DIGESTS.get((self.id, self.version))
+        if expected_digest is None:
+            raise ValueError(f"unsupported published taxonomy reference {self.id}@{self.version}")
+        if self.sha256 != expected_digest:
+            raise ValueError(
+                f"taxonomy reference digest does not match published {self.id}@{self.version}"
+            )
+        return self
+
+
+class TrainingLabelMap(StrictFrozenModel):
+    """The immutable output order required before a training run can start."""
+
+    hello: JsonZero
+    no: JsonOne
+    please: JsonTwo
+    thank_you: JsonThree
+    yes: JsonFour
+    other: JsonFive
+
+
+class TrainingLabelCounts(StrictFrozenModel):
+    """Observed training counts, including a nonempty learned negative class."""
+
+    hello: JsonPositiveInteger
+    no: JsonPositiveInteger
+    please: JsonPositiveInteger
+    thank_you: JsonPositiveInteger
+    yes: JsonPositiveInteger
+    other: JsonPositiveInteger
+
+
+class CollectionTaxonomyBinding(StrictFrozenModel):
+    model_config = _contract_config("collection-taxonomy-binding-1.schema.json")
+    schema_version: Literal["collection-taxonomy-binding/1"]
+    taxonomy: TaxonomyRef
+
+
+class AnnotationTaxonomyBinding(StrictFrozenModel):
+    model_config = _contract_config("annotation-taxonomy-binding-1.schema.json")
+    schema_version: Literal["annotation-taxonomy-binding/1"]
+    taxonomy: TaxonomyRef
+
+
+class TrainingTaxonomyBinding(StrictFrozenModel):
+    model_config = _contract_config("training-taxonomy-binding-1.schema.json")
+    schema_version: Literal["training-taxonomy-binding/1"]
+    taxonomy: TaxonomyRef
+    label_map: TrainingLabelMap
+    label_counts: TrainingLabelCounts
+
+
+class EvaluationTaxonomyBinding(StrictFrozenModel):
+    model_config = _contract_config("evaluation-taxonomy-binding-1.schema.json")
+    schema_version: Literal["evaluation-taxonomy-binding/1"]
+    taxonomy: TaxonomyRef
+
+
+class BundleTaxonomyBinding(StrictFrozenModel):
+    model_config = _contract_config("bundle-taxonomy-binding-1.schema.json")
+    schema_version: Literal["bundle-taxonomy-binding/1"]
+    taxonomy: TaxonomyRef
+
+
+class PublicCopyTaxonomyBinding(StrictFrozenModel):
+    model_config = _contract_config("public-copy-taxonomy-binding-1.schema.json")
+    schema_version: Literal["public-copy-taxonomy-binding/1"]
+    taxonomy: TaxonomyRef
+
+
+CONSUMER_BINDING_MODELS: Final[dict[str, type[BaseModel]]] = {
+    "collection-taxonomy-binding-1.schema.json": CollectionTaxonomyBinding,
+    "annotation-taxonomy-binding-1.schema.json": AnnotationTaxonomyBinding,
+    "training-taxonomy-binding-1.schema.json": TrainingTaxonomyBinding,
+    "evaluation-taxonomy-binding-1.schema.json": EvaluationTaxonomyBinding,
+    "bundle-taxonomy-binding-1.schema.json": BundleTaxonomyBinding,
+    "public-copy-taxonomy-binding-1.schema.json": PublicCopyTaxonomyBinding,
+}
+
+type JsonObject = dict[str, Any]
+type TaxonomyInput = GestureTaxonomy | str | bytes | bytearray | Mapping[str, object]
+type TrainingBindingInput = TrainingTaxonomyBinding | str | bytes | bytearray | Mapping[str, object]
+
+
+def _validation_message(error: ValidationError) -> str:
+    details: list[str] = []
+    for item in error.errors(include_input=False, include_url=False):
+        location = ".".join(str(part) for part in item["loc"]) or "document"
+        details.append(f"{location}: {item['msg']}")
+    return "; ".join(details)
+
+
+def validate_taxonomy(document: TaxonomyInput) -> GestureTaxonomy:
+    """Validate JSON-compatible input without permitting Python-side coercion."""
+    if isinstance(document, GestureTaxonomy):
+        document = document.model_dump_json(round_trip=True)
+    if isinstance(document, Mapping):
+        try:
+            document = json.dumps(document, ensure_ascii=False, allow_nan=False)
+        except (TypeError, ValueError) as error:
+            raise TaxonomyContractError("taxonomy is not JSON-serializable") from error
+    try:
+        taxonomy = GestureTaxonomy.model_validate_json(document, strict=True)
+    except ValidationError as error:
+        raise TaxonomyContractError(
+            f"invalid gesture taxonomy: {_validation_message(error)}"
+        ) from error
+    identity = (taxonomy.taxonomy_id, taxonomy.version)
+    expected_digest = PUBLISHED_TAXONOMY_DIGESTS.get(identity)
+    if expected_digest is None:
+        supported = ", ".join(
+            f"{taxonomy_id}@{version}"
+            for taxonomy_id, version in sorted(PUBLISHED_TAXONOMY_DIGESTS)
+        )
+        raise TaxonomyContractError(
+            f"unsupported taxonomy {taxonomy.taxonomy_id}@{taxonomy.version}; "
+            f"supported releases: {supported}; publish a new immutable artifact to migrate"
+        )
+    if taxonomy_digest(taxonomy) != expected_digest:
+        raise TaxonomyContractError(
+            f"published taxonomy {taxonomy.taxonomy_id}@{taxonomy.version} is immutable; "
+            "semantic changes require a new version and registered digest"
+        )
+    return taxonomy
+
+
+def validate_training_taxonomy_binding(
+    document: TrainingBindingInput,
+) -> TrainingTaxonomyBinding:
+    """Validate the taxonomy, exact label map, and observed counts for training."""
+    if isinstance(document, TrainingTaxonomyBinding):
+        document = document.model_dump_json(round_trip=True)
+    if isinstance(document, Mapping):
+        try:
+            document = json.dumps(document, ensure_ascii=False, allow_nan=False)
+        except (TypeError, ValueError) as error:
+            raise TaxonomyContractError(
+                "training taxonomy input is not JSON-serializable"
+            ) from error
+    try:
+        return TrainingTaxonomyBinding.model_validate_json(document, strict=True)
+    except ValidationError as error:
+        raise TaxonomyContractError(
+            f"invalid training taxonomy input: {_validation_message(error)}"
+        ) from error
+
+
+def canonical_json_bytes(value: BaseModel | Mapping[str, object]) -> bytes:
+    """Serialize validated public data into SignLab's deterministic JSON form."""
+    payload: object
+    if isinstance(value, BaseModel):
+        payload = value.model_dump(mode="json", round_trip=True)
+    else:
+        payload = dict(value)
+    return json.dumps(
+        payload,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def taxonomy_digest(taxonomy: GestureTaxonomy) -> str:
+    """Return the content identity of a validated taxonomy."""
+    return f"sha256:{hashlib.sha256(canonical_json_bytes(taxonomy)).hexdigest()}"
+
+
+def taxonomy_reference(taxonomy: GestureTaxonomy) -> TaxonomyRef:
+    """Build the immutable reference required by every taxonomy consumer."""
+    taxonomy = validate_taxonomy(taxonomy)
+    return TaxonomyRef(
+        schema_version="taxonomy-reference/1",
+        id=taxonomy.taxonomy_id,
+        version=taxonomy.version,
+        sha256=taxonomy_digest(taxonomy),
+    )
+
+
+def load_builtin_taxonomy() -> GestureTaxonomy:
+    """Load and integrity-check the taxonomy shipped inside the Python package."""
+    resource_name = PUBLISHED_TAXONOMY_RESOURCES[CURRENT_TAXONOMY]
+    document = files("signlab.resources.taxonomies").joinpath(resource_name).read_bytes()
+    taxonomy = validate_taxonomy(document)
+    actual_digest = taxonomy_digest(taxonomy)
+    if (
+        taxonomy.taxonomy_id,
+        taxonomy.version,
+    ) != CURRENT_TAXONOMY or actual_digest != BUILTIN_TAXONOMY_DIGEST:
+        raise TaxonomyContractError(
+            "built-in taxonomy content does not match its immutable published digest"
+        )
+    return taxonomy
+
+
+def load_published_taxonomies() -> tuple[GestureTaxonomy, ...]:
+    """Load every registered release so portable schemas remain backward compatible."""
+    if set(PUBLISHED_TAXONOMY_RESOURCES) != set(PUBLISHED_TAXONOMY_DIGESTS):
+        raise TaxonomyContractError("published taxonomy resource and digest registries disagree")
+    loaded: list[GestureTaxonomy] = []
+    resource_root = files("signlab.resources.taxonomies")
+    for identity, resource_name in sorted(PUBLISHED_TAXONOMY_RESOURCES.items()):
+        try:
+            taxonomy = validate_taxonomy(resource_root.joinpath(resource_name).read_bytes())
+        except OSError as error:
+            raise TaxonomyContractError("a published taxonomy resource is missing") from error
+        if (taxonomy.taxonomy_id, taxonomy.version) != identity:
+            raise TaxonomyContractError("a published taxonomy resource has the wrong identity")
+        loaded.append(taxonomy)
+    return tuple(loaded)
+
+
+def generated_json_schemas() -> dict[str, JsonObject]:
+    """Generate every committed taxonomy schema from its authoritative model."""
+    models: dict[str, type[BaseModel]] = {
+        "gesture-taxonomy-1.schema.json": GestureTaxonomy,
+        "taxonomy-reference-1.schema.json": TaxonomyRef,
+        **CONSUMER_BINDING_MODELS,
+    }
+    generated: dict[str, JsonObject] = {}
+    for filename, model in models.items():
+        schema = model.model_json_schema(mode="validation")
+        schema["$schema"] = "https://json-schema.org/draft/2020-12/schema"
+        generated[filename] = schema
+    taxonomies = load_published_taxonomies()
+    taxonomy_documents = [
+        taxonomy.model_dump(mode="json", round_trip=True) for taxonomy in taxonomies
+    ]
+    reference_documents = [
+        taxonomy_reference(taxonomy).model_dump(mode="json", round_trip=True)
+        for taxonomy in taxonomies
+    ]
+    generated["gesture-taxonomy-1.schema.json"]["oneOf"] = [
+        {"const": document} for document in taxonomy_documents
+    ]
+    generated["taxonomy-reference-1.schema.json"]["oneOf"] = [
+        {"const": document} for document in reference_documents
+    ]
+    for filename in CONSUMER_BINDING_MODELS:
+        taxonomy_definition = generated[filename]["$defs"]["TaxonomyRef"]
+        taxonomy_definition["oneOf"] = [{"const": document} for document in reference_documents]
+    return generated
+
+
+def validate_packaged_taxonomy_resources() -> None:
+    """Check that every packaged schema is valid and matches generated output."""
+    expected = generated_json_schemas()
+    schema_root = files("signlab.resources.schemas")
+    try:
+        for filename, generated in expected.items():
+            packaged = json.loads(schema_root.joinpath(filename).read_text(encoding="utf-8"))
+            Draft202012Validator.check_schema(packaged)
+            if packaged != generated:
+                raise TaxonomyContractError(f"packaged schema drift detected for {filename}")
+    except (OSError, json.JSONDecodeError, SchemaError) as error:
+        raise TaxonomyContractError("packaged taxonomy schemas are missing or invalid") from error
+
+
+def normalize_legacy_label(label: str) -> str:
+    """Apply only the legacy migrations explicitly approved by the taxonomy."""
+    taxonomy = load_builtin_taxonomy()
+    if label in EXPECTED_CLASS_IDS:
+        return label
+    aliases = {alias.source: alias.target for alias in taxonomy.legacy_import.aliases}
+    if label in aliases:
+        return aliases[label]
+    if label in taxonomy.legacy_import.quarantined:
+        raise TaxonomyContractError(
+            f"legacy label {label!r} is quarantined and must be reannotated; it is not 'other'"
+        )
+    raise TaxonomyContractError(f"unknown legacy label {label!r}; no implicit normalization exists")
+
+
+def validate_training_label_map(label_map: Mapping[str, int]) -> tuple[str, ...]:
+    """Reject training outputs that drift from the immutable classifier order."""
+    invalid_values = sorted(label for label, index in label_map.items() if type(index) is not int)
+    if invalid_values:
+        raise TaxonomyContractError(f"label indices must be integers: {invalid_values}")
+    if "other" not in label_map:
+        raise TaxonomyContractError(
+            "training label map is missing required learned negative class 'other'"
+        )
+    expected = {label: index for index, label in enumerate(EXPECTED_CLASS_IDS)}
+    missing = sorted(set(expected) - set(label_map))
+    unexpected = sorted(set(label_map) - set(expected))
+    if missing or unexpected:
+        raise TaxonomyContractError(
+            "training label map does not match taxonomy; "
+            f"missing={missing}, unexpected={unexpected}"
+        )
+    if dict(label_map) != expected:
+        raise TaxonomyContractError(f"training label indices must match {expected}")
+    return EXPECTED_CLASS_IDS
+
+
+def validate_training_label_counts(label_counts: Mapping[str, int]) -> None:
+    """Require observed examples for every target and the learned negative class."""
+    if "other" not in label_counts:
+        raise TaxonomyContractError(
+            "training data is missing required learned negative class 'other'"
+        )
+    missing = sorted(set(EXPECTED_CLASS_IDS) - set(label_counts))
+    unexpected = sorted(set(label_counts) - set(EXPECTED_CLASS_IDS))
+    if missing or unexpected:
+        raise TaxonomyContractError(
+            "training label counts do not match taxonomy; "
+            f"missing={missing}, unexpected={unexpected}"
+        )
+    invalid = sorted(
+        label for label, count in label_counts.items() if type(count) is not int or count < 0
+    )
+    if invalid:
+        raise TaxonomyContractError(f"label counts must be non-negative integers: {invalid}")
+    if label_counts["other"] == 0:
+        raise TaxonomyContractError("learned negative class 'other' has zero training examples")
+    empty_targets = sorted(label for label in EXPECTED_TARGET_IDS if label_counts[label] == 0)
+    if empty_targets:
+        raise TaxonomyContractError(f"target classes have zero training examples: {empty_targets}")

--- a/src/signlab/resources/__init__.py
+++ b/src/signlab/resources/__init__.py
@@ -1,0 +1,1 @@
+"""Packaged, immutable SignLab contract resources."""

--- a/src/signlab/resources/schemas/__init__.py
+++ b/src/signlab/resources/schemas/__init__.py
@@ -1,0 +1,1 @@
+"""JSON Schemas generated from SignLab's authoritative Python contracts."""

--- a/src/signlab/resources/schemas/annotation-taxonomy-binding-1.schema.json
+++ b/src/signlab/resources/schemas/annotation-taxonomy-binding-1.schema.json
@@ -1,0 +1,68 @@
+{
+  "$defs": {
+    "TaxonomyRef": {
+      "$id": "https://signlab.dev/schemas/taxonomy-reference-1.schema.json",
+      "additionalProperties": false,
+      "description": "Portable identity embedded in downstream manifests and bundles.",
+      "oneOf": [
+        {
+          "const": {
+            "id": "signlab-five",
+            "schema_version": "taxonomy-reference/1",
+            "sha256": "sha256:c0f6cbddfe43e3a6eb3de01dbbbbc1ceebcb83d50cc197999776f58e3d9ce20d",
+            "version": "1.0.0"
+          }
+        }
+      ],
+      "properties": {
+        "id": {
+          "pattern": "^[a-z][a-z0-9_-]*$",
+          "title": "Id",
+          "type": "string"
+        },
+        "schema_version": {
+          "const": "taxonomy-reference/1",
+          "title": "Schema Version",
+          "type": "string"
+        },
+        "sha256": {
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "title": "Sha256",
+          "type": "string"
+        },
+        "version": {
+          "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$",
+          "title": "Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "schema_version",
+        "id",
+        "version",
+        "sha256"
+      ],
+      "title": "TaxonomyRef",
+      "type": "object"
+    }
+  },
+  "$id": "https://signlab.dev/schemas/annotation-taxonomy-binding-1.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "const": "annotation-taxonomy-binding/1",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "taxonomy": {
+      "$ref": "#/$defs/TaxonomyRef"
+    }
+  },
+  "required": [
+    "schema_version",
+    "taxonomy"
+  ],
+  "title": "AnnotationTaxonomyBinding",
+  "type": "object"
+}

--- a/src/signlab/resources/schemas/bundle-taxonomy-binding-1.schema.json
+++ b/src/signlab/resources/schemas/bundle-taxonomy-binding-1.schema.json
@@ -1,0 +1,68 @@
+{
+  "$defs": {
+    "TaxonomyRef": {
+      "$id": "https://signlab.dev/schemas/taxonomy-reference-1.schema.json",
+      "additionalProperties": false,
+      "description": "Portable identity embedded in downstream manifests and bundles.",
+      "oneOf": [
+        {
+          "const": {
+            "id": "signlab-five",
+            "schema_version": "taxonomy-reference/1",
+            "sha256": "sha256:c0f6cbddfe43e3a6eb3de01dbbbbc1ceebcb83d50cc197999776f58e3d9ce20d",
+            "version": "1.0.0"
+          }
+        }
+      ],
+      "properties": {
+        "id": {
+          "pattern": "^[a-z][a-z0-9_-]*$",
+          "title": "Id",
+          "type": "string"
+        },
+        "schema_version": {
+          "const": "taxonomy-reference/1",
+          "title": "Schema Version",
+          "type": "string"
+        },
+        "sha256": {
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "title": "Sha256",
+          "type": "string"
+        },
+        "version": {
+          "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$",
+          "title": "Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "schema_version",
+        "id",
+        "version",
+        "sha256"
+      ],
+      "title": "TaxonomyRef",
+      "type": "object"
+    }
+  },
+  "$id": "https://signlab.dev/schemas/bundle-taxonomy-binding-1.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "const": "bundle-taxonomy-binding/1",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "taxonomy": {
+      "$ref": "#/$defs/TaxonomyRef"
+    }
+  },
+  "required": [
+    "schema_version",
+    "taxonomy"
+  ],
+  "title": "BundleTaxonomyBinding",
+  "type": "object"
+}

--- a/src/signlab/resources/schemas/collection-taxonomy-binding-1.schema.json
+++ b/src/signlab/resources/schemas/collection-taxonomy-binding-1.schema.json
@@ -1,0 +1,68 @@
+{
+  "$defs": {
+    "TaxonomyRef": {
+      "$id": "https://signlab.dev/schemas/taxonomy-reference-1.schema.json",
+      "additionalProperties": false,
+      "description": "Portable identity embedded in downstream manifests and bundles.",
+      "oneOf": [
+        {
+          "const": {
+            "id": "signlab-five",
+            "schema_version": "taxonomy-reference/1",
+            "sha256": "sha256:c0f6cbddfe43e3a6eb3de01dbbbbc1ceebcb83d50cc197999776f58e3d9ce20d",
+            "version": "1.0.0"
+          }
+        }
+      ],
+      "properties": {
+        "id": {
+          "pattern": "^[a-z][a-z0-9_-]*$",
+          "title": "Id",
+          "type": "string"
+        },
+        "schema_version": {
+          "const": "taxonomy-reference/1",
+          "title": "Schema Version",
+          "type": "string"
+        },
+        "sha256": {
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "title": "Sha256",
+          "type": "string"
+        },
+        "version": {
+          "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$",
+          "title": "Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "schema_version",
+        "id",
+        "version",
+        "sha256"
+      ],
+      "title": "TaxonomyRef",
+      "type": "object"
+    }
+  },
+  "$id": "https://signlab.dev/schemas/collection-taxonomy-binding-1.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "const": "collection-taxonomy-binding/1",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "taxonomy": {
+      "$ref": "#/$defs/TaxonomyRef"
+    }
+  },
+  "required": [
+    "schema_version",
+    "taxonomy"
+  ],
+  "title": "CollectionTaxonomyBinding",
+  "type": "object"
+}

--- a/src/signlab/resources/schemas/evaluation-taxonomy-binding-1.schema.json
+++ b/src/signlab/resources/schemas/evaluation-taxonomy-binding-1.schema.json
@@ -1,0 +1,68 @@
+{
+  "$defs": {
+    "TaxonomyRef": {
+      "$id": "https://signlab.dev/schemas/taxonomy-reference-1.schema.json",
+      "additionalProperties": false,
+      "description": "Portable identity embedded in downstream manifests and bundles.",
+      "oneOf": [
+        {
+          "const": {
+            "id": "signlab-five",
+            "schema_version": "taxonomy-reference/1",
+            "sha256": "sha256:c0f6cbddfe43e3a6eb3de01dbbbbc1ceebcb83d50cc197999776f58e3d9ce20d",
+            "version": "1.0.0"
+          }
+        }
+      ],
+      "properties": {
+        "id": {
+          "pattern": "^[a-z][a-z0-9_-]*$",
+          "title": "Id",
+          "type": "string"
+        },
+        "schema_version": {
+          "const": "taxonomy-reference/1",
+          "title": "Schema Version",
+          "type": "string"
+        },
+        "sha256": {
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "title": "Sha256",
+          "type": "string"
+        },
+        "version": {
+          "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$",
+          "title": "Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "schema_version",
+        "id",
+        "version",
+        "sha256"
+      ],
+      "title": "TaxonomyRef",
+      "type": "object"
+    }
+  },
+  "$id": "https://signlab.dev/schemas/evaluation-taxonomy-binding-1.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "const": "evaluation-taxonomy-binding/1",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "taxonomy": {
+      "$ref": "#/$defs/TaxonomyRef"
+    }
+  },
+  "required": [
+    "schema_version",
+    "taxonomy"
+  ],
+  "title": "EvaluationTaxonomyBinding",
+  "type": "object"
+}

--- a/src/signlab/resources/schemas/gesture-taxonomy-1.schema.json
+++ b/src/signlab/resources/schemas/gesture-taxonomy-1.schema.json
@@ -1,0 +1,675 @@
+{
+  "$defs": {
+    "AnnotationDisposition": {
+      "additionalProperties": false,
+      "description": "A non-class annotation disposition and its handling rule.",
+      "properties": {
+        "description": {
+          "minLength": 1,
+          "pattern": "^\\S(?:.*\\S)?$",
+          "title": "Description",
+          "type": "string"
+        },
+        "id": {
+          "enum": [
+            "ambiguous",
+            "ignore"
+          ],
+          "title": "Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "description"
+      ],
+      "title": "AnnotationDisposition",
+      "type": "object"
+    },
+    "ConsumerReferenceRule": {
+      "additionalProperties": false,
+      "description": "A domain contract that must embed an immutable taxonomy reference.",
+      "properties": {
+        "consumer": {
+          "enum": [
+            "collection",
+            "annotation",
+            "training",
+            "evaluation",
+            "bundle",
+            "public_copy"
+          ],
+          "title": "Consumer",
+          "type": "string"
+        },
+        "required": {
+          "const": true,
+          "title": "Required",
+          "type": "boolean"
+        },
+        "schema_id": {
+          "pattern": "^https://signlab\\.dev/schemas/.+$",
+          "title": "Schema Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "consumer",
+        "schema_id",
+        "required"
+      ],
+      "title": "ConsumerReferenceRule",
+      "type": "object"
+    },
+    "GestureDefinition": {
+      "additionalProperties": false,
+      "description": "One learned classifier output and its operational definition.",
+      "properties": {
+        "description": {
+          "minLength": 1,
+          "pattern": "^\\S(?:.*\\S)?$",
+          "title": "Description",
+          "type": "string"
+        },
+        "display_name": {
+          "minLength": 1,
+          "pattern": "^\\S(?:.*\\S)?$",
+          "title": "Display Name",
+          "type": "string"
+        },
+        "examples": {
+          "$ref": "#/$defs/GestureExamples"
+        },
+        "id": {
+          "pattern": "^[a-z][a-z0-9_-]*$",
+          "title": "Id",
+          "type": "string"
+        },
+        "index": {
+          "minimum": 0,
+          "title": "Index",
+          "type": "integer"
+        },
+        "role": {
+          "enum": [
+            "target",
+            "learned_negative"
+          ],
+          "title": "Role",
+          "type": "string"
+        }
+      },
+      "required": [
+        "index",
+        "id",
+        "display_name",
+        "role",
+        "description",
+        "examples"
+      ],
+      "title": "GestureDefinition",
+      "type": "object"
+    },
+    "GestureExamples": {
+      "additionalProperties": false,
+      "description": "Observable inclusion and boundary examples for one class.",
+      "properties": {
+        "ambiguous": {
+          "items": {
+            "minLength": 1,
+            "pattern": "^\\S(?:.*\\S)?$",
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Ambiguous",
+          "type": "array"
+        },
+        "negative": {
+          "items": {
+            "minLength": 1,
+            "pattern": "^\\S(?:.*\\S)?$",
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Negative",
+          "type": "array"
+        },
+        "positive": {
+          "items": {
+            "minLength": 1,
+            "pattern": "^\\S(?:.*\\S)?$",
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Positive",
+          "type": "array"
+        },
+        "transition": {
+          "items": {
+            "minLength": 1,
+            "pattern": "^\\S(?:.*\\S)?$",
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Transition",
+          "type": "array"
+        }
+      },
+      "required": [
+        "positive",
+        "negative",
+        "ambiguous",
+        "transition"
+      ],
+      "title": "GestureExamples",
+      "type": "object"
+    },
+    "LegacyAlias": {
+      "additionalProperties": false,
+      "description": "One explicit, reviewable legacy spelling migration.",
+      "properties": {
+        "source": {
+          "minLength": 1,
+          "pattern": "^\\S(?:.*\\S)?$",
+          "title": "Source",
+          "type": "string"
+        },
+        "target": {
+          "pattern": "^[a-z][a-z0-9_-]*$",
+          "title": "Target",
+          "type": "string"
+        }
+      },
+      "required": [
+        "source",
+        "target"
+      ],
+      "title": "LegacyAlias",
+      "type": "object"
+    },
+    "LegacyImportPolicy": {
+      "additionalProperties": false,
+      "description": "Explicit migration behavior for historical labels.",
+      "properties": {
+        "aliases": {
+          "items": {
+            "$ref": "#/$defs/LegacyAlias"
+          },
+          "title": "Aliases",
+          "type": "array"
+        },
+        "quarantined": {
+          "items": {
+            "minLength": 1,
+            "pattern": "^\\S(?:.*\\S)?$",
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Quarantined",
+          "type": "array"
+        }
+      },
+      "required": [
+        "aliases",
+        "quarantined"
+      ],
+      "title": "LegacyImportPolicy",
+      "type": "object"
+    },
+    "ProductClaim": {
+      "additionalProperties": false,
+      "description": "The only public claim authorized for the current reviewed taxonomy.",
+      "properties": {
+        "profile": {
+          "const": "predefined_gestures",
+          "title": "Profile",
+          "type": "string"
+        },
+        "statement": {
+          "minLength": 1,
+          "pattern": "^\\S(?:.*\\S)?$",
+          "title": "Statement",
+          "type": "string"
+        }
+      },
+      "required": [
+        "profile",
+        "statement"
+      ],
+      "title": "ProductClaim",
+      "type": "object"
+    },
+    "RuntimeConcept": {
+      "additionalProperties": false,
+      "description": "A state or outcome that must not be conflated with other pipeline layers.",
+      "properties": {
+        "description": {
+          "minLength": 1,
+          "pattern": "^\\S(?:.*\\S)?$",
+          "title": "Description",
+          "type": "string"
+        },
+        "id": {
+          "enum": [
+            "inactive",
+            "other",
+            "abstain"
+          ],
+          "title": "Id",
+          "type": "string"
+        },
+        "role": {
+          "enum": [
+            "detector_state",
+            "learned_class",
+            "decision_outcome"
+          ],
+          "title": "Role",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "role",
+        "description"
+      ],
+      "title": "RuntimeConcept",
+      "type": "object"
+    },
+    "TaxonomyRules": {
+      "additionalProperties": false,
+      "description": "Cross-cutting decisions for edge cases and event boundaries.",
+      "properties": {
+        "ambiguous_annotations": {
+          "minLength": 1,
+          "pattern": "^\\S(?:.*\\S)?$",
+          "title": "Ambiguous Annotations",
+          "type": "string"
+        },
+        "handedness": {
+          "minLength": 1,
+          "pattern": "^\\S(?:.*\\S)?$",
+          "title": "Handedness",
+          "type": "string"
+        },
+        "ignore_regions": {
+          "minLength": 1,
+          "pattern": "^\\S(?:.*\\S)?$",
+          "title": "Ignore Regions",
+          "type": "string"
+        },
+        "out_of_vocabulary": {
+          "minLength": 1,
+          "pattern": "^\\S(?:.*\\S)?$",
+          "title": "Out Of Vocabulary",
+          "type": "string"
+        },
+        "partial_gesture": {
+          "minLength": 1,
+          "pattern": "^\\S(?:.*\\S)?$",
+          "title": "Partial Gesture",
+          "type": "string"
+        },
+        "poor_segmentation": {
+          "minLength": 1,
+          "pattern": "^\\S(?:.*\\S)?$",
+          "title": "Poor Segmentation",
+          "type": "string"
+        },
+        "second_hand": {
+          "minLength": 1,
+          "pattern": "^\\S(?:.*\\S)?$",
+          "title": "Second Hand",
+          "type": "string"
+        },
+        "transitions": {
+          "minLength": 1,
+          "pattern": "^\\S(?:.*\\S)?$",
+          "title": "Transitions",
+          "type": "string"
+        }
+      },
+      "required": [
+        "handedness",
+        "second_hand",
+        "partial_gesture",
+        "out_of_vocabulary",
+        "poor_segmentation",
+        "transitions",
+        "ignore_regions",
+        "ambiguous_annotations"
+      ],
+      "title": "TaxonomyRules",
+      "type": "object"
+    }
+  },
+  "$id": "https://signlab.dev/schemas/gesture-taxonomy-1.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "The authoritative, versioned definition of SignLab's learned vocabulary.",
+  "oneOf": [
+    {
+      "const": {
+        "annotation_dispositions": [
+          {
+            "description": "The visible evidence cannot support a reliable class decision; adjudication is required before training or evaluation.",
+            "id": "ambiguous"
+          },
+          {
+            "description": "The region must not be trained or scored under the evaluator's declared overlap rule, and a reason is required.",
+            "id": "ignore"
+          }
+        ],
+        "claim": {
+          "profile": "predefined_gestures",
+          "statement": "SignLab is a research prototype for recognizing isolated performances of five predefined hand gestures within continuous webcam video. It separates non-target events (`other`) from no active event (`inactive`) and uncertain decisions (`abstain`); no sign-language or translation capability is claimed."
+        },
+        "concepts": [
+          {
+            "description": "No finalized candidate event is active; this state belongs to the event detector and is never a classifier label.",
+            "id": "inactive",
+            "role": "detector_state"
+          },
+          {
+            "description": "A complete candidate event is confidently not one of the five targets; this is the required learned negative class.",
+            "id": "other",
+            "role": "learned_class"
+          },
+          {
+            "description": "A finalized candidate cannot be named at the accepted risk threshold; this is a decision-policy outcome, not a class.",
+            "id": "abstain",
+            "role": "decision_outcome"
+          }
+        ],
+        "consumer_references": [
+          {
+            "consumer": "collection",
+            "required": true,
+            "schema_id": "https://signlab.dev/schemas/collection-taxonomy-binding-1.schema.json"
+          },
+          {
+            "consumer": "annotation",
+            "required": true,
+            "schema_id": "https://signlab.dev/schemas/annotation-taxonomy-binding-1.schema.json"
+          },
+          {
+            "consumer": "training",
+            "required": true,
+            "schema_id": "https://signlab.dev/schemas/training-taxonomy-binding-1.schema.json"
+          },
+          {
+            "consumer": "evaluation",
+            "required": true,
+            "schema_id": "https://signlab.dev/schemas/evaluation-taxonomy-binding-1.schema.json"
+          },
+          {
+            "consumer": "bundle",
+            "required": true,
+            "schema_id": "https://signlab.dev/schemas/bundle-taxonomy-binding-1.schema.json"
+          },
+          {
+            "consumer": "public_copy",
+            "required": true,
+            "schema_id": "https://signlab.dev/schemas/public-copy-taxonomy-binding-1.schema.json"
+          }
+        ],
+        "decision_precedence": [
+          "inactive",
+          "target",
+          "other",
+          "abstain"
+        ],
+        "labels": [
+          {
+            "description": "Open hand near the temple or upper face with a short outward or side-to-side wave.",
+            "display_name": "Hello",
+            "examples": {
+              "ambiguous": [
+                "The face or hand location is unavailable, the active hand is occluded, or the defining wave is clipped."
+              ],
+              "negative": [
+                "A static raised palm, a low chest-level wave, or a chin-origin outward stroke."
+              ],
+              "positive": [
+                "An open hand near the temple or upper face, palm generally outward, makes a short outward or side-to-side wave."
+              ],
+              "transition": [
+                "Arm raising and hand pre-shaping before the wave, plus lowering or relaxation after it, are outside the event."
+              ]
+            },
+            "id": "hello",
+            "index": 0,
+            "role": "target"
+          },
+          {
+            "description": "Thumb closes toward extended index and middle fingertips one or more times.",
+            "display_name": "No",
+            "examples": {
+              "ambiguous": [
+                "The thumb or fingertips are occluded, or closure toward the fingertips cannot be established."
+              ],
+              "negative": [
+                "A whole-hand fist or opening, a static two-finger pose, a head shake alone, or a closed-fist vertical nod."
+              ],
+              "positive": [
+                "The thumb closes toward the extended index and middle fingertips one or more times."
+              ],
+              "transition": [
+                "Hand raising and pre-shaping before the first closure, plus relaxation after the final closure, are outside the event."
+              ]
+            },
+            "id": "no",
+            "index": 1,
+            "role": "target"
+          },
+          {
+            "description": "Flat or open palm at the upper chest with a small circular stroke.",
+            "display_name": "Please",
+            "examples": {
+              "ambiguous": [
+                "The chest anchor is missing, the circular stroke is clipped, or the motion path is indeterminate."
+              ],
+              "negative": [
+                "Static chest contact, a straight chest rub, a circle away from the chest, or a chin-origin outward stroke."
+              ],
+              "positive": [
+                "A flat or open palm at or near the upper chest makes a small circular stroke."
+              ],
+              "transition": [
+                "Approach to the chest before the circle and withdrawal after the circle are outside the target interval."
+              ]
+            },
+            "id": "please",
+            "index": 2,
+            "role": "target"
+          },
+          {
+            "description": "Flat or open hand begins at the chin or lower face and moves outward in one stroke.",
+            "display_name": "Thank you",
+            "examples": {
+              "ambiguous": [
+                "The origin at the chin or lower face is unavailable, or the outward stroke is occluded or clipped."
+              ],
+              "negative": [
+                "A forehead-origin wave, a chest circle, or an unrelated hand movement near the mouth."
+              ],
+              "positive": [
+                "A flat or open hand starts at the chin or lower face and moves outward, usually slightly downward, in one stroke."
+              ],
+              "transition": [
+                "Approach to the chin before the stroke and the return or drop after the stroke are outside the event."
+              ]
+            },
+            "id": "thank_you",
+            "index": 3,
+            "role": "target"
+          },
+          {
+            "description": "Closed fist near the upper torso performs one or more wrist-driven vertical nods.",
+            "display_name": "Yes",
+            "examples": {
+              "ambiguous": [
+                "The fist shape or the wrist-driven vertical motion cannot be observed reliably."
+              ],
+              "negative": [
+                "A static fist, thumbs-up, punch, whole-hand opening, or thumb-to-fingertip closure."
+              ],
+              "positive": [
+                "A closed fist near the upper torso performs one or more wrist-driven vertical nods."
+              ],
+              "transition": [
+                "Fist formation or raising before the first nod and opening or lowering after the last nod are outside the event."
+              ]
+            },
+            "id": "yes",
+            "index": 4,
+            "role": "target"
+          },
+          {
+            "description": "A complete candidate event that is confidently outside the five-target vocabulary.",
+            "display_name": "Other",
+            "examples": {
+              "ambiguous": [
+                "A candidate whose defining motion or hand shape is not visible enough to determine whether it is a target."
+              ],
+              "negative": [
+                "A complete, correctly bounded performance of any of the five target gestures."
+              ],
+              "positive": [
+                "A complete out-of-vocabulary gesture, a clearly incomplete target attempt, or unrelated intentional hand activity."
+              ],
+              "transition": [
+                "A derived target transition may be a training hard negative only on train or development splits, never relabeled source truth."
+              ]
+            },
+            "id": "other",
+            "index": 5,
+            "role": "learned_negative"
+          }
+        ],
+        "legacy_import": {
+          "aliases": [
+            {
+              "source": "thank you",
+              "target": "thank_you"
+            }
+          ],
+          "quarantined": [
+            "nothing"
+          ]
+        },
+        "other_kinds": [
+          "partial_target",
+          "transition_fragment",
+          "oov_gesture",
+          "incidental_activity",
+          "two_hand_non_target"
+        ],
+        "rules": {
+          "ambiguous_annotations": "Ambiguous records require adjudication before they become trainable or evaluable.",
+          "handedness": "Either hand is accepted only after handedness normalization is recorded explicitly.",
+          "ignore_regions": "Ignore regions require a documented reason such as consent exclusion, camera setup, third-party presence, unresolved conflict, or unusable occlusion.",
+          "out_of_vocabulary": "A complete gesture candidate outside the five targets is other with kind oov_gesture.",
+          "partial_gesture": "A clearly incomplete target attempt is other with kind partial_target; insufficient visibility is ambiguous instead.",
+          "poor_segmentation": "Poor segmentation never changes source event truth; continuous evaluation still records detector misses and fragmentation.",
+          "second_hand": "An incidental second hand is allowed only when it does not contact, occlude, or alter the active-hand form; coordinated two-hand activity is other.",
+          "transitions": "Transitions are not automatically training examples; derived transition fragments may be other only on train or development splits."
+        },
+        "schema_version": "gesture-taxonomy/1",
+        "taxonomy_id": "signlab-five",
+        "version": "1.0.0"
+      }
+    }
+  ],
+  "properties": {
+    "annotation_dispositions": {
+      "items": {
+        "$ref": "#/$defs/AnnotationDisposition"
+      },
+      "title": "Annotation Dispositions",
+      "type": "array"
+    },
+    "claim": {
+      "$ref": "#/$defs/ProductClaim"
+    },
+    "concepts": {
+      "items": {
+        "$ref": "#/$defs/RuntimeConcept"
+      },
+      "title": "Concepts",
+      "type": "array"
+    },
+    "consumer_references": {
+      "items": {
+        "$ref": "#/$defs/ConsumerReferenceRule"
+      },
+      "title": "Consumer References",
+      "type": "array"
+    },
+    "decision_precedence": {
+      "items": {
+        "enum": [
+          "inactive",
+          "target",
+          "other",
+          "abstain"
+        ],
+        "type": "string"
+      },
+      "title": "Decision Precedence",
+      "type": "array"
+    },
+    "labels": {
+      "items": {
+        "$ref": "#/$defs/GestureDefinition"
+      },
+      "title": "Labels",
+      "type": "array"
+    },
+    "legacy_import": {
+      "$ref": "#/$defs/LegacyImportPolicy"
+    },
+    "other_kinds": {
+      "items": {
+        "pattern": "^[a-z][a-z0-9_-]*$",
+        "type": "string"
+      },
+      "title": "Other Kinds",
+      "type": "array"
+    },
+    "rules": {
+      "$ref": "#/$defs/TaxonomyRules"
+    },
+    "schema_version": {
+      "const": "gesture-taxonomy/1",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "taxonomy_id": {
+      "const": "signlab-five",
+      "title": "Taxonomy Id",
+      "type": "string"
+    },
+    "version": {
+      "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$",
+      "title": "Version",
+      "type": "string"
+    }
+  },
+  "required": [
+    "schema_version",
+    "taxonomy_id",
+    "version",
+    "claim",
+    "labels",
+    "concepts",
+    "annotation_dispositions",
+    "decision_precedence",
+    "other_kinds",
+    "rules",
+    "legacy_import",
+    "consumer_references"
+  ],
+  "title": "GestureTaxonomy",
+  "type": "object"
+}

--- a/src/signlab/resources/schemas/public-copy-taxonomy-binding-1.schema.json
+++ b/src/signlab/resources/schemas/public-copy-taxonomy-binding-1.schema.json
@@ -1,0 +1,68 @@
+{
+  "$defs": {
+    "TaxonomyRef": {
+      "$id": "https://signlab.dev/schemas/taxonomy-reference-1.schema.json",
+      "additionalProperties": false,
+      "description": "Portable identity embedded in downstream manifests and bundles.",
+      "oneOf": [
+        {
+          "const": {
+            "id": "signlab-five",
+            "schema_version": "taxonomy-reference/1",
+            "sha256": "sha256:c0f6cbddfe43e3a6eb3de01dbbbbc1ceebcb83d50cc197999776f58e3d9ce20d",
+            "version": "1.0.0"
+          }
+        }
+      ],
+      "properties": {
+        "id": {
+          "pattern": "^[a-z][a-z0-9_-]*$",
+          "title": "Id",
+          "type": "string"
+        },
+        "schema_version": {
+          "const": "taxonomy-reference/1",
+          "title": "Schema Version",
+          "type": "string"
+        },
+        "sha256": {
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "title": "Sha256",
+          "type": "string"
+        },
+        "version": {
+          "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$",
+          "title": "Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "schema_version",
+        "id",
+        "version",
+        "sha256"
+      ],
+      "title": "TaxonomyRef",
+      "type": "object"
+    }
+  },
+  "$id": "https://signlab.dev/schemas/public-copy-taxonomy-binding-1.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "const": "public-copy-taxonomy-binding/1",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "taxonomy": {
+      "$ref": "#/$defs/TaxonomyRef"
+    }
+  },
+  "required": [
+    "schema_version",
+    "taxonomy"
+  ],
+  "title": "PublicCopyTaxonomyBinding",
+  "type": "object"
+}

--- a/src/signlab/resources/schemas/taxonomy-reference-1.schema.json
+++ b/src/signlab/resources/schemas/taxonomy-reference-1.schema.json
@@ -1,0 +1,46 @@
+{
+  "$id": "https://signlab.dev/schemas/taxonomy-reference-1.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Portable identity embedded in downstream manifests and bundles.",
+  "oneOf": [
+    {
+      "const": {
+        "id": "signlab-five",
+        "schema_version": "taxonomy-reference/1",
+        "sha256": "sha256:c0f6cbddfe43e3a6eb3de01dbbbbc1ceebcb83d50cc197999776f58e3d9ce20d",
+        "version": "1.0.0"
+      }
+    }
+  ],
+  "properties": {
+    "id": {
+      "pattern": "^[a-z][a-z0-9_-]*$",
+      "title": "Id",
+      "type": "string"
+    },
+    "schema_version": {
+      "const": "taxonomy-reference/1",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "sha256": {
+      "pattern": "^sha256:[0-9a-f]{64}$",
+      "title": "Sha256",
+      "type": "string"
+    },
+    "version": {
+      "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$",
+      "title": "Version",
+      "type": "string"
+    }
+  },
+  "required": [
+    "schema_version",
+    "id",
+    "version",
+    "sha256"
+  ],
+  "title": "TaxonomyRef",
+  "type": "object"
+}

--- a/src/signlab/resources/schemas/training-taxonomy-binding-1.schema.json
+++ b/src/signlab/resources/schemas/training-taxonomy-binding-1.schema.json
@@ -1,0 +1,168 @@
+{
+  "$defs": {
+    "TaxonomyRef": {
+      "$id": "https://signlab.dev/schemas/taxonomy-reference-1.schema.json",
+      "additionalProperties": false,
+      "description": "Portable identity embedded in downstream manifests and bundles.",
+      "oneOf": [
+        {
+          "const": {
+            "id": "signlab-five",
+            "schema_version": "taxonomy-reference/1",
+            "sha256": "sha256:c0f6cbddfe43e3a6eb3de01dbbbbc1ceebcb83d50cc197999776f58e3d9ce20d",
+            "version": "1.0.0"
+          }
+        }
+      ],
+      "properties": {
+        "id": {
+          "pattern": "^[a-z][a-z0-9_-]*$",
+          "title": "Id",
+          "type": "string"
+        },
+        "schema_version": {
+          "const": "taxonomy-reference/1",
+          "title": "Schema Version",
+          "type": "string"
+        },
+        "sha256": {
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "title": "Sha256",
+          "type": "string"
+        },
+        "version": {
+          "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$",
+          "title": "Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "schema_version",
+        "id",
+        "version",
+        "sha256"
+      ],
+      "title": "TaxonomyRef",
+      "type": "object"
+    },
+    "TrainingLabelCounts": {
+      "additionalProperties": false,
+      "description": "Observed training counts, including a nonempty learned negative class.",
+      "properties": {
+        "hello": {
+          "exclusiveMinimum": 0,
+          "title": "Hello",
+          "type": "integer"
+        },
+        "no": {
+          "exclusiveMinimum": 0,
+          "title": "No",
+          "type": "integer"
+        },
+        "other": {
+          "exclusiveMinimum": 0,
+          "title": "Other",
+          "type": "integer"
+        },
+        "please": {
+          "exclusiveMinimum": 0,
+          "title": "Please",
+          "type": "integer"
+        },
+        "thank_you": {
+          "exclusiveMinimum": 0,
+          "title": "Thank You",
+          "type": "integer"
+        },
+        "yes": {
+          "exclusiveMinimum": 0,
+          "title": "Yes",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "hello",
+        "no",
+        "please",
+        "thank_you",
+        "yes",
+        "other"
+      ],
+      "title": "TrainingLabelCounts",
+      "type": "object"
+    },
+    "TrainingLabelMap": {
+      "additionalProperties": false,
+      "description": "The immutable output order required before a training run can start.",
+      "properties": {
+        "hello": {
+          "const": 0,
+          "title": "Hello",
+          "type": "integer"
+        },
+        "no": {
+          "const": 1,
+          "title": "No",
+          "type": "integer"
+        },
+        "other": {
+          "const": 5,
+          "title": "Other",
+          "type": "integer"
+        },
+        "please": {
+          "const": 2,
+          "title": "Please",
+          "type": "integer"
+        },
+        "thank_you": {
+          "const": 3,
+          "title": "Thank You",
+          "type": "integer"
+        },
+        "yes": {
+          "const": 4,
+          "title": "Yes",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "hello",
+        "no",
+        "please",
+        "thank_you",
+        "yes",
+        "other"
+      ],
+      "title": "TrainingLabelMap",
+      "type": "object"
+    }
+  },
+  "$id": "https://signlab.dev/schemas/training-taxonomy-binding-1.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "label_counts": {
+      "$ref": "#/$defs/TrainingLabelCounts"
+    },
+    "label_map": {
+      "$ref": "#/$defs/TrainingLabelMap"
+    },
+    "schema_version": {
+      "const": "training-taxonomy-binding/1",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "taxonomy": {
+      "$ref": "#/$defs/TaxonomyRef"
+    }
+  },
+  "required": [
+    "schema_version",
+    "taxonomy",
+    "label_map",
+    "label_counts"
+  ],
+  "title": "TrainingTaxonomyBinding",
+  "type": "object"
+}

--- a/src/signlab/resources/taxonomies/__init__.py
+++ b/src/signlab/resources/taxonomies/__init__.py
@@ -1,0 +1,1 @@
+"""Versioned gesture-taxonomy instances."""

--- a/src/signlab/resources/taxonomies/signlab-five-1.0.0.json
+++ b/src/signlab/resources/taxonomies/signlab-five-1.0.0.json
@@ -1,0 +1,230 @@
+{
+  "annotation_dispositions": [
+    {
+      "description": "The visible evidence cannot support a reliable class decision; adjudication is required before training or evaluation.",
+      "id": "ambiguous"
+    },
+    {
+      "description": "The region must not be trained or scored under the evaluator's declared overlap rule, and a reason is required.",
+      "id": "ignore"
+    }
+  ],
+  "claim": {
+    "profile": "predefined_gestures",
+    "statement": "SignLab is a research prototype for recognizing isolated performances of five predefined hand gestures within continuous webcam video. It separates non-target events (`other`) from no active event (`inactive`) and uncertain decisions (`abstain`); no sign-language or translation capability is claimed."
+  },
+  "concepts": [
+    {
+      "description": "No finalized candidate event is active; this state belongs to the event detector and is never a classifier label.",
+      "id": "inactive",
+      "role": "detector_state"
+    },
+    {
+      "description": "A complete candidate event is confidently not one of the five targets; this is the required learned negative class.",
+      "id": "other",
+      "role": "learned_class"
+    },
+    {
+      "description": "A finalized candidate cannot be named at the accepted risk threshold; this is a decision-policy outcome, not a class.",
+      "id": "abstain",
+      "role": "decision_outcome"
+    }
+  ],
+  "consumer_references": [
+    {
+      "consumer": "collection",
+      "required": true,
+      "schema_id": "https://signlab.dev/schemas/collection-taxonomy-binding-1.schema.json"
+    },
+    {
+      "consumer": "annotation",
+      "required": true,
+      "schema_id": "https://signlab.dev/schemas/annotation-taxonomy-binding-1.schema.json"
+    },
+    {
+      "consumer": "training",
+      "required": true,
+      "schema_id": "https://signlab.dev/schemas/training-taxonomy-binding-1.schema.json"
+    },
+    {
+      "consumer": "evaluation",
+      "required": true,
+      "schema_id": "https://signlab.dev/schemas/evaluation-taxonomy-binding-1.schema.json"
+    },
+    {
+      "consumer": "bundle",
+      "required": true,
+      "schema_id": "https://signlab.dev/schemas/bundle-taxonomy-binding-1.schema.json"
+    },
+    {
+      "consumer": "public_copy",
+      "required": true,
+      "schema_id": "https://signlab.dev/schemas/public-copy-taxonomy-binding-1.schema.json"
+    }
+  ],
+  "decision_precedence": [
+    "inactive",
+    "target",
+    "other",
+    "abstain"
+  ],
+  "labels": [
+    {
+      "description": "Open hand near the temple or upper face with a short outward or side-to-side wave.",
+      "display_name": "Hello",
+      "examples": {
+        "ambiguous": [
+          "The face or hand location is unavailable, the active hand is occluded, or the defining wave is clipped."
+        ],
+        "negative": [
+          "A static raised palm, a low chest-level wave, or a chin-origin outward stroke."
+        ],
+        "positive": [
+          "An open hand near the temple or upper face, palm generally outward, makes a short outward or side-to-side wave."
+        ],
+        "transition": [
+          "Arm raising and hand pre-shaping before the wave, plus lowering or relaxation after it, are outside the event."
+        ]
+      },
+      "id": "hello",
+      "index": 0,
+      "role": "target"
+    },
+    {
+      "description": "Thumb closes toward extended index and middle fingertips one or more times.",
+      "display_name": "No",
+      "examples": {
+        "ambiguous": [
+          "The thumb or fingertips are occluded, or closure toward the fingertips cannot be established."
+        ],
+        "negative": [
+          "A whole-hand fist or opening, a static two-finger pose, a head shake alone, or a closed-fist vertical nod."
+        ],
+        "positive": [
+          "The thumb closes toward the extended index and middle fingertips one or more times."
+        ],
+        "transition": [
+          "Hand raising and pre-shaping before the first closure, plus relaxation after the final closure, are outside the event."
+        ]
+      },
+      "id": "no",
+      "index": 1,
+      "role": "target"
+    },
+    {
+      "description": "Flat or open palm at the upper chest with a small circular stroke.",
+      "display_name": "Please",
+      "examples": {
+        "ambiguous": [
+          "The chest anchor is missing, the circular stroke is clipped, or the motion path is indeterminate."
+        ],
+        "negative": [
+          "Static chest contact, a straight chest rub, a circle away from the chest, or a chin-origin outward stroke."
+        ],
+        "positive": [
+          "A flat or open palm at or near the upper chest makes a small circular stroke."
+        ],
+        "transition": [
+          "Approach to the chest before the circle and withdrawal after the circle are outside the target interval."
+        ]
+      },
+      "id": "please",
+      "index": 2,
+      "role": "target"
+    },
+    {
+      "description": "Flat or open hand begins at the chin or lower face and moves outward in one stroke.",
+      "display_name": "Thank you",
+      "examples": {
+        "ambiguous": [
+          "The origin at the chin or lower face is unavailable, or the outward stroke is occluded or clipped."
+        ],
+        "negative": [
+          "A forehead-origin wave, a chest circle, or an unrelated hand movement near the mouth."
+        ],
+        "positive": [
+          "A flat or open hand starts at the chin or lower face and moves outward, usually slightly downward, in one stroke."
+        ],
+        "transition": [
+          "Approach to the chin before the stroke and the return or drop after the stroke are outside the event."
+        ]
+      },
+      "id": "thank_you",
+      "index": 3,
+      "role": "target"
+    },
+    {
+      "description": "Closed fist near the upper torso performs one or more wrist-driven vertical nods.",
+      "display_name": "Yes",
+      "examples": {
+        "ambiguous": [
+          "The fist shape or the wrist-driven vertical motion cannot be observed reliably."
+        ],
+        "negative": [
+          "A static fist, thumbs-up, punch, whole-hand opening, or thumb-to-fingertip closure."
+        ],
+        "positive": [
+          "A closed fist near the upper torso performs one or more wrist-driven vertical nods."
+        ],
+        "transition": [
+          "Fist formation or raising before the first nod and opening or lowering after the last nod are outside the event."
+        ]
+      },
+      "id": "yes",
+      "index": 4,
+      "role": "target"
+    },
+    {
+      "description": "A complete candidate event that is confidently outside the five-target vocabulary.",
+      "display_name": "Other",
+      "examples": {
+        "ambiguous": [
+          "A candidate whose defining motion or hand shape is not visible enough to determine whether it is a target."
+        ],
+        "negative": [
+          "A complete, correctly bounded performance of any of the five target gestures."
+        ],
+        "positive": [
+          "A complete out-of-vocabulary gesture, a clearly incomplete target attempt, or unrelated intentional hand activity."
+        ],
+        "transition": [
+          "A derived target transition may be a training hard negative only on train or development splits, never relabeled source truth."
+        ]
+      },
+      "id": "other",
+      "index": 5,
+      "role": "learned_negative"
+    }
+  ],
+  "legacy_import": {
+    "aliases": [
+      {
+        "source": "thank you",
+        "target": "thank_you"
+      }
+    ],
+    "quarantined": [
+      "nothing"
+    ]
+  },
+  "other_kinds": [
+    "partial_target",
+    "transition_fragment",
+    "oov_gesture",
+    "incidental_activity",
+    "two_hand_non_target"
+  ],
+  "rules": {
+    "ambiguous_annotations": "Ambiguous records require adjudication before they become trainable or evaluable.",
+    "handedness": "Either hand is accepted only after handedness normalization is recorded explicitly.",
+    "ignore_regions": "Ignore regions require a documented reason such as consent exclusion, camera setup, third-party presence, unresolved conflict, or unusable occlusion.",
+    "out_of_vocabulary": "A complete gesture candidate outside the five targets is other with kind oov_gesture.",
+    "partial_gesture": "A clearly incomplete target attempt is other with kind partial_target; insufficient visibility is ambiguous instead.",
+    "poor_segmentation": "Poor segmentation never changes source event truth; continuous evaluation still records detector misses and fragmentation.",
+    "second_hand": "An incidental second hand is allowed only when it does not contact, occlude, or alter the active-hand form; coordinated two-hand activity is other.",
+    "transitions": "Transitions are not automatically training examples; derived transition fragments may be other only on train or development splits."
+  },
+  "schema_version": "gesture-taxonomy/1",
+  "taxonomy_id": "signlab-five",
+  "version": "1.0.0"
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,11 +19,11 @@ def test_top_level_help_exposes_thin_command_groups(runner: CliRunner) -> None:
     result = runner.invoke(cli.app, ["--help"])
 
     assert result.exit_code == 0
-    for command in ("data", "train", "evaluate", "export", "doctor"):
+    for command in ("data", "train", "evaluate", "export", "doctor", "taxonomy"):
         assert command in result.output
 
 
-@pytest.mark.parametrize("command", ["data", "train", "evaluate", "export", "doctor"])
+@pytest.mark.parametrize("command", ["data", "train", "evaluate", "export", "doctor", "taxonomy"])
 def test_command_group_help_has_no_pipeline_prerequisites(
     runner: CliRunner,
     command: str,

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -1,0 +1,523 @@
+from __future__ import annotations
+
+import json
+from importlib.resources import files
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import ValidationError as JsonSchemaValidationError
+from pydantic import ValidationError
+
+import signlab.contracts.taxonomy as taxonomy_contract
+from signlab.contracts.taxonomy import (
+    APPROVED_PRODUCT_CLAIM,
+    BUILTIN_TAXONOMY_DIGEST,
+    CONSUMER_BINDING_MODELS,
+    EXPECTED_CLASS_IDS,
+    EXPECTED_CONSUMERS,
+    EXPECTED_OTHER_KINDS,
+    EXPECTED_TARGET_IDS,
+    TaxonomyContractError,
+    TaxonomyRef,
+    canonical_json_bytes,
+    generated_json_schemas,
+    load_builtin_taxonomy,
+    normalize_legacy_label,
+    taxonomy_digest,
+    taxonomy_reference,
+    validate_packaged_taxonomy_resources,
+    validate_taxonomy,
+    validate_training_label_counts,
+    validate_training_label_map,
+    validate_training_taxonomy_binding,
+)
+
+EXPECTED_DIGEST = "sha256:" + "c0f6cbddfe43e3a6eb3de01dbbbbc1ceebcb83d50cc197999776f58e3d9ce20d"
+BINDING_VERSIONS = {
+    "collection-taxonomy-binding-1.schema.json": "collection-taxonomy-binding/1",
+    "annotation-taxonomy-binding-1.schema.json": "annotation-taxonomy-binding/1",
+    "training-taxonomy-binding-1.schema.json": "training-taxonomy-binding/1",
+    "evaluation-taxonomy-binding-1.schema.json": "evaluation-taxonomy-binding/1",
+    "bundle-taxonomy-binding-1.schema.json": "bundle-taxonomy-binding/1",
+    "public-copy-taxonomy-binding-1.schema.json": "public-copy-taxonomy-binding/1",
+}
+
+
+def _document() -> dict[str, Any]:
+    return load_builtin_taxonomy().model_dump(mode="json", round_trip=True)
+
+
+def _training_map() -> dict[str, int]:
+    return {label: index for index, label in enumerate(EXPECTED_CLASS_IDS)}
+
+
+def _training_counts() -> dict[str, int]:
+    return dict.fromkeys(EXPECTED_CLASS_IDS, 3)
+
+
+def _training_binding_document() -> dict[str, Any]:
+    return {
+        "schema_version": "training-taxonomy-binding/1",
+        "taxonomy": taxonomy_reference(load_builtin_taxonomy()).model_dump(mode="json"),
+        "label_map": _training_map(),
+        "label_counts": _training_counts(),
+    }
+
+
+def test_builtin_taxonomy_has_stable_identity_and_output_order() -> None:
+    taxonomy = load_builtin_taxonomy()
+
+    assert taxonomy.taxonomy_id == "signlab-five"
+    assert taxonomy.version == "1.0.0"
+    assert tuple(label.id for label in taxonomy.labels) == EXPECTED_CLASS_IDS
+    assert tuple(label.index for label in taxonomy.labels) == tuple(range(6))
+    assert BUILTIN_TAXONOMY_DIGEST == EXPECTED_DIGEST
+    assert taxonomy_digest(taxonomy) == EXPECTED_DIGEST
+    assert taxonomy_reference(taxonomy).model_dump(mode="json") == {
+        "schema_version": "taxonomy-reference/1",
+        "id": "signlab-five",
+        "version": "1.0.0",
+        "sha256": EXPECTED_DIGEST,
+    }
+
+
+def test_every_target_has_all_operational_example_categories() -> None:
+    taxonomy = load_builtin_taxonomy()
+
+    targets = tuple(label for label in taxonomy.labels if label.role == "target")
+    assert tuple(label.id for label in targets) == EXPECTED_TARGET_IDS
+    for target in targets:
+        assert target.examples.positive
+        assert target.examples.negative
+        assert target.examples.ambiguous
+        assert target.examples.transition
+
+
+def test_runtime_layers_annotation_states_and_edge_rules_are_explicit() -> None:
+    taxonomy = load_builtin_taxonomy()
+
+    assert {concept.id: concept.role for concept in taxonomy.concepts} == {
+        "inactive": "detector_state",
+        "other": "learned_class",
+        "abstain": "decision_outcome",
+    }
+    assert tuple(item.id for item in taxonomy.annotation_dispositions) == (
+        "ambiguous",
+        "ignore",
+    )
+    assert taxonomy.decision_precedence == ("inactive", "target", "other", "abstain")
+    assert taxonomy.other_kinds == EXPECTED_OTHER_KINDS
+    assert all(
+        getattr(taxonomy.rules, field)
+        for field in (
+            "handedness",
+            "second_hand",
+            "partial_gesture",
+            "out_of_vocabulary",
+            "poor_segmentation",
+            "transitions",
+            "ignore_regions",
+            "ambiguous_annotations",
+        )
+    )
+
+
+def test_default_claim_is_bounded_and_has_no_named_language_attribution() -> None:
+    claim = load_builtin_taxonomy().claim
+
+    assert claim.profile == "predefined_gestures"
+    assert claim.statement == APPROVED_PRODUCT_CLAIM
+    assert "five predefined hand gestures" in claim.statement
+    assert "named_language_evidence" not in claim.model_dump(mode="json")
+
+
+def test_v1_rejects_every_named_language_claim_until_human_review() -> None:
+    document = _document()
+    document["claim"] = {
+        "profile": "validated_named_language",
+        "statement": "An unsupported named-language claim.",
+        "named_language_evidence": {
+            "reviewer_role": "self-asserted fixture",
+            "evidence_digest": "sha256:" + "a" * 64,
+        },
+    }
+
+    with pytest.raises(TaxonomyContractError, match="predefined_gestures"):
+        validate_taxonomy(document)
+
+
+def test_predefined_claim_cannot_be_silently_reworded_or_carry_evidence() -> None:
+    document = _document()
+    claim = cast(dict[str, Any], document["claim"])
+    claim["statement"] = "A broader unsupported claim."
+
+    with pytest.raises(TaxonomyContractError, match="approved statement"):
+        validate_taxonomy(document)
+
+    document = _document()
+    claim = cast(dict[str, Any], document["claim"])
+    claim["named_language_evidence"] = {"reviewer_role": "fixture"}
+    with pytest.raises(TaxonomyContractError, match="Extra inputs are not permitted"):
+        validate_taxonomy(document)
+
+
+def test_taxonomy_models_and_json_schemas_are_closed() -> None:
+    taxonomy = load_builtin_taxonomy()
+    with pytest.raises(ValidationError, match="frozen"):
+        taxonomy.version = "2.0.0"
+
+    document = _document()
+    document["unexpected"] = True
+    with pytest.raises(TaxonomyContractError, match="Extra inputs are not permitted"):
+        validate_taxonomy(document)
+
+    schema = generated_json_schemas()["gesture-taxonomy-1.schema.json"]
+    with pytest.raises(JsonSchemaValidationError):
+        Draft202012Validator(schema).validate(document)
+
+
+def test_public_validator_rechecks_unsafe_model_copies() -> None:
+    taxonomy = load_builtin_taxonomy()
+    unsafe = taxonomy.model_copy(update={"labels": taxonomy.labels[:-1]})
+
+    with pytest.raises(TaxonomyContractError, match="classifier labels must be ordered"):
+        validate_taxonomy(unsafe)
+    with pytest.raises(TaxonomyContractError, match="classifier labels must be ordered"):
+        taxonomy_reference(unsafe)
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (lambda document: document["labels"].pop(), "classifier labels must be ordered"),
+        (
+            lambda document: document["labels"][0].update({"index": 1}),
+            "classifier indices must be contiguous",
+        ),
+        (
+            lambda document: document["concepts"][0].update({"role": "learned_class"}),
+            "distinct layer ownership",
+        ),
+        (
+            lambda document: document["legacy_import"].update({"quarantined": []}),
+            "at least 1 item",
+        ),
+        (
+            lambda document: document["consumer_references"].pop(),
+            "consumer references must be ordered",
+        ),
+        (
+            lambda document: document["consumer_references"][0].update(
+                {
+                    "schema_id": (
+                        "https://signlab.dev/schemas/annotation-taxonomy-binding-1.schema.json"
+                    )
+                }
+            ),
+            "published binding schema",
+        ),
+    ],
+)
+def test_cross_field_invariants_reject_semantic_drift(
+    mutation: Any,
+    message: str,
+) -> None:
+    document = _document()
+    mutation(document)
+
+    with pytest.raises(TaxonomyContractError, match=message):
+        validate_taxonomy(document)
+
+
+def test_generated_schemas_are_valid_and_match_packaged_documents() -> None:
+    generated = generated_json_schemas()
+    schema_root = files("signlab.resources.schemas")
+
+    assert set(generated) == {
+        "gesture-taxonomy-1.schema.json",
+        "taxonomy-reference-1.schema.json",
+        *BINDING_VERSIONS,
+    }
+    for filename, schema in generated.items():
+        Draft202012Validator.check_schema(schema)
+        packaged = json.loads(schema_root.joinpath(filename).read_text(encoding="utf-8"))
+        assert packaged == schema
+
+
+def test_generated_schemas_validate_taxonomy_reference_and_all_six_bindings() -> None:
+    taxonomy = load_builtin_taxonomy()
+    reference = taxonomy_reference(taxonomy)
+    schemas = generated_json_schemas()
+
+    Draft202012Validator(schemas["gesture-taxonomy-1.schema.json"]).validate(
+        taxonomy.model_dump(mode="json")
+    )
+    Draft202012Validator(schemas["taxonomy-reference-1.schema.json"]).validate(
+        reference.model_dump(mode="json")
+    )
+    for filename, model in CONSUMER_BINDING_MODELS.items():
+        fields: dict[str, Any] = {
+            "schema_version": BINDING_VERSIONS[filename],
+            "taxonomy": reference,
+        }
+        if filename == "training-taxonomy-binding-1.schema.json":
+            fields.update(label_map=_training_map(), label_counts=_training_counts())
+        binding = model(
+            **fields,
+        )
+        payload = binding.model_dump(mode="json")
+        Draft202012Validator(schemas[filename]).validate(payload)
+        assert payload["taxonomy"] == reference.model_dump(mode="json")
+
+    assert tuple(rule.consumer for rule in taxonomy.consumer_references) == EXPECTED_CONSUMERS
+
+
+def test_published_reference_and_every_binding_reject_unknown_identity() -> None:
+    reference = taxonomy_reference(load_builtin_taxonomy()).model_dump(mode="json")
+    unknown = {**reference, "id": "unreviewed", "version": "9.9.9"}
+
+    with pytest.raises(ValidationError, match="unsupported published taxonomy reference"):
+        TaxonomyRef.model_validate(unknown, strict=True)
+
+    collision = {**reference, "sha256": "sha256:" + "0" * 64}
+    with pytest.raises(ValidationError, match="does not match published"):
+        TaxonomyRef.model_validate(collision, strict=True)
+
+    schemas = generated_json_schemas()
+    with pytest.raises(JsonSchemaValidationError):
+        Draft202012Validator(schemas["taxonomy-reference-1.schema.json"]).validate(unknown)
+    for filename in BINDING_VERSIONS:
+        payload: dict[str, Any] = {
+            "schema_version": BINDING_VERSIONS[filename],
+            "taxonomy": unknown,
+        }
+        if filename == "training-taxonomy-binding-1.schema.json":
+            payload.update(label_map=_training_map(), label_counts=_training_counts())
+        with pytest.raises(JsonSchemaValidationError):
+            Draft202012Validator(schemas[filename]).validate(payload)
+    with pytest.raises(JsonSchemaValidationError):
+        Draft202012Validator(schemas["taxonomy-reference-1.schema.json"]).validate(collision)
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda document: document["labels"].pop(),
+        lambda document: document["claim"].update({"statement": "An unsupported claim."}),
+        lambda document: document["concepts"][0].update({"role": "learned_class"}),
+        lambda document: document["legacy_import"]["aliases"][0].update({"target": "other"}),
+    ],
+)
+def test_portable_schema_rejects_every_reviewed_semantic_invariant(mutation: Any) -> None:
+    document = _document()
+    mutation(document)
+    schema = generated_json_schemas()["gesture-taxonomy-1.schema.json"]
+
+    with pytest.raises(JsonSchemaValidationError):
+        Draft202012Validator(schema).validate(document)
+
+
+def test_published_version_cannot_be_reused_for_changed_content() -> None:
+    document = _document()
+    document["labels"][0]["description"] = "A semantically changed definition."
+
+    with pytest.raises(TaxonomyContractError, match="is immutable"):
+        validate_taxonomy(document)
+
+    document = _document()
+    document["version"] = "1.0.1"
+    with pytest.raises(TaxonomyContractError, match=r"unsupported taxonomy.*publish a new"):
+        validate_taxonomy(document)
+
+
+def test_python_and_json_schema_share_numeric_and_whitespace_acceptance() -> None:
+    taxonomy_document = _document()
+    taxonomy_document["labels"][0]["index"] = 0.0
+    taxonomy_schema = generated_json_schemas()["gesture-taxonomy-1.schema.json"]
+
+    validated = validate_taxonomy(taxonomy_document)
+    assert validated.labels[0].index == 0
+    Draft202012Validator(taxonomy_schema).validate(taxonomy_document)
+
+    padded = _document()
+    padded["labels"][0]["description"] = f" {padded['labels'][0]['description']}"
+    with pytest.raises(TaxonomyContractError, match="String should match pattern"):
+        validate_taxonomy(padded)
+    with pytest.raises(JsonSchemaValidationError):
+        Draft202012Validator(taxonomy_schema).validate(padded)
+
+    training_document = _training_binding_document()
+    training_document["label_map"]["hello"] = 0.0
+    training_document["label_counts"]["other"] = 2.0
+    training_schema = generated_json_schemas()["training-taxonomy-binding-1.schema.json"]
+    training = validate_training_taxonomy_binding(training_document)
+    assert training.label_map.hello == 0
+    assert training.label_counts.other == 2
+    Draft202012Validator(training_schema).validate(training_document)
+
+    for invalid_integer in (False, "0"):
+        invalid = _training_binding_document()
+        invalid["label_map"]["hello"] = invalid_integer
+        with pytest.raises(TaxonomyContractError):
+            validate_training_taxonomy_binding(invalid)
+        with pytest.raises(JsonSchemaValidationError):
+            Draft202012Validator(training_schema).validate(invalid)
+
+
+def test_generated_schemas_keep_every_registered_release_backward_compatible(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    version_one = load_builtin_taxonomy()
+    version_two_unchecked = version_one.model_copy(update={"version": "1.0.1"})
+    version_two_digest = taxonomy_digest(version_two_unchecked)
+    monkeypatch.setattr(
+        taxonomy_contract,
+        "PUBLISHED_TAXONOMY_DIGESTS",
+        {
+            ("signlab-five", "1.0.0"): BUILTIN_TAXONOMY_DIGEST,
+            ("signlab-five", "1.0.1"): version_two_digest,
+        },
+    )
+    version_two = validate_taxonomy(version_two_unchecked)
+    monkeypatch.setattr(
+        taxonomy_contract,
+        "load_published_taxonomies",
+        lambda: (version_one, version_two),
+    )
+
+    schemas = generated_json_schemas()
+    assert len(schemas["gesture-taxonomy-1.schema.json"]["oneOf"]) == 2
+    assert len(schemas["taxonomy-reference-1.schema.json"]["oneOf"]) == 2
+    for taxonomy in (version_one, version_two):
+        reference = taxonomy_reference(taxonomy)
+        Draft202012Validator(schemas["gesture-taxonomy-1.schema.json"]).validate(
+            taxonomy.model_dump(mode="json")
+        )
+        Draft202012Validator(schemas["taxonomy-reference-1.schema.json"]).validate(
+            reference.model_dump(mode="json")
+        )
+        Draft202012Validator(schemas["collection-taxonomy-binding-1.schema.json"]).validate(
+            {
+                "schema_version": "collection-taxonomy-binding/1",
+                "taxonomy": reference.model_dump(mode="json"),
+            }
+        )
+
+
+def test_canonical_serialization_is_deterministic_and_rejects_non_json_values() -> None:
+    taxonomy = load_builtin_taxonomy()
+    first = canonical_json_bytes(taxonomy)
+    second = canonical_json_bytes(validate_taxonomy(first))
+
+    assert first == second
+    assert first == canonical_json_bytes(json.loads(first))
+    with pytest.raises(ValueError, match="Out of range float values"):
+        canonical_json_bytes({"invalid": float("nan")})
+    with pytest.raises(TaxonomyContractError, match="not JSON-serializable"):
+        validate_taxonomy({"invalid": Path("not-json")})
+
+
+def test_legacy_normalization_is_explicit_and_nothing_stays_quarantined() -> None:
+    assert normalize_legacy_label("thank you") == "thank_you"
+    assert normalize_legacy_label("thank_you") == "thank_you"
+
+    with pytest.raises(TaxonomyContractError, match="must be reannotated"):
+        normalize_legacy_label("nothing")
+    with pytest.raises(TaxonomyContractError, match="no implicit normalization"):
+        normalize_legacy_label("Thank You")
+
+
+def test_training_label_map_requires_exact_six_output_order() -> None:
+    assert validate_training_label_map(_training_map()) == EXPECTED_CLASS_IDS
+
+    target_only = {label: index for index, label in enumerate(EXPECTED_TARGET_IDS)}
+    with pytest.raises(TaxonomyContractError, match="required learned negative class 'other'"):
+        validate_training_label_map(target_only)
+
+    reordered = _training_map()
+    reordered["hello"], reordered["no"] = reordered["no"], reordered["hello"]
+    with pytest.raises(TaxonomyContractError, match="indices must match"):
+        validate_training_label_map(reordered)
+
+    invalid_type = _training_map()
+    invalid_type["hello"] = cast(int, False)
+    with pytest.raises(TaxonomyContractError, match="indices must be integers"):
+        validate_training_label_map(invalid_type)
+
+
+@pytest.mark.parametrize(
+    "forbidden_label",
+    ["inactive", "abstain", "ambiguous", "ignore", "nothing", "thank you"],
+)
+def test_non_classifier_tokens_are_rejected_from_training(forbidden_label: str) -> None:
+    label_map = _training_map()
+    label_map[forbidden_label] = 6
+
+    with pytest.raises(TaxonomyContractError, match="unexpected"):
+        validate_training_label_map(label_map)
+
+
+def test_training_counts_require_observed_targets_and_other_examples() -> None:
+    validate_training_label_counts(_training_counts())
+
+    without_other = _training_counts()
+    del without_other["other"]
+    with pytest.raises(TaxonomyContractError, match="required learned negative class 'other'"):
+        validate_training_label_counts(without_other)
+
+    empty_other = _training_counts()
+    empty_other["other"] = 0
+    with pytest.raises(TaxonomyContractError, match="zero training examples"):
+        validate_training_label_counts(empty_other)
+
+    empty_target = _training_counts()
+    empty_target["hello"] = 0
+    with pytest.raises(TaxonomyContractError, match="target classes have zero"):
+        validate_training_label_counts(empty_target)
+
+    invalid = _training_counts()
+    invalid["hello"] = -1
+    with pytest.raises(TaxonomyContractError, match="non-negative integers"):
+        validate_training_label_counts(invalid)
+
+
+def test_training_binding_requires_exact_labels_and_positive_observed_counts() -> None:
+    binding = validate_training_taxonomy_binding(_training_binding_document())
+    assert binding.label_map.other == 5
+    assert binding.label_counts.other == 3
+
+    without_other = _training_binding_document()
+    del without_other["label_map"]["other"]
+    with pytest.raises(TaxonomyContractError, match=r"label_map\.other: Field required"):
+        validate_training_taxonomy_binding(without_other)
+
+    empty_other = _training_binding_document()
+    empty_other["label_counts"]["other"] = 0
+    with pytest.raises(TaxonomyContractError, match=r"label_counts\.other"):
+        validate_training_taxonomy_binding(empty_other)
+
+    schema = generated_json_schemas()["training-taxonomy-binding-1.schema.json"]
+    with pytest.raises(JsonSchemaValidationError):
+        Draft202012Validator(schema).validate(without_other)
+    with pytest.raises(JsonSchemaValidationError):
+        Draft202012Validator(schema).validate(empty_other)
+
+
+def test_every_packaged_schema_is_readable_valid_and_current() -> None:
+    validate_packaged_taxonomy_resources()
+
+
+def test_docs_publish_the_same_claim_and_do_not_call_it_five_class() -> None:
+    repository_root = Path(__file__).resolve().parents[1]
+    public_copy = "\n".join(
+        (repository_root / path).read_text(encoding="utf-8")
+        for path in ("README.md", "docs/PROJECT_CHARTER.md", "docs/gesture-taxonomy.md")
+    )
+
+    normalized_claim = " ".join(APPROVED_PRODUCT_CLAIM.split())
+    for path in ("README.md", "docs/PROJECT_CHARTER.md", "docs/gesture-taxonomy.md"):
+        content = (repository_root / path).read_text(encoding="utf-8").replace("> ", "")
+        assert normalized_claim in " ".join(content.split())
+    assert "five-class" not in public_copy.casefold()

--- a/tests/test_taxonomy_cli.py
+++ b/tests/test_taxonomy_cli.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from signlab import cli
+from signlab.commands import taxonomy as taxonomy_command
+from signlab.contracts.taxonomy import (
+    BUILTIN_TAXONOMY_DIGEST,
+    EXPECTED_CLASS_IDS,
+    TaxonomyContractError,
+    load_builtin_taxonomy,
+    taxonomy_reference,
+)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner(env={"NO_COLOR": "1"})
+
+
+def test_validate_builtin_taxonomy_prints_only_portable_identity(runner: CliRunner) -> None:
+    result = runner.invoke(cli.app, ["taxonomy", "validate"])
+
+    assert result.exit_code == 0
+    assert "signlab-five@1.0.0" in result.output
+    assert BUILTIN_TAXONOMY_DIGEST in result.output
+    assert "Users" not in result.output
+
+
+def test_validate_external_taxonomy_uses_a_generic_source_label(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    path = tmp_path / "participant-name-must-not-echo.json"
+    path.write_text(
+        json.dumps(load_builtin_taxonomy().model_dump(mode="json")),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(cli.app, ["taxonomy", "validate", str(path)])
+
+    assert result.exit_code == 0
+    assert "external" in result.output
+    assert path.name not in result.output
+    assert str(tmp_path) not in result.output
+
+
+def test_validate_invalid_taxonomy_returns_a_redacted_failure(
+    runner: CliRunner,
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "invalid.json"
+    path.write_text("{}", encoding="utf-8")
+
+    result = runner.invoke(cli.app, ["taxonomy", "validate", str(path)])
+
+    assert result.exit_code == 1
+    assert "Taxonomy validation failed" in result.output
+    assert str(tmp_path) not in result.output
+    assert "schema_version" in result.output
+
+
+@pytest.mark.parametrize("kind", ["missing", "directory"])
+def test_unreadable_external_paths_never_echo_identifiers(
+    runner: CliRunner,
+    tmp_path: Path,
+    kind: str,
+) -> None:
+    path = tmp_path / "participant-name-must-not-echo.json"
+    if kind == "directory":
+        path.mkdir()
+
+    result = runner.invoke(cli.app, ["taxonomy", "validate", str(path)])
+
+    assert result.exit_code == 1
+    assert "file could not be read" in result.output
+    assert path.name not in result.output
+    assert str(tmp_path) not in result.output
+
+
+def test_show_outputs_the_validated_packaged_document(runner: CliRunner) -> None:
+    result = runner.invoke(cli.app, ["taxonomy", "show"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.output)["taxonomy_id"] == "signlab-five"
+
+
+def test_validate_resources_reads_every_packaged_schema(runner: CliRunner) -> None:
+    result = runner.invoke(cli.app, ["taxonomy", "validate-resources"])
+
+    assert result.exit_code == 0
+    assert result.output.strip() == "Packaged taxonomy and schemas are valid."
+
+
+@pytest.mark.parametrize("command", ["validate", "validate-resources", "show"])
+def test_builtin_integrity_failure_returns_nonzero_without_traceback(
+    runner: CliRunner,
+    monkeypatch: pytest.MonkeyPatch,
+    command: str,
+) -> None:
+    monkeypatch.setattr(
+        taxonomy_command,
+        "load_builtin_taxonomy",
+        lambda: (_ for _ in ()).throw(TaxonomyContractError("integrity check failed")),
+    )
+
+    result = runner.invoke(cli.app, ["taxonomy", command])
+
+    assert result.exit_code == 1
+    assert "integrity check failed" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_train_entry_point_fails_before_work_when_other_is_missing(
+    runner: CliRunner,
+    tmp_path: Path,
+) -> None:
+    reference = taxonomy_reference(load_builtin_taxonomy()).model_dump(mode="json")
+    document: dict[str, Any] = {
+        "schema_version": "training-taxonomy-binding/1",
+        "taxonomy": reference,
+        "label_map": {label: index for index, label in enumerate(EXPECTED_CLASS_IDS)},
+        "label_counts": dict.fromkeys(EXPECTED_CLASS_IDS, 2),
+    }
+    valid_path = tmp_path / "valid.json"
+    valid_path.write_text(json.dumps(document), encoding="utf-8")
+
+    valid = runner.invoke(cli.app, ["train", "validate-taxonomy", str(valid_path)])
+    assert valid.exit_code == 0
+    assert "learned negative 'other'" in valid.output
+
+    del document["label_map"]["other"]
+    invalid_path = tmp_path / "participant-name-must-not-echo.json"
+    invalid_path.write_text(json.dumps(document), encoding="utf-8")
+    invalid = runner.invoke(cli.app, ["train", "validate-taxonomy", str(invalid_path)])
+
+    assert invalid.exit_code == 1
+    assert "label_map.other: Field required" in invalid.output
+    assert invalid_path.name not in invalid.output
+    assert str(tmp_path) not in invalid.output
+
+
+def test_train_entry_point_redacts_missing_input_path(
+    runner: CliRunner,
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "participant-name-must-not-echo.json"
+
+    result = runner.invoke(cli.app, ["train", "validate-taxonomy", str(path)])
+
+    assert result.exit_code == 1
+    assert "input file could not be read" in result.output
+    assert path.name not in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-types"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/56/a8120250d128bed162cd73c76d45f6ef9991f3e068f62a8ee060afa3104a/annotated_types-0.8.0.tar.gz", hash = "sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7", size = 15893, upload-time = "2026-07-23T20:16:13.995Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl", hash = "sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0", size = 13427, upload-time = "2026-07-23T20:16:12.938Z" },
+]
+
+[[package]]
 name = "ast-serialize"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -336,6 +345,51 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.21.0"
 source = { registry = "https://pypi.org/simple" }
@@ -502,6 +556,7 @@ name = "signlab"
 source = { editable = "." }
 dependencies = [
     { name = "jsonschema" },
+    { name = "pydantic" },
     { name = "typer" },
 ]
 
@@ -520,6 +575,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "jsonschema", specifier = ">=4.26,<5" },
+    { name = "pydantic", specifier = ">=2.13.4,<2.14" },
     { name = "typer", specifier = ">=0.27.1,<0.28" },
 ]
 
@@ -587,6 +643,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/26/b09b8010994eccc3c09092e6b34058f36a460eea2d4c3e8b910c695975a0/typing_inspection-0.4.4.tar.gz", hash = "sha256:547274fa6b0a561ccf549cc9524b999a578e737d015d8709d021f9d0d13bea47", size = 76928, upload-time = "2026-08-12T12:37:25.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl", hash = "sha256:65b8397ba37ccbce054456aaccddfc91e6e3083c92824df348d96ca832f3f147", size = 14750, upload-time = "2026-08-12T12:37:24.648Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Outcome

Defines the immutable `signlab-five@1.0.0` gesture taxonomy and the only currently authorized product claim: five predefined hand gestures, with no named-language or translation claim.

The implementation separates detector `inactive`, learned `other`, and policy `abstain`; publishes the fixed six-output label order; defines positive, negative, ambiguous, and transition examples for every target; and records rules for partial gestures, two-hand activity, out-of-vocabulary events, poor segmentation, ignore regions, and the quarantined legacy `nothing` label.

## Contracts and enforcement

- strict, frozen Pydantic taxonomy and reference models
- immutable `(id, version) -> digest` registry with same-version collision rejection
- Draft 2020-12 schemas for the taxonomy, reference, and collection/annotation/training/evaluation/bundle/public-copy bindings
- portable schemas enumerate every registered release so future versions retain backward compatibility
- training binding requires the exact six-output label map and positive observed counts, including `other`
- Python and standalone JSON Schema share numeric and whitespace acceptance
- packaged-resource validation and isolated-wheel verification cover the exact taxonomy/schema set
- redacted taxonomy and training CLI validation commands

## Verification

- `uv run pytest` — 241 passed, 91.91% branch-aware coverage
- Ruff, formatting, and strict mypy
- repository hygiene and pre-commit
- source/wheel build and isolated installed-wheel verification
- adversarial replay of schema, claim, version-collision, forged-reference, missing-negative, unsafe-model, path-disclosure, package-resource, numeric, and multi-release compatibility bypasses
- independent final review: no remaining P0/P1/P2 findings

Closes #11