### PR TITLE
Define the repeatable collection and annotation protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ executable withdrawal dry run. Real participant collection remains blocked until
 the documented human, institutional, legal, storage, and contact checks are
 resolved outside this public repository.
 
+The [collection and annotation protocol](docs/collection-protocol.md) defines the
+draft pilot design, randomized prompt procedure, capture checklists, temporal
+boundary rules, review workflow, and a no-camera synthetic rehearsal. It does not
+authorize real collection; the governance readiness gate remains authoritative.
+
 The [versioned pipeline contracts](docs/contracts.md) give datasets, grouped
 splits, preprocessing plans, resolved configurations, terminal runs, and research
 models portable RFC 8785 identities with explicit compatibility checks.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -56,10 +56,12 @@ label order, event boundaries, negative examples, legacy aliases, and the public
 claim. Downstream contracts may add fields but cannot reinterpret its identifiers.
 
 The [dataset manifest](dataset-manifests.md) includes stable identifiers for clips,
-participants, sessions, source recordings, devices, capture conditions,
-handedness, mirroring, consent, and checksums. Derived samples inherit the source
-recording and split. Six normalized tables use explicit Arrow schemas and Parquet
-storage while retaining storage-independent semantic hashes. V2 row artifacts use
+participants, sessions, source recordings, devices, camera facts, handedness,
+mirroring, consent, and checksums. Prompt order and condition assignments live in a
+separate collection sidecar whose production contract belongs to Story #17; they
+must not be smuggled into dataset IDs. Derived samples inherit the source recording
+and split. Six normalized tables use explicit Arrow schemas and Parquet storage
+while retaining storage-independent semantic hashes. V2 row artifacts use
 hash-derived logical paths whose only filename is the opaque artifact ID; dataset
 locators therefore cannot carry hostnames, participant names, or free-text labels.
 

--- a/docs/collection-protocol.md
+++ b/docs/collection-protocol.md
@@ -1,0 +1,467 @@
+# Collection and annotation protocol
+
+- Protocol ID: `signlab-collection-protocol`
+- Draft version: `0.1.0`
+- Status: pilot draft; not approved for real participant collection
+- Taxonomy: `signlab-five@1.0.0`
+Taxonomy digest:
+`sha256:c0f6cbddfe43e3a6eb3de01dbbbbc1ceebcb83d50cc197999776f58e3d9ce20d`
+
+This protocol makes SignLab collection and temporal annotation repeatable. It covers
+the five predefined target gestures and the learned `other` class described by the
+[gesture taxonomy](gesture-taxonomy.md). It does not claim that those gestures are
+validated words in a named sign language.
+
+This is a draft for a synthetic dry run and the later pilot. The numerical targets
+below are engineering starting points, not universal statistical standards. Story
+#21 will measure rejection rates and coverage during a real, authorized pilot and
+then either revise or freeze version 1.
+
+## Hard stop before real collection
+
+**Do not turn on a camera for a participant while the governance readiness result is
+`blocked`.** The current public repository cannot authenticate consent or authorize
+collection. A real session requires all of the following outside this protocol:
+
+1. An authorized operator confirms that the exact collection-readiness record is
+   `ready`, with every required external approval and storage control resolved.
+2. The identity-vault workflow produces an authenticated consent receipt and a
+   recording-level grant for the exact purpose and study.
+3. The participant receives the approved information, can ask questions, and knows
+   that participation is voluntary and may be stopped or withdrawn.
+4. The private capture destination, access roles, backup behavior, and deletion path
+   match the approved governance configuration.
+
+Never copy names, contact information, signatures, device serials, or the
+identity-to-pseudonym mapping into a prompt plan, filename, dataset table, log, Git,
+DVC metadata, or experiment tracker. Audio is disabled for every SignLab recording.
+See [participant-data governance](governance/README.md) for the authoritative gate.
+
+The committed mock session is intentionally identity-free, uses no person or camera,
+and does not represent consent, approval, or production readiness.
+
+## Roles and records
+
+One person may hold multiple roles during a synthetic rehearsal, but the real pilot
+records who performed each role using approved operator/reviewer IDs:
+
+- **Session operator:** verifies the gate and checklists, prepares the prompt plan,
+  operates capture, records deviations, and never coaches the answer after a prompt.
+- **Participant:** chooses whether to continue and may pause, retry, skip, or stop.
+- **Annotator:** applies temporal boundaries and dispositions without seeing model
+  predictions.
+- **Reviewer:** independently checks labels, boundaries, and exclusions.
+- **Adjudicator:** resolves recorded disagreements; the original draft remains
+  auditable.
+
+Use three distinct record layers:
+
+1. The normalized dataset tables hold stable participant/session/recording identities,
+   camera facts, root-recording intervals, labels, dispositions, and review state.
+2. The collection sidecar holds protocol version, visit, prompt seed and realized
+   order, repetition, condition codes, checklists, technical retries, and deviations.
+   The fixture in `tests/fixtures/public/collection/mock-session-plan.json` is an
+   evidence format, not yet a production interchange contract. Story #17 owns that
+   tool-facing contract.
+3. Authenticated consent and identity records stay behind the identity-vault boundary;
+   only the approved pseudonymous grant snapshot reaches restricted research data.
+
+Do not overload filenames, device IDs, or annotation reason codes with information
+that belongs in the collection sidecar.
+
+## Pilot collection design
+
+The initial pilot design is deliberately small enough to execute and rich enough to
+expose leakage and coverage problems:
+
+- Use at least three adult signers after the governance gate becomes ready.
+- Give each signer a random pseudonymous ID and collect two visits at least 24 hours
+  apart. Tear down or reposition the setup between visits.
+- A visit contains separate `isolated` and `continuous` dataset sessions because
+  `capture_mode` is a scalar session field.
+- In each visit, schedule five isolated attempts for each target: 25 target trials
+  per visit and ten per target across the two visits. Retain mistakes and technical
+  failures; the pilot report distinguishes scheduled, accepted, and recollected
+  counts.
+- In each continuous block, include every target at least once and at least 60 total
+  seconds of explicit inactivity distributed before, between, and after events.
+- Across a signer's two visits, prompt at least two examples of each source hard-
+  negative kind: `partial_target`, `oov_gesture`, `incidental_activity`, and
+  `two_hand_non_target`.
+- Retain natural mistakes, partial attempts, unrelated movement, pauses, and direct
+  target-to-target transitions. Do not keep only successful, tightly trimmed clips.
+- Cover at least two device configurations, with each configuration used by at least
+  two signers. Every declared framing, distance, lighting, and clothing-contrast
+  profile must include every target and be used by at least two signers.
+- Seek naturally occurring left- and right-hand coverage. Never ask a participant to
+  perform unnaturally with a nondominant hand just to fill a cell. Record the gap and
+  narrow the eventual claim if coverage remains insufficient.
+
+These are minimum pilot targets, not a promise of dataset sufficiency. The intended
+production study is roughly 8–12 signers, at least two separated visits per signer,
+and about ten accepted performances per signer and target. Story #21 must replace
+those estimates with a documented decision based on pilot evidence before scaling.
+
+### Condition ledger
+
+Before a visit, assign opaque condition codes for these controlled dimensions:
+
+| Dimension | Required record | Pilot variation rule |
+| --- | --- | --- |
+| Framing | upper body and both hand-travel areas visible, with margin | Use each declared profile for every target. |
+| Distance | measured setup profile, not a person's location | Use each profile for every target and at least two signers. |
+| Lighting | stable, usable face/hand/body-anchor visibility | Include ordinary variation; reject unsafe or unusable setups. |
+| Clothing | coarse contrast profile only | Vary contrast without recording sensitive free text. |
+| Handedness | observed `left`, `right`, or `both` per recording | Preserve natural performance; normalization is downstream. |
+| Camera | facing, resolution, frame rate, rotation, and mirror state | Record actual facts; do not infer them from a filename. |
+
+Change conditions by block or visit, not by class. Every target appears under each
+assigned profile so a label cannot be learned from lighting, clothing, device, or
+background. Keep signer, visit, session, and device grouping intact for later
+leakage-resistant splits.
+
+### Repeatable pilot profiles and prompt cards
+
+The draft pilot begins with two setup profiles. Measure distance from the camera
+lens to the participant's upper-chest plane after the participant is comfortably
+positioned; do not record a home or venue location.
+
+| Profile code | Distance and orientation | Lighting and clothing observation | Framing check |
+| --- | --- | --- | --- |
+| `near_soft_front_landscape` | `0.8 m +/- 0.1 m`; landscape; record actual rotation | Diffuse source within 30 degrees of camera; plain top whose boundary with the hands remains visually clear | Top of head through mid-torso and both complete hand-travel areas remain visible with roughly one hand-width of margin. |
+| `medium_diffuse_side_portrait` | `1.2 m +/- 0.1 m`; portrait; record actual rotation | Diffuse source 30–60 degrees to one side; plain top with reduced but still usable hand-boundary contrast | Same body and hand-travel coverage; rotate/reframe without cropping either side. |
+
+`High contrast` means that an operator can follow the hand boundary throughout the
+short setup playback; `medium contrast` means the boundary remains visible but has
+less separation. Do not record skin color, ethnicity, clothing descriptions, room
+descriptions, or other sensitive/free-text attributes. If the distinction cannot be
+made consistently, use an `unassessed` profile, record the limitation, and do not
+invent a value. Story #20 later defines machine-computable landmark-quality policy.
+
+The prompt display uses the immutable taxonomy text, not an operator paraphrase:
+
+| Stable ID | Card title | Card instruction |
+| --- | --- | --- |
+| `hello` | Hello | Open hand near the temple or upper face; make one short outward or side-to-side wave. |
+| `no` | No | Close the thumb toward the extended index and middle fingertips one or more times. |
+| `please` | Please | Place a flat or open palm at the upper chest; make one small circular stroke. |
+| `thank_you` | Thank you | Begin with a flat or open hand at the chin or lower face; move outward in one stroke. |
+| `yes` | Yes | With a closed fist near the upper torso, make one or more wrist-driven vertical nods. |
+
+Every card also says: “Perform this once at a natural, comfortable speed using the
+hand you would normally use. You may pause, skip, retry, or stop.” The title is a
+project mnemonic, not a named-language claim. Show all cards during orientation;
+during capture show only the current occurrence ID and its card.
+
+## Prepare the prompt plan
+
+Generate the plan once before capture and preserve the realized order even if the
+session later aborts. Record a seed, an algorithm/version marker, and the exact
+realized order. The realized order is authoritative evidence; a seed without the
+matching algorithm is not enough to reconstruct it. The fixture demonstrates these
+fields, while Story #17 owns their production contract and generator.
+
+For each isolated session:
+
+1. Create five occurrences of each target ID: `hello`, `no`, `please`, `thank_you`,
+   and `yes`.
+2. Randomize the balanced list with a recorded seed.
+3. Reject an order only if the same target is immediately adjacent to itself; use a
+   deterministic balancing procedure, not operator preference.
+4. Use a different realized order for the second visit.
+5. Assign a stable prompt occurrence ID and repetition number. Never renumber after a
+   failure, skip, or retry.
+
+For each continuous session, prepare a block containing all five targets, inactivity,
+direct transitions, natural mistakes, partial attempts, and unrelated hand activity.
+Randomize target order independently of the isolated block. Prompts describe what to
+attempt, not what the annotation must become.
+
+Do not reroll a sequence because a participant made mistakes. A technical failure may
+create a linked retry, but the failed occurrence and coded reason remain in the
+sidecar. A performance mistake remains source evidence and is annotated according to
+what is visible.
+
+## Run a visit
+
+### Before capture
+
+For a real visit, stop unless every consent item below is confirmed through the
+authorized workflow:
+
+- the readiness result is `ready`, current, and bound to this policy and storage;
+- the authenticated receipt, recording grant, purpose ID, and study ID agree;
+- the participant received the current documents and a copy to keep;
+- requested uses are no broader than the choices the participant allowed;
+- the participant knows how to pause, stop, ask questions, and withdraw;
+- the pseudonymous participant ID is active and the identity mapping stays in the
+  separate vault; and
+- audio capture is disabled.
+
+Then complete the setup checklist:
+
+- clean the lens; stabilize and orient the camera;
+- remove third parties and identifying material from the frame;
+- verify that the full hand-travel region, upper torso, face-area anchors, and both
+  hands when relevant remain visible with margin;
+- verify usable, stable lighting without glare or silhouette;
+- record the device configuration, camera facing, actual resolution and frame rate,
+  rotation, mirror state, distance, framing, lighting, and clothing-contrast codes;
+- confirm monotonic timestamps and available private storage; and
+- show the participant the five standardized taxonomy prompts and allow questions
+  without coaching a particular performance.
+
+The pilot targets 720p at 30 frames per second when the approved device supports it,
+but always record actual values. Landmark completeness and missing-frame thresholds
+belong to Story #20, not to operator judgment in this protocol.
+
+### During isolated capture
+
+Present one occurrence at a time in the realized order. Allow a neutral rest before
+and after the attempt. Do not stop early because the operator thinks the gesture was
+wrong. Record one of these outcomes in the sidecar:
+
+- completed as presented;
+- participant-requested pause or skip;
+- natural mistake retained;
+- technical retry required; or
+- session stopped.
+
+Retry only for a technical or protocol failure such as camera interruption, prompt
+display failure, a third party entering frame, or the hand-travel area leaving the
+declared setup. Link the retry to the original occurrence and keep the reason. Never
+silently replace an inconvenient example.
+
+### During continuous capture
+
+Record untrimmed sequences. Include:
+
+- neutral rest and ordinary inactivity;
+- every target in independently randomized order;
+- direct target-to-target transitions;
+- partial or aborted target attempts;
+- complete out-of-vocabulary gestures;
+- incidental activity such as reaching, device interaction, face or clothing touch;
+- coordinated two-hand non-target activity; and
+- naturally occurring occlusion or off-frame evidence.
+
+Natural transition movement is context, not automatically a source `other` label.
+Only a later derived train/development artifact may use
+`other/transition_fragment`, as allowed by the taxonomy.
+
+### After each recording
+
+Before leaving the capture workflow:
+
+- play a short portion from the beginning, middle, and end;
+- confirm expected duration, readable motion, audio absence, orientation, mirror
+  state, timestamps, and recorded resolution/frame rate;
+- check for frozen, truncated, corrupt, or unexpectedly missing content without
+  inventing downstream landmark-quality thresholds;
+- reconcile prompt occurrence IDs, skips, retries, deviations, and recording IDs;
+- compute and store the media checksum in the restricted manifest;
+- quarantine any recording with a consent, third-party, or storage-boundary problem;
+  and
+- record accept, quarantine, or recollect—not a silent deletion.
+
+## Temporal annotation rules
+
+All annotation intervals use root-recording microseconds and half-open bounds:
+`[start_us, end_us)`. The start is included; the end is the first excluded instant.
+Intervals must be non-empty and must remain inside the source recording and any
+referenced clip.
+
+Annotate observable evidence rather than the prompt:
+
+- **Static or held form:** start when the class-defining handshape, orientation, and
+  body-relative location are first established. End before a defining parameter
+  changes or retraction begins.
+- **Dynamic form:** start at the first class-defining motion after generic raising or
+  pre-shaping. End after the final defining motion or hold and before retraction or
+  the next event.
+- **Direct transition:** exclude generic travel from both neighboring targets. When
+  there is a defensible direction, shape, or parameter change, place the boundary
+  there. If no defensible boundary or class can be observed, use `ambiguous` with a
+  coded reason and send it to review.
+- **Inactivity:** leave it without a candidate annotation. `inactive` is a detector
+  state, never a classifier label.
+
+Use the taxonomy's positive, negative, ambiguous, and transition examples for each
+target. `abstain` is a runtime decision and never annotation ground truth.
+
+### Dispositions
+
+| Visible evidence | Annotation |
+| --- | --- |
+| Complete, defensible target | `class_label` with its target `label_id` |
+| Complete non-target event | `class_label`, `label_id: other`, and registered `other_kind` |
+| Clearly incomplete target attempt | `other/partial_target` |
+| Complete out-of-vocabulary gesture | `other/oov_gesture` |
+| Unrelated intentional hand activity | `other/incidental_activity` |
+| Coordinated two-hand non-target activity | `other/two_hand_non_target` |
+| Defining evidence is not reliably visible | `ambiguous` with a coded reason |
+| Region is excluded from training and scoring | `ignore` with a coded reason |
+
+Do not create a source `other/transition_fragment` annotation merely because two
+targets touch. Do not convert poor detector segmentation into a different source
+class.
+
+The initial reason-code allowlist is:
+
+- `unusable_occlusion` or `boundary_unclear` for genuinely ambiguous evidence;
+- `consent_exclusion`, `camera_setup`, `third_party_presence`,
+  `unresolved_conflict`, or `unusable_occlusion` for ignored regions.
+
+Story #17 must publish the controlled sidecar/reason-code contract before production
+import. Free-text explanations belong only in an approved restricted review system,
+not in dataset identifiers.
+
+## Review and adjudication
+
+The first pass is `draft` and never eligible for training. A reviewer sees the source
+recording, taxonomy, protocol version, and draft annotation but not a model prediction.
+The reviewer checks class, `other_kind`, disposition, interval boundaries, reason,
+and source IDs.
+
+For the pilot:
+
+- independently review every `ambiguous` and `ignore` row;
+- independently review every pilot class row (the future production minimum may be
+  a signer/session/label/condition-stratified 20% sample only after pilot evidence);
+- record each disagreement rather than overwriting the first pass;
+- mark an agreed row `reviewed`; and
+- route every disagreement to an adjudicator, who records the final row as
+  `adjudicated`.
+
+Only `class_label` rows with `reviewed` or `adjudicated` status are
+`eligible_for_training: true`. `draft`, `ambiguous`, and `ignore` rows are always
+ineligible. Review status proves workflow completion, not current consent; use still
+requires the separate authenticated authorization check.
+
+## Coverage and release check
+
+After each visit, update a coverage ledger by target, signer, visit, dataset session,
+device configuration, condition code, observed handedness, and hard-negative kind.
+Before declaring the pilot complete, verify:
+
+- every target has the planned isolated repetitions for every signer and visit;
+- every target appears in every declared condition profile;
+- no target is uniquely associated with one device, background, lighting, clothing,
+  distance, prompt position, signer, or visit;
+- visits remain separated and grouping IDs can support signer- and session-held-out
+  splits;
+- continuous recordings include the inactivity and hard-negative plan;
+- all skips, retries, quarantine decisions, and protocol deviations are retained;
+- all annotations satisfy the dataset contract and independent review rules; and
+- consent authorization is checked independently at every permitted use boundary.
+
+Missing coverage is a recorded limitation or a recollection decision. It is never
+filled by copying a recording, relabeling a transition, moving the same signer across
+evaluation groups, or fabricating authorization.
+
+## Synthetic mock rehearsal
+
+A mock annotation output uses this exact closed `annotations-table/1` shape. The
+top-level collection is named `rows`, every listed field is required, and no other
+field is allowed:
+
+```json
+{
+  "schema_version": "annotations-table/1",
+  "rows": [
+    {
+      "annotation_id": "annotation_<32 lowercase hexadecimal characters>",
+      "clip_id": null,
+      "disposition": "class_label | ambiguous | ignore",
+      "eligible_for_training": true,
+      "interval": {
+        "schema_version": "media-interval/1",
+        "start_us": 1000000,
+        "end_us": 2000000
+      },
+      "label_id": "hello | no | please | thank_you | yes | other | null",
+      "other_kind": "partial_target | transition_fragment | oov_gesture | incidental_activity | two_hand_non_target | null",
+      "participant_id": "participant_<32 lowercase hexadecimal characters>",
+      "reason_code": null,
+      "review_status": "draft | reviewed | adjudicated",
+      "session_id": "session_<32 lowercase hexadecimal characters>",
+      "source_recording_id": "recording_<32 lowercase hexadecimal characters>"
+    }
+  ]
+}
+```
+
+The union-style strings above document allowed values; an actual row contains one
+JSON string or `null`, not the `|` notation. For `ambiguous` and `ignore`, set
+`label_id` and `other_kind` to `null`, supply the protocol reason code, and set
+eligibility to `false`. For `class_label`, set `reason_code` to `null`; only the
+`other` class has a non-null `other_kind`. Use `clip_id: null` for the root-recording
+mock observations. Sort rows by unique `annotation_id`.
+
+A new collector can rehearse without a camera or participant:
+
+1. Read this protocol and the gesture taxonomy.
+2. Open `tests/fixtures/public/collection/mock-session-plan.json`; verify that it is
+   marked fixture-only, synthetic, and governance-blocked.
+3. Check the two visit times, separate capture-mode sessions, taxonomy digest,
+   condition ledger, realized prompt sequences, repetition counts, and checklists.
+4. Treat the mock observations as the visible evidence and apply the disposition,
+   boundary, review, and eligibility rules above.
+5. Write the result in the exact `annotations-table/1` shape above, sorted by
+   `annotation_id`, without adding prompt or reviewer fields to table rows.
+6. Compare with
+   `tests/fixtures/public/collection/annotations-table-1.mock-session.json` and run:
+
+   ```shell
+   uv run pytest --no-cov tests/test_collection_protocol.py
+   ```
+
+Passing proves that the synthetic plan and annotations are repeatable and
+schema-valid. It does not prove capture quality, participant consent, operator
+training, institutional approval, private storage, or production readiness.
+
+The mock plan supplies synthetic independent-review/adjudication outcomes so a new
+collector can derive the final `review_status`. It does not preserve real reviewer
+identities, first-pass drafts, comments, or disagreement history. Story #17 owns
+that auditable production sidecar; the normalized annotation table remains the final
+reviewed projection.
+
+## Versioning and deviations
+
+Every collection sidecar records the exact protocol version. Correct spelling,
+clarify language, or add non-semantic examples with a patch version. Change
+collection quantities, condition assignments, boundary rules, review thresholds, or
+eligibility behavior only in a reviewed new version. Never rewrite the meaning of a
+version already used by a recording.
+
+Record deviations with the visit, session, affected prompt occurrences or recording,
+reason, operator decision, and whether recollection is required. Story #21 owns the
+pilot report and the decision to freeze or revise version 1.
+
+## Research basis
+
+The operating rules combine primary-source guidance with conservative engineering
+judgment:
+
+- [NIST randomized designs](https://www.itl.nist.gov/div898/handbook/pri/section3/pri331.htm)
+  motivate preserving randomized run order to avoid confounding conditions with
+  experimental order.
+- The [IPN Hand paper](https://gibranbenitez.github.io/2021_ICPR_IpnHand.pdf) and
+  [project](https://gibranbenitez.github.io/IPN_Hand/) motivate randomized prompts,
+  continuous sequences, non-gesture activity, breaks, and direct transitions.
+- [EgoGesture](https://nlpr.ia.ac.cn/iva/yfzhang/datasets/EgoGesture.pdf) and
+  [HaGRID](https://openaccess.thecvf.com/content/WACV2024/papers/Kapitanov_HaGRID_--_HAnd_Gesture_Recognition_Image_Dataset_WACV_2024_paper.pdf)
+  motivate deliberate subject, scene, distance, lighting, and device variation.
+- The [DGS Corpus segmentation guidelines](https://www.sign-lang.uni-hamburg.de/dgs-korpus/arbeitspapiere/DGS-Korpus_AP03-2010-01v02_en.pdf)
+  motivate written onset, offset, retraction, and transition rules.
+- [CVAT's manual QA workflow](https://docs.cvat.ai/docs/qa-analytics/manual-qa/)
+  motivates distinct annotation, review, correction, and adjudication steps.
+- [HHS OHRP consent checklists](https://www.hhs.gov/ohrp/regulations-and-policy/guidance/checklists/index.html)
+  inform the consent-process checklist without determining whether a regulation
+  applies to SignLab.
+- [Datasheets for Datasets](https://arxiv.org/abs/1803.09010) motivates documenting
+  collection, composition, uses, limitations, and maintenance decisions.
+
+The exact signer counts, repetition counts, visit separation, coverage minima, and
+review percentages in this draft are SignLab engineering decisions. The cited sources
+do not establish them as universal statistical or regulatory thresholds.

--- a/docs/dataset-manifests.md
+++ b/docs/dataset-manifests.md
@@ -37,6 +37,15 @@ Participants are pseudonymous. Sessions and recordings carry only coarse,
 non-identifying device and capture facts. Every recording embeds its exact
 recording-level consent grant. Names, contact details, signatures, device serials,
 hostnames, and identity-vault mappings never belong in these tables.
+
+Prompt IDs, randomized order and seed, repetition numbers, protocol version,
+condition assignments, checklists, technical retries, deviations, and reviewer
+workflow identities are collection-sidecar concerns. They are deliberately not
+fields in the current normalized tables and must not be encoded in filenames,
+device IDs, or reason codes. The draft
+[collection protocol](collection-protocol.md) defines their meaning; Story #17 owns
+the future machine-readable sidecar and capture/import tooling.
+
 Every v2 row artifact uses an enforceable content-addressed location with no
 user-selected path segments:
 

--- a/tests/fixtures/public/README.md
+++ b/tests/fixtures/public/README.md
@@ -4,3 +4,9 @@ Only tiny synthetic, explicitly consented, or separately licensed fixtures may b
 committed here. Every non-text fixture must include provenance and license notes in
 the story that adds it. The repository guard limits each tracked file to 1 MiB; real
 participant media, extracted features, and trained weights remain outside Git.
+
+`collection/` contains an identity-free, no-camera rehearsal for the draft
+[collection and annotation protocol](../../../docs/collection-protocol.md). Its
+session plan is evidence for the protocol, not a production sidecar contract, and
+its annotation table uses only invented observations and identifiers. The fixture
+does not represent consent, collection approval, or participant data.

--- a/tests/fixtures/public/collection/annotations-table-1.mock-session.json
+++ b/tests/fixtures/public/collection/annotations-table-1.mock-session.json
@@ -1,0 +1,203 @@
+{
+  "rows": [
+    {
+      "annotation_id": "annotation_00000000000000000000000000000001",
+      "clip_id": null,
+      "disposition": "class_label",
+      "eligible_for_training": true,
+      "interval": {
+        "end_us": 2000000,
+        "schema_version": "media-interval/1",
+        "start_us": 1000000
+      },
+      "label_id": "hello",
+      "other_kind": null,
+      "participant_id": "participant_00000000000000000000000000000001",
+      "reason_code": null,
+      "review_status": "reviewed",
+      "session_id": "session_00000000000000000000000000000002",
+      "source_recording_id": "recording_00000000000000000000000000000001"
+    },
+    {
+      "annotation_id": "annotation_00000000000000000000000000000002",
+      "clip_id": null,
+      "disposition": "class_label",
+      "eligible_for_training": true,
+      "interval": {
+        "end_us": 4000000,
+        "schema_version": "media-interval/1",
+        "start_us": 3000000
+      },
+      "label_id": "no",
+      "other_kind": null,
+      "participant_id": "participant_00000000000000000000000000000001",
+      "reason_code": null,
+      "review_status": "reviewed",
+      "session_id": "session_00000000000000000000000000000002",
+      "source_recording_id": "recording_00000000000000000000000000000001"
+    },
+    {
+      "annotation_id": "annotation_00000000000000000000000000000003",
+      "clip_id": null,
+      "disposition": "class_label",
+      "eligible_for_training": true,
+      "interval": {
+        "end_us": 6000000,
+        "schema_version": "media-interval/1",
+        "start_us": 5000000
+      },
+      "label_id": "please",
+      "other_kind": null,
+      "participant_id": "participant_00000000000000000000000000000001",
+      "reason_code": null,
+      "review_status": "adjudicated",
+      "session_id": "session_00000000000000000000000000000002",
+      "source_recording_id": "recording_00000000000000000000000000000001"
+    },
+    {
+      "annotation_id": "annotation_00000000000000000000000000000004",
+      "clip_id": null,
+      "disposition": "class_label",
+      "eligible_for_training": true,
+      "interval": {
+        "end_us": 8000000,
+        "schema_version": "media-interval/1",
+        "start_us": 7000000
+      },
+      "label_id": "thank_you",
+      "other_kind": null,
+      "participant_id": "participant_00000000000000000000000000000001",
+      "reason_code": null,
+      "review_status": "reviewed",
+      "session_id": "session_00000000000000000000000000000002",
+      "source_recording_id": "recording_00000000000000000000000000000001"
+    },
+    {
+      "annotation_id": "annotation_00000000000000000000000000000005",
+      "clip_id": null,
+      "disposition": "class_label",
+      "eligible_for_training": true,
+      "interval": {
+        "end_us": 10000000,
+        "schema_version": "media-interval/1",
+        "start_us": 9000000
+      },
+      "label_id": "yes",
+      "other_kind": null,
+      "participant_id": "participant_00000000000000000000000000000001",
+      "reason_code": null,
+      "review_status": "reviewed",
+      "session_id": "session_00000000000000000000000000000002",
+      "source_recording_id": "recording_00000000000000000000000000000001"
+    },
+    {
+      "annotation_id": "annotation_00000000000000000000000000000006",
+      "clip_id": null,
+      "disposition": "class_label",
+      "eligible_for_training": true,
+      "interval": {
+        "end_us": 12000000,
+        "schema_version": "media-interval/1",
+        "start_us": 11000000
+      },
+      "label_id": "other",
+      "other_kind": "partial_target",
+      "participant_id": "participant_00000000000000000000000000000001",
+      "reason_code": null,
+      "review_status": "adjudicated",
+      "session_id": "session_00000000000000000000000000000002",
+      "source_recording_id": "recording_00000000000000000000000000000001"
+    },
+    {
+      "annotation_id": "annotation_00000000000000000000000000000007",
+      "clip_id": null,
+      "disposition": "class_label",
+      "eligible_for_training": true,
+      "interval": {
+        "end_us": 14000000,
+        "schema_version": "media-interval/1",
+        "start_us": 13000000
+      },
+      "label_id": "other",
+      "other_kind": "oov_gesture",
+      "participant_id": "participant_00000000000000000000000000000001",
+      "reason_code": null,
+      "review_status": "reviewed",
+      "session_id": "session_00000000000000000000000000000002",
+      "source_recording_id": "recording_00000000000000000000000000000001"
+    },
+    {
+      "annotation_id": "annotation_00000000000000000000000000000008",
+      "clip_id": null,
+      "disposition": "class_label",
+      "eligible_for_training": true,
+      "interval": {
+        "end_us": 16000000,
+        "schema_version": "media-interval/1",
+        "start_us": 15000000
+      },
+      "label_id": "other",
+      "other_kind": "incidental_activity",
+      "participant_id": "participant_00000000000000000000000000000001",
+      "reason_code": null,
+      "review_status": "reviewed",
+      "session_id": "session_00000000000000000000000000000002",
+      "source_recording_id": "recording_00000000000000000000000000000001"
+    },
+    {
+      "annotation_id": "annotation_00000000000000000000000000000009",
+      "clip_id": null,
+      "disposition": "class_label",
+      "eligible_for_training": true,
+      "interval": {
+        "end_us": 18000000,
+        "schema_version": "media-interval/1",
+        "start_us": 17000000
+      },
+      "label_id": "other",
+      "other_kind": "two_hand_non_target",
+      "participant_id": "participant_00000000000000000000000000000001",
+      "reason_code": null,
+      "review_status": "adjudicated",
+      "session_id": "session_00000000000000000000000000000002",
+      "source_recording_id": "recording_00000000000000000000000000000001"
+    },
+    {
+      "annotation_id": "annotation_0000000000000000000000000000000a",
+      "clip_id": null,
+      "disposition": "ambiguous",
+      "eligible_for_training": false,
+      "interval": {
+        "end_us": 20000000,
+        "schema_version": "media-interval/1",
+        "start_us": 19000000
+      },
+      "label_id": null,
+      "other_kind": null,
+      "participant_id": "participant_00000000000000000000000000000001",
+      "reason_code": "unusable_occlusion",
+      "review_status": "adjudicated",
+      "session_id": "session_00000000000000000000000000000002",
+      "source_recording_id": "recording_00000000000000000000000000000001"
+    },
+    {
+      "annotation_id": "annotation_0000000000000000000000000000000b",
+      "clip_id": null,
+      "disposition": "ignore",
+      "eligible_for_training": false,
+      "interval": {
+        "end_us": 22000000,
+        "schema_version": "media-interval/1",
+        "start_us": 21000000
+      },
+      "label_id": null,
+      "other_kind": null,
+      "participant_id": "participant_00000000000000000000000000000001",
+      "reason_code": "third_party_presence",
+      "review_status": "reviewed",
+      "session_id": "session_00000000000000000000000000000002",
+      "source_recording_id": "recording_00000000000000000000000000000001"
+    }
+  ],
+  "schema_version": "annotations-table/1"
+}

--- a/tests/fixtures/public/collection/mock-session-plan.json
+++ b/tests/fixtures/public/collection/mock-session-plan.json
@@ -1,0 +1,765 @@
+{
+  "checklist_policy": {
+    "capture_quality": [
+      "camera_and_lens_ready",
+      "framing_and_lighting_usable",
+      "no_third_party_present",
+      "orientation_and_mirror_recorded",
+      "timing_and_playback_checked"
+    ],
+    "consent_verification": [
+      "collection_readiness_is_ready",
+      "authenticated_receipt_is_current",
+      "purpose_is_authorized_before_capture"
+    ]
+  },
+  "evidence": {
+    "annotation_source": "synthetic_timeline",
+    "camera_used": false,
+    "contains_person_data": false,
+    "media_created": false,
+    "purpose": "protocol_dry_run_only"
+  },
+  "fixture_only": true,
+  "governance": {
+    "authorization_claimed": false,
+    "collection_readiness_status": "blocked",
+    "real_collection_authorized": false
+  },
+  "mock_observations": [
+    {
+      "annotation_id": "annotation_00000000000000000000000000000001",
+      "interval": {
+        "end_us": 2000000,
+        "schema_version": "media-interval/1",
+        "start_us": 1000000
+      },
+      "observation_id": "mock_observation_01",
+      "review_path": "independent_review_agreed",
+      "session_id": "session_00000000000000000000000000000002",
+      "source_recording_id": "recording_00000000000000000000000000000001",
+      "visible_evidence": "An open hand near the temple makes a short outward wave."
+    },
+    {
+      "annotation_id": "annotation_00000000000000000000000000000002",
+      "interval": {
+        "end_us": 4000000,
+        "schema_version": "media-interval/1",
+        "start_us": 3000000
+      },
+      "observation_id": "mock_observation_02",
+      "review_path": "independent_review_agreed",
+      "session_id": "session_00000000000000000000000000000002",
+      "source_recording_id": "recording_00000000000000000000000000000001",
+      "visible_evidence": "The thumb closes toward the extended index and middle fingertips."
+    },
+    {
+      "annotation_id": "annotation_00000000000000000000000000000003",
+      "interval": {
+        "end_us": 6000000,
+        "schema_version": "media-interval/1",
+        "start_us": 5000000
+      },
+      "observation_id": "mock_observation_03",
+      "review_path": "conflict_resolved_by_adjudication",
+      "session_id": "session_00000000000000000000000000000002",
+      "source_recording_id": "recording_00000000000000000000000000000001",
+      "visible_evidence": "A flat palm at the upper chest makes one small circular stroke."
+    },
+    {
+      "annotation_id": "annotation_00000000000000000000000000000004",
+      "interval": {
+        "end_us": 8000000,
+        "schema_version": "media-interval/1",
+        "start_us": 7000000
+      },
+      "observation_id": "mock_observation_04",
+      "review_path": "independent_review_agreed",
+      "session_id": "session_00000000000000000000000000000002",
+      "source_recording_id": "recording_00000000000000000000000000000001",
+      "visible_evidence": "A flat hand begins at the chin and moves outward in one stroke."
+    },
+    {
+      "annotation_id": "annotation_00000000000000000000000000000005",
+      "interval": {
+        "end_us": 10000000,
+        "schema_version": "media-interval/1",
+        "start_us": 9000000
+      },
+      "observation_id": "mock_observation_05",
+      "review_path": "independent_review_agreed",
+      "session_id": "session_00000000000000000000000000000002",
+      "source_recording_id": "recording_00000000000000000000000000000001",
+      "visible_evidence": "A closed fist near the upper torso makes a wrist-driven vertical nod."
+    },
+    {
+      "annotation_id": "annotation_00000000000000000000000000000006",
+      "interval": {
+        "end_us": 12000000,
+        "schema_version": "media-interval/1",
+        "start_us": 11000000
+      },
+      "observation_id": "mock_observation_06",
+      "review_path": "conflict_resolved_by_adjudication",
+      "session_id": "session_00000000000000000000000000000002",
+      "source_recording_id": "recording_00000000000000000000000000000001",
+      "visible_evidence": "A prompted target attempt begins but stops before its defining movement."
+    },
+    {
+      "annotation_id": "annotation_00000000000000000000000000000007",
+      "interval": {
+        "end_us": 14000000,
+        "schema_version": "media-interval/1",
+        "start_us": 13000000
+      },
+      "observation_id": "mock_observation_07",
+      "review_path": "independent_review_agreed",
+      "session_id": "session_00000000000000000000000000000002",
+      "source_recording_id": "recording_00000000000000000000000000000001",
+      "visible_evidence": "A complete intentional gesture is visible but matches none of the five targets."
+    },
+    {
+      "annotation_id": "annotation_00000000000000000000000000000008",
+      "interval": {
+        "end_us": 16000000,
+        "schema_version": "media-interval/1",
+        "start_us": 15000000
+      },
+      "observation_id": "mock_observation_08",
+      "review_path": "independent_review_agreed",
+      "session_id": "session_00000000000000000000000000000002",
+      "source_recording_id": "recording_00000000000000000000000000000001",
+      "visible_evidence": "Unrelated intentional hand activity occurs between prompted performances."
+    },
+    {
+      "annotation_id": "annotation_00000000000000000000000000000009",
+      "interval": {
+        "end_us": 18000000,
+        "schema_version": "media-interval/1",
+        "start_us": 17000000
+      },
+      "observation_id": "mock_observation_09",
+      "review_path": "conflict_resolved_by_adjudication",
+      "session_id": "session_00000000000000000000000000000002",
+      "source_recording_id": "recording_00000000000000000000000000000001",
+      "visible_evidence": "Coordinated two-hand activity changes the visible hand form."
+    },
+    {
+      "annotation_id": "annotation_0000000000000000000000000000000a",
+      "interval": {
+        "end_us": 20000000,
+        "schema_version": "media-interval/1",
+        "start_us": 19000000
+      },
+      "observation_id": "mock_observation_0a",
+      "review_path": "conflict_resolved_by_adjudication",
+      "session_id": "session_00000000000000000000000000000002",
+      "source_recording_id": "recording_00000000000000000000000000000001",
+      "visible_evidence": "The active hand is occluded, so its defining shape and motion cannot be seen."
+    },
+    {
+      "annotation_id": "annotation_0000000000000000000000000000000b",
+      "interval": {
+        "end_us": 22000000,
+        "schema_version": "media-interval/1",
+        "start_us": 21000000
+      },
+      "observation_id": "mock_observation_0b",
+      "review_path": "independent_review_agreed",
+      "session_id": "session_00000000000000000000000000000002",
+      "source_recording_id": "recording_00000000000000000000000000000001",
+      "visible_evidence": "An unrelated third party enters the frame during this region."
+    }
+  ],
+  "participant": {
+    "handedness": "right",
+    "participant_id": "participant_00000000000000000000000000000001",
+    "synthetic": true
+  },
+  "protocol": {
+    "id": "signlab-collection-protocol",
+    "status": "draft",
+    "version": "0.1.0"
+  },
+  "schema_version": "collection-mock-session-plan/1",
+  "taxonomy": {
+    "id": "signlab-five",
+    "schema_version": "taxonomy-reference/1",
+    "sha256": "sha256:c0f6cbddfe43e3a6eb3de01dbbbbc1ceebcb83d50cc197999776f58e3d9ce20d",
+    "version": "1.0.0"
+  },
+  "visits": [
+    {
+      "checklists": {
+        "capture_quality": {
+          "camera_opened": false,
+          "media_reviewed": false,
+          "reason_code": "synthetic_no_person_no_camera",
+          "result": "not_applicable"
+        },
+        "consent_verification": {
+          "authenticated_receipt_present": false,
+          "authorization_granted": false,
+          "reason_code": "synthetic_no_person_no_camera",
+          "result": "not_applicable"
+        }
+      },
+      "condition_profile": {
+        "allowed_variation": [
+          "natural_speed",
+          "natural_retraction"
+        ],
+        "camera_orientation": "landscape",
+        "clothing": "plain_high_contrast_top",
+        "distance": "near",
+        "distance_m": 0.8,
+        "framing": "upper_torso_face_and_hands_visible",
+        "handedness": "right",
+        "lighting": "soft_front",
+        "profile_id": "near_soft_front_landscape",
+        "scope": "entire_visit"
+      },
+      "continuous_activities": [
+        {
+          "activity": "inactivity",
+          "duration_seconds": 20,
+          "position": "before"
+        },
+        {
+          "activity": "target",
+          "label_id": "hello"
+        },
+        {
+          "activity": "target",
+          "label_id": "no"
+        },
+        {
+          "activity": "target",
+          "label_id": "please"
+        },
+        {
+          "activity": "inactivity",
+          "duration_seconds": 20,
+          "position": "between"
+        },
+        {
+          "activity": "target",
+          "label_id": "thank_you"
+        },
+        {
+          "activity": "target",
+          "label_id": "yes"
+        },
+        {
+          "activity": "direct_transition",
+          "retention": "context_only"
+        },
+        {
+          "activity": "natural_mistake",
+          "retention": "preserve"
+        },
+        {
+          "activity": "hard_negative",
+          "other_kind": "partial_target"
+        },
+        {
+          "activity": "hard_negative",
+          "other_kind": "oov_gesture"
+        },
+        {
+          "activity": "hard_negative",
+          "other_kind": "incidental_activity"
+        },
+        {
+          "activity": "hard_negative",
+          "other_kind": "two_hand_non_target"
+        },
+        {
+          "activity": "inactivity",
+          "duration_seconds": 20,
+          "position": "after"
+        }
+      ],
+      "prompt_randomization": {
+        "algorithm_id": "balanced_constrained_shuffle",
+        "algorithm_version": "mock-1",
+        "mock_seed": "signlab-mock-visit-01",
+        "realized_order_authoritative": true,
+        "rerolled_for_performance": false
+      },
+      "isolated_prompt_sequence": [
+        {
+          "label_id": "hello",
+          "ordinal": 1,
+          "repetition": 1,
+          "prompt_occurrence_id": "mock_visit_01_prompt_01"
+        },
+        {
+          "label_id": "please",
+          "ordinal": 2,
+          "repetition": 1,
+          "prompt_occurrence_id": "mock_visit_01_prompt_02"
+        },
+        {
+          "label_id": "no",
+          "ordinal": 3,
+          "repetition": 1,
+          "prompt_occurrence_id": "mock_visit_01_prompt_03"
+        },
+        {
+          "label_id": "yes",
+          "ordinal": 4,
+          "repetition": 1,
+          "prompt_occurrence_id": "mock_visit_01_prompt_04"
+        },
+        {
+          "label_id": "thank_you",
+          "ordinal": 5,
+          "repetition": 1,
+          "prompt_occurrence_id": "mock_visit_01_prompt_05"
+        },
+        {
+          "label_id": "please",
+          "ordinal": 6,
+          "repetition": 2,
+          "prompt_occurrence_id": "mock_visit_01_prompt_06"
+        },
+        {
+          "label_id": "thank_you",
+          "ordinal": 7,
+          "repetition": 2,
+          "prompt_occurrence_id": "mock_visit_01_prompt_07"
+        },
+        {
+          "label_id": "hello",
+          "ordinal": 8,
+          "repetition": 2,
+          "prompt_occurrence_id": "mock_visit_01_prompt_08"
+        },
+        {
+          "label_id": "no",
+          "ordinal": 9,
+          "repetition": 2,
+          "prompt_occurrence_id": "mock_visit_01_prompt_09"
+        },
+        {
+          "label_id": "yes",
+          "ordinal": 10,
+          "repetition": 2,
+          "prompt_occurrence_id": "mock_visit_01_prompt_10"
+        },
+        {
+          "label_id": "no",
+          "ordinal": 11,
+          "repetition": 3,
+          "prompt_occurrence_id": "mock_visit_01_prompt_11"
+        },
+        {
+          "label_id": "hello",
+          "ordinal": 12,
+          "repetition": 3,
+          "prompt_occurrence_id": "mock_visit_01_prompt_12"
+        },
+        {
+          "label_id": "thank_you",
+          "ordinal": 13,
+          "repetition": 3,
+          "prompt_occurrence_id": "mock_visit_01_prompt_13"
+        },
+        {
+          "label_id": "yes",
+          "ordinal": 14,
+          "repetition": 3,
+          "prompt_occurrence_id": "mock_visit_01_prompt_14"
+        },
+        {
+          "label_id": "please",
+          "ordinal": 15,
+          "repetition": 3,
+          "prompt_occurrence_id": "mock_visit_01_prompt_15"
+        },
+        {
+          "label_id": "thank_you",
+          "ordinal": 16,
+          "repetition": 4,
+          "prompt_occurrence_id": "mock_visit_01_prompt_16"
+        },
+        {
+          "label_id": "yes",
+          "ordinal": 17,
+          "repetition": 4,
+          "prompt_occurrence_id": "mock_visit_01_prompt_17"
+        },
+        {
+          "label_id": "please",
+          "ordinal": 18,
+          "repetition": 4,
+          "prompt_occurrence_id": "mock_visit_01_prompt_18"
+        },
+        {
+          "label_id": "hello",
+          "ordinal": 19,
+          "repetition": 4,
+          "prompt_occurrence_id": "mock_visit_01_prompt_19"
+        },
+        {
+          "label_id": "no",
+          "ordinal": 20,
+          "repetition": 4,
+          "prompt_occurrence_id": "mock_visit_01_prompt_20"
+        },
+        {
+          "label_id": "yes",
+          "ordinal": 21,
+          "repetition": 5,
+          "prompt_occurrence_id": "mock_visit_01_prompt_21"
+        },
+        {
+          "label_id": "no",
+          "ordinal": 22,
+          "repetition": 5,
+          "prompt_occurrence_id": "mock_visit_01_prompt_22"
+        },
+        {
+          "label_id": "hello",
+          "ordinal": 23,
+          "repetition": 5,
+          "prompt_occurrence_id": "mock_visit_01_prompt_23"
+        },
+        {
+          "label_id": "please",
+          "ordinal": 24,
+          "repetition": 5,
+          "prompt_occurrence_id": "mock_visit_01_prompt_24"
+        },
+        {
+          "label_id": "thank_you",
+          "ordinal": 25,
+          "repetition": 5,
+          "prompt_occurrence_id": "mock_visit_01_prompt_25"
+        }
+      ],
+      "sessions": [
+        {
+          "camera_facing": "front",
+          "capture_mode": "isolated",
+          "capture_software_version": "0.1.0",
+          "device_id": "device_00000000000000000000000000000001",
+          "finished_at": "2026-09-01T14:20:00Z",
+          "frame_height_px": 720,
+          "frame_rate_denominator": 1,
+          "frame_rate_numerator": 30,
+          "frame_width_px": 1280,
+          "mirror_state": "not_mirrored",
+          "participant_id": "participant_00000000000000000000000000000001",
+          "rotation_degrees": 0,
+          "session_id": "session_00000000000000000000000000000001",
+          "started_at": "2026-09-01T14:00:00Z"
+        },
+        {
+          "camera_facing": "front",
+          "capture_mode": "continuous",
+          "capture_software_version": "0.1.0",
+          "device_id": "device_00000000000000000000000000000001",
+          "finished_at": "2026-09-01T14:35:00Z",
+          "frame_height_px": 720,
+          "frame_rate_denominator": 1,
+          "frame_rate_numerator": 30,
+          "frame_width_px": 1280,
+          "mirror_state": "not_mirrored",
+          "participant_id": "participant_00000000000000000000000000000001",
+          "rotation_degrees": 0,
+          "session_id": "session_00000000000000000000000000000002",
+          "started_at": "2026-09-01T14:25:00Z"
+        }
+      ],
+      "visit_id": "mock_visit_01"
+    },
+    {
+      "checklists": {
+        "capture_quality": {
+          "camera_opened": false,
+          "media_reviewed": false,
+          "reason_code": "synthetic_no_person_no_camera",
+          "result": "not_applicable"
+        },
+        "consent_verification": {
+          "authenticated_receipt_present": false,
+          "authorization_granted": false,
+          "reason_code": "synthetic_no_person_no_camera",
+          "result": "not_applicable"
+        }
+      },
+      "condition_profile": {
+        "allowed_variation": [
+          "natural_speed",
+          "natural_retraction"
+        ],
+        "camera_orientation": "portrait",
+        "clothing": "plain_medium_contrast_top",
+        "distance": "medium",
+        "distance_m": 1.2,
+        "framing": "upper_torso_face_and_hands_visible",
+        "handedness": "right",
+        "lighting": "diffuse_side",
+        "profile_id": "medium_diffuse_side_portrait",
+        "scope": "entire_visit"
+      },
+      "continuous_activities": [
+        {
+          "activity": "inactivity",
+          "duration_seconds": 20,
+          "position": "before"
+        },
+        {
+          "activity": "target",
+          "label_id": "yes"
+        },
+        {
+          "activity": "target",
+          "label_id": "thank_you"
+        },
+        {
+          "activity": "target",
+          "label_id": "please"
+        },
+        {
+          "activity": "inactivity",
+          "duration_seconds": 20,
+          "position": "between"
+        },
+        {
+          "activity": "target",
+          "label_id": "no"
+        },
+        {
+          "activity": "target",
+          "label_id": "hello"
+        },
+        {
+          "activity": "direct_transition",
+          "retention": "context_only"
+        },
+        {
+          "activity": "natural_mistake",
+          "retention": "preserve"
+        },
+        {
+          "activity": "hard_negative",
+          "other_kind": "partial_target"
+        },
+        {
+          "activity": "hard_negative",
+          "other_kind": "oov_gesture"
+        },
+        {
+          "activity": "hard_negative",
+          "other_kind": "incidental_activity"
+        },
+        {
+          "activity": "hard_negative",
+          "other_kind": "two_hand_non_target"
+        },
+        {
+          "activity": "inactivity",
+          "duration_seconds": 20,
+          "position": "after"
+        }
+      ],
+      "prompt_randomization": {
+        "algorithm_id": "balanced_constrained_shuffle",
+        "algorithm_version": "mock-1",
+        "mock_seed": "signlab-mock-visit-02",
+        "realized_order_authoritative": true,
+        "rerolled_for_performance": false
+      },
+      "isolated_prompt_sequence": [
+        {
+          "label_id": "yes",
+          "ordinal": 1,
+          "repetition": 1,
+          "prompt_occurrence_id": "mock_visit_02_prompt_01"
+        },
+        {
+          "label_id": "thank_you",
+          "ordinal": 2,
+          "repetition": 1,
+          "prompt_occurrence_id": "mock_visit_02_prompt_02"
+        },
+        {
+          "label_id": "no",
+          "ordinal": 3,
+          "repetition": 1,
+          "prompt_occurrence_id": "mock_visit_02_prompt_03"
+        },
+        {
+          "label_id": "hello",
+          "ordinal": 4,
+          "repetition": 1,
+          "prompt_occurrence_id": "mock_visit_02_prompt_04"
+        },
+        {
+          "label_id": "please",
+          "ordinal": 5,
+          "repetition": 1,
+          "prompt_occurrence_id": "mock_visit_02_prompt_05"
+        },
+        {
+          "label_id": "no",
+          "ordinal": 6,
+          "repetition": 2,
+          "prompt_occurrence_id": "mock_visit_02_prompt_06"
+        },
+        {
+          "label_id": "please",
+          "ordinal": 7,
+          "repetition": 2,
+          "prompt_occurrence_id": "mock_visit_02_prompt_07"
+        },
+        {
+          "label_id": "yes",
+          "ordinal": 8,
+          "repetition": 2,
+          "prompt_occurrence_id": "mock_visit_02_prompt_08"
+        },
+        {
+          "label_id": "thank_you",
+          "ordinal": 9,
+          "repetition": 2,
+          "prompt_occurrence_id": "mock_visit_02_prompt_09"
+        },
+        {
+          "label_id": "hello",
+          "ordinal": 10,
+          "repetition": 2,
+          "prompt_occurrence_id": "mock_visit_02_prompt_10"
+        },
+        {
+          "label_id": "yes",
+          "ordinal": 11,
+          "repetition": 3,
+          "prompt_occurrence_id": "mock_visit_02_prompt_11"
+        },
+        {
+          "label_id": "hello",
+          "ordinal": 12,
+          "repetition": 3,
+          "prompt_occurrence_id": "mock_visit_02_prompt_12"
+        },
+        {
+          "label_id": "please",
+          "ordinal": 13,
+          "repetition": 3,
+          "prompt_occurrence_id": "mock_visit_02_prompt_13"
+        },
+        {
+          "label_id": "no",
+          "ordinal": 14,
+          "repetition": 3,
+          "prompt_occurrence_id": "mock_visit_02_prompt_14"
+        },
+        {
+          "label_id": "thank_you",
+          "ordinal": 15,
+          "repetition": 3,
+          "prompt_occurrence_id": "mock_visit_02_prompt_15"
+        },
+        {
+          "label_id": "please",
+          "ordinal": 16,
+          "repetition": 4,
+          "prompt_occurrence_id": "mock_visit_02_prompt_16"
+        },
+        {
+          "label_id": "no",
+          "ordinal": 17,
+          "repetition": 4,
+          "prompt_occurrence_id": "mock_visit_02_prompt_17"
+        },
+        {
+          "label_id": "thank_you",
+          "ordinal": 18,
+          "repetition": 4,
+          "prompt_occurrence_id": "mock_visit_02_prompt_18"
+        },
+        {
+          "label_id": "hello",
+          "ordinal": 19,
+          "repetition": 4,
+          "prompt_occurrence_id": "mock_visit_02_prompt_19"
+        },
+        {
+          "label_id": "yes",
+          "ordinal": 20,
+          "repetition": 4,
+          "prompt_occurrence_id": "mock_visit_02_prompt_20"
+        },
+        {
+          "label_id": "thank_you",
+          "ordinal": 21,
+          "repetition": 5,
+          "prompt_occurrence_id": "mock_visit_02_prompt_21"
+        },
+        {
+          "label_id": "hello",
+          "ordinal": 22,
+          "repetition": 5,
+          "prompt_occurrence_id": "mock_visit_02_prompt_22"
+        },
+        {
+          "label_id": "yes",
+          "ordinal": 23,
+          "repetition": 5,
+          "prompt_occurrence_id": "mock_visit_02_prompt_23"
+        },
+        {
+          "label_id": "please",
+          "ordinal": 24,
+          "repetition": 5,
+          "prompt_occurrence_id": "mock_visit_02_prompt_24"
+        },
+        {
+          "label_id": "no",
+          "ordinal": 25,
+          "repetition": 5,
+          "prompt_occurrence_id": "mock_visit_02_prompt_25"
+        }
+      ],
+      "sessions": [
+        {
+          "camera_facing": "rear",
+          "capture_mode": "isolated",
+          "capture_software_version": "0.1.0",
+          "device_id": "device_00000000000000000000000000000002",
+          "finished_at": "2026-09-03T15:20:00Z",
+          "frame_height_px": 720,
+          "frame_rate_denominator": 1,
+          "frame_rate_numerator": 30,
+          "frame_width_px": 1280,
+          "mirror_state": "not_mirrored",
+          "participant_id": "participant_00000000000000000000000000000001",
+          "rotation_degrees": 90,
+          "session_id": "session_00000000000000000000000000000003",
+          "started_at": "2026-09-03T15:00:00Z"
+        },
+        {
+          "camera_facing": "rear",
+          "capture_mode": "continuous",
+          "capture_software_version": "0.1.0",
+          "device_id": "device_00000000000000000000000000000002",
+          "finished_at": "2026-09-03T15:35:00Z",
+          "frame_height_px": 720,
+          "frame_rate_denominator": 1,
+          "frame_rate_numerator": 30,
+          "frame_width_px": 1280,
+          "mirror_state": "not_mirrored",
+          "participant_id": "participant_00000000000000000000000000000001",
+          "rotation_degrees": 90,
+          "session_id": "session_00000000000000000000000000000004",
+          "started_at": "2026-09-03T15:25:00Z"
+        }
+      ],
+      "visit_id": "mock_visit_02"
+    }
+  ]
+}

--- a/tests/test_collection_protocol.py
+++ b/tests/test_collection_protocol.py
@@ -1,0 +1,320 @@
+from __future__ import annotations
+
+import json
+from collections import Counter
+from datetime import UTC, datetime, timedelta
+from importlib.resources import files
+from itertools import pairwise
+from pathlib import Path
+from typing import Any, cast
+
+from jsonschema import Draft202012Validator
+
+from signlab.contracts import (
+    BUILTIN_TAXONOMY_DIGEST,
+    AnnotationsTableV1,
+    SessionRowV1,
+    load_builtin_taxonomy,
+    taxonomy_reference,
+    validate_dataset_table,
+)
+from signlab.contracts.taxonomy import EXPECTED_TARGET_IDS
+
+FIXTURE_ROOT = Path(__file__).parent / "fixtures" / "public" / "collection"
+PLAN_PATH = FIXTURE_ROOT / "mock-session-plan.json"
+ANNOTATIONS_PATH = FIXTURE_ROOT / "annotations-table-1.mock-session.json"
+SOURCE_HARD_NEGATIVE_KINDS = (
+    "partial_target",
+    "oov_gesture",
+    "incidental_activity",
+    "two_hand_non_target",
+)
+
+
+def _load_object(path: Path) -> dict[str, Any]:
+    payload: object = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return cast(dict[str, Any], payload)
+
+
+def _objects(value: object) -> list[dict[str, Any]]:
+    assert isinstance(value, list)
+    assert all(isinstance(item, dict) for item in value)
+    return cast(list[dict[str, Any]], value)
+
+
+def _utc(value: object) -> datetime:
+    assert isinstance(value, str)
+    return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC)
+
+
+def _checked_annotations() -> AnnotationsTableV1:
+    checked = validate_dataset_table(_load_object(ANNOTATIONS_PATH))
+    assert isinstance(checked, AnnotationsTableV1)
+    return checked
+
+
+def test_mock_annotations_pass_the_published_schema_and_authoritative_contract() -> None:
+    payload = _load_object(ANNOTATIONS_PATH)
+    schema = cast(
+        dict[str, Any],
+        json.loads(
+            files("signlab.resources.datasets")
+            .joinpath("schemas", "annotations-table-1.schema.json")
+            .read_text(encoding="utf-8")
+        ),
+    )
+
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(payload)
+    checked = _checked_annotations()
+
+    assert checked.model_dump(mode="json", round_trip=True) == payload
+    annotation_ids = tuple(row.annotation_id for row in checked.rows)
+    assert annotation_ids == tuple(sorted(annotation_ids))
+
+
+def test_mock_plan_binds_the_exact_immutable_taxonomy() -> None:
+    plan = _load_object(PLAN_PATH)
+    expected_reference = taxonomy_reference(load_builtin_taxonomy()).model_dump(
+        mode="json", round_trip=True
+    )
+
+    assert plan["taxonomy"] == expected_reference
+    assert expected_reference["sha256"] == BUILTIN_TAXONOMY_DIGEST
+    assert tuple(expected_reference[key] for key in ("id", "version")) == (
+        "signlab-five",
+        "1.0.0",
+    )
+
+
+def test_mock_visits_are_separated_and_emit_distinct_contract_valid_sessions() -> None:
+    plan = _load_object(PLAN_PATH)
+    participant = cast(dict[str, Any], plan["participant"])
+    visits = _objects(plan["visits"])
+    validated_sessions: list[SessionRowV1] = []
+    visit_starts: list[datetime] = []
+
+    assert len(visits) == 2
+    for visit in visits:
+        sessions = tuple(
+            SessionRowV1.model_validate(session, strict=True)
+            for session in _objects(visit["sessions"])
+        )
+        validated_sessions.extend(sessions)
+        visit_starts.append(min(_utc(session.started_at) for session in sessions))
+
+        assert {session.capture_mode for session in sessions} == {"isolated", "continuous"}
+        assert {session.participant_id for session in sessions} == {participant["participant_id"]}
+        assert len({session.session_id for session in sessions}) == 2
+        assert len({session.device_id for session in sessions}) == 1
+
+    assert visit_starts[1] - visit_starts[0] >= timedelta(hours=24)
+    assert len({session.session_id for session in validated_sessions}) == 4
+    assert len({session.device_id for session in validated_sessions}) == 2
+
+
+def test_realized_prompt_orders_are_balanced_non_adjacent_and_visit_specific() -> None:
+    visits = _objects(_load_object(PLAN_PATH)["visits"])
+    realized_orders: list[tuple[str, ...]] = []
+    randomization_seeds: list[str] = []
+    occurrence_ids: list[str] = []
+
+    for visit in visits:
+        prompts = _objects(visit["isolated_prompt_sequence"])
+        labels = tuple(cast(str, prompt["label_id"]) for prompt in prompts)
+        condition = cast(dict[str, Any], visit["condition_profile"])
+        randomization = cast(dict[str, Any], visit["prompt_randomization"])
+        visit_id = cast(str, visit["visit_id"])
+
+        assert tuple(prompt["ordinal"] for prompt in prompts) == tuple(range(1, 26))
+        assert Counter(labels) == Counter({label: 5 for label in EXPECTED_TARGET_IDS})
+        assert all(left != right for left, right in pairwise(labels))
+        assert condition["scope"] == "entire_visit"
+        assert set(labels) == set(EXPECTED_TARGET_IDS)
+        for label in EXPECTED_TARGET_IDS:
+            assert sorted(
+                cast(int, prompt["repetition"]) for prompt in prompts if prompt["label_id"] == label
+            ) == list(range(1, 6))
+        for prompt in prompts:
+            occurrence_id = cast(str, prompt["prompt_occurrence_id"])
+            assert occurrence_id == f"{visit_id}_prompt_{cast(int, prompt['ordinal']):02d}"
+            occurrence_ids.append(occurrence_id)
+        assert randomization["algorithm_id"] == "balanced_constrained_shuffle"
+        assert randomization["algorithm_version"] == "mock-1"
+        assert randomization["realized_order_authoritative"] is True
+        assert randomization["rerolled_for_performance"] is False
+        randomization_seeds.append(cast(str, randomization["mock_seed"]))
+        realized_orders.append(labels)
+
+    assert realized_orders[0] != realized_orders[1]
+    assert randomization_seeds == ["signlab-mock-visit-01", "signlab-mock-visit-02"]
+    assert len(occurrence_ids) == len(set(occurrence_ids)) == 50
+
+
+def test_continuous_plan_covers_inactivity_targets_and_source_hard_negatives() -> None:
+    visits = _objects(_load_object(PLAN_PATH)["visits"])
+    hard_negative_counts: Counter[str] = Counter()
+
+    for visit in visits:
+        activities = _objects(visit["continuous_activities"])
+        target_labels = {
+            cast(str, activity["label_id"])
+            for activity in activities
+            if activity["activity"] == "target"
+        }
+        inactivity_seconds = sum(
+            cast(int, activity["duration_seconds"])
+            for activity in activities
+            if activity["activity"] == "inactivity"
+        )
+        hard_negative_counts.update(
+            cast(str, activity["other_kind"])
+            for activity in activities
+            if activity["activity"] == "hard_negative"
+        )
+
+        assert target_labels == set(EXPECTED_TARGET_IDS)
+        assert inactivity_seconds == 60
+        assert {
+            cast(str, activity["position"])
+            for activity in activities
+            if activity["activity"] == "inactivity"
+        } == {"before", "between", "after"}
+        assert {activity["activity"] for activity in activities} >= {
+            "direct_transition",
+            "natural_mistake",
+        }
+        assert {
+            cast(str, activity["retention"])
+            for activity in activities
+            if activity["activity"] in {"direct_transition", "natural_mistake"}
+        } == {"context_only", "preserve"}
+
+    assert hard_negative_counts == Counter(
+        {other_kind: 2 for other_kind in SOURCE_HARD_NEGATIVE_KINDS}
+    )
+    assert "transition_fragment" not in hard_negative_counts
+
+
+def test_mock_conditions_match_the_repeatable_pilot_profiles() -> None:
+    visits = _objects(_load_object(PLAN_PATH)["visits"])
+    profiles = tuple(cast(dict[str, Any], visit["condition_profile"]) for visit in visits)
+
+    assert tuple(profile["profile_id"] for profile in profiles) == (
+        "near_soft_front_landscape",
+        "medium_diffuse_side_portrait",
+    )
+    assert tuple(profile["distance_m"] for profile in profiles) == (0.8, 1.2)
+    assert tuple(profile["camera_orientation"] for profile in profiles) == (
+        "landscape",
+        "portrait",
+    )
+
+
+def test_mock_annotations_cover_reviewed_targets_negatives_and_exclusions() -> None:
+    rows = _checked_annotations().rows
+    target_rows = tuple(row for row in rows if row.label_id in EXPECTED_TARGET_IDS)
+    other_rows = tuple(row for row in rows if row.label_id == "other")
+    exclusion_rows = tuple(row for row in rows if row.disposition != "class_label")
+
+    assert {row.label_id for row in target_rows} == set(EXPECTED_TARGET_IDS)
+    assert {row.other_kind for row in other_rows} == set(SOURCE_HARD_NEGATIVE_KINDS)
+    assert "transition_fragment" not in {row.other_kind for row in rows}
+    assert {(row.disposition, row.reason_code) for row in exclusion_rows} == {
+        ("ambiguous", "unusable_occlusion"),
+        ("ignore", "third_party_presence"),
+    }
+    assert all(row.review_status in {"reviewed", "adjudicated"} for row in rows)
+    assert all(
+        row.eligible_for_training
+        == (row.disposition == "class_label" and row.review_status in {"reviewed", "adjudicated"})
+        for row in rows
+    )
+
+
+def test_mock_observations_supply_timestamps_and_evidence_without_answer_fields() -> None:
+    plan = _load_object(PLAN_PATH)
+    observations = _objects(plan["mock_observations"])
+    annotations = _checked_annotations().rows
+    answer_fields = {
+        "disposition",
+        "eligible_for_training",
+        "label_id",
+        "other_kind",
+        "reason_code",
+        "review_status",
+    }
+
+    assert len(observations) == len(annotations) == 11
+    assert tuple(observation["interval"] for observation in observations) == tuple(
+        row.interval.model_dump(mode="json", round_trip=True) for row in annotations
+    )
+    assert tuple(observation["annotation_id"] for observation in observations) == tuple(
+        row.annotation_id for row in annotations
+    )
+    assert tuple(observation["session_id"] for observation in observations) == tuple(
+        row.session_id for row in annotations
+    )
+    assert tuple(observation["source_recording_id"] for observation in observations) == tuple(
+        row.source_recording_id for row in annotations
+    )
+    assert all(
+        isinstance(observation["visible_evidence"], str) and observation["visible_evidence"]
+        for observation in observations
+    )
+    review_status_by_path = {
+        "conflict_resolved_by_adjudication": "adjudicated",
+        "independent_review_agreed": "reviewed",
+    }
+    assert tuple(
+        review_status_by_path[observation["review_path"]] for observation in observations
+    ) == tuple(row.review_status for row in annotations)
+    assert all(answer_fields.isdisjoint(observation) for observation in observations)
+
+
+def test_evidence_is_explicitly_synthetic_and_never_claims_collection_authority() -> None:
+    plan = _load_object(PLAN_PATH)
+    evidence = cast(dict[str, Any], plan["evidence"])
+    governance = cast(dict[str, Any], plan["governance"])
+    participant = cast(dict[str, Any], plan["participant"])
+    visits = _objects(plan["visits"])
+
+    assert plan["fixture_only"] is True
+    assert participant["synthetic"] is True
+    assert evidence == {
+        "annotation_source": "synthetic_timeline",
+        "camera_used": False,
+        "contains_person_data": False,
+        "media_created": False,
+        "purpose": "protocol_dry_run_only",
+    }
+    assert governance == {
+        "authorization_claimed": False,
+        "collection_readiness_status": "blocked",
+        "real_collection_authorized": False,
+    }
+
+    continuous_session_ids = {
+        session.session_id
+        for visit in visits
+        for session in (
+            SessionRowV1.model_validate(item, strict=True) for item in _objects(visit["sessions"])
+        )
+        if session.capture_mode == "continuous"
+    }
+    annotations = _checked_annotations().rows
+    assert {row.participant_id for row in annotations} == {participant["participant_id"]}
+    assert {row.session_id for row in annotations} <= continuous_session_ids
+
+    for visit in visits:
+        checklists = cast(dict[str, dict[str, Any]], visit["checklists"])
+        assert set(checklists) == {"capture_quality", "consent_verification"}
+        assert all(item["result"] == "not_applicable" for item in checklists.values())
+        assert all(
+            item["reason_code"] == "synthetic_no_person_no_camera" for item in checklists.values()
+        )
+        assert checklists["capture_quality"]["camera_opened"] is False
+        assert checklists["capture_quality"]["media_reviewed"] is False
+        assert checklists["consent_verification"]["authenticated_receipt_present"] is False
+        assert checklists["consent_verification"]["authorization_granted"] is False


### PR DESCRIPTION
## Summary

- define draft collection protocol 0.1.0 with a fail-closed governance gate, repeatable pilot profiles, randomized prompt planning, isolated/continuous capture, coverage targets, and consent/capture checklists
- define temporal onset/end, ambiguity, ignore, review, adjudication, and training-eligibility rules against the existing immutable taxonomy and dataset contracts
- add an identity-free, no-camera mock plan and schema-valid annotation projection; keep the fixture sidecar explicitly non-production and defer capture/import tooling to #17 and protocol-v1 freeze to #21
- correct architecture documentation so prompt order and condition assignments are not claimed as normalized dataset-table fields

## Acceptance evidence

- two synthetic visits are more than 24 hours apart, each with separate isolated and continuous sessions
- balanced target orders have stable occurrence IDs, recorded mock randomization evidence, no adjacent duplicate target, and different realized orders
- continuous plans include distributed inactivity, direct transitions, retained natural mistakes, partial attempts, unrelated activity, and all four source hard-negative kinds
- the mock output covers all five target labels, all source hard-negative kinds, an ambiguous occlusion, and an ignored third-party region
- both the published Draft 2020-12 schema and the authoritative Python validator accept the annotation table
- a fresh context generated the table from only the protocol, taxonomy, and mock observations; its contract-valid output exactly matched the committed projection
- all evidence states that no person, camera, media, authenticated receipt, or real collection authorization was involved

## Verification

- `uv lock --check`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv run python scripts/check_repository_hygiene.py`
- `uv run pytest` — 775 passed, 4 expected Windows capability skips, 90.63% coverage

Closes #16