### PR TITLE
feat(data): window isolated PopSign clips

### DIFF
--- a/docs/external-datasets.md
+++ b/docs/external-datasets.md
@@ -146,6 +146,12 @@ bound feature and runs a metric-free five-class fit/predict interface check. Thi
 proves data plumbing only; it is not an accuracy claim or the training system
 planned for later stories.
 
+Before quality assessment, PopSign isolated-sign sequences use the fixed, label-blind
+`popsign_longest_detected_hand_episode/1` window. The original extracted Parquet and the
+explicitly rebased windowed Parquet are both retained; quality and features consume the
+same windowed view. The 750-file no-extraction evaluation is recorded in
+[`popsign-active-window-v1.md`](reports/popsign-active-window-v1.md).
+
 ## Import and security guarantees
 
 The importer treats every tar as hostile input. It streams regular MP4 members and

--- a/docs/reports/popsign-active-window-v1.md
+++ b/docs/reports/popsign-active-window-v1.md
@@ -1,0 +1,112 @@
+# PopSign active-sign window result
+
+## Decision
+
+**READY for quota selection.** The fixed, label-blind active-sign window leaves 693 of
+the 750 already-extracted PopSign attempts usable under the unchanged quality policy.
+Every split/gesture group has more distinct usable signers than the required 10 train,
+3 validation, or 3 test clips.
+
+This result resolves the seven-clip shortfall reported by `#79`. It does not claim model
+performance and does not overwrite the immutable `#79` corpus. The exact 80-clip corpus
+and leakage-resistant split manifest remain downstream artifacts.
+
+## Frozen rule
+
+Rule ID: `popsign_longest_detected_hand_episode/1`
+
+For each landmark sequence, before any label, split, signer, filename, or quota metadata
+is joined:
+
+1. Mark frames with at least one detected hand.
+2. Bridge only an internal gap of at most two frames whose neighboring observations are
+   at most 100,000 microseconds apart. These are the existing policy's interpolation
+   limits.
+3. Form contiguous episodes and rank them by observed-hand frame count, quantized palm
+   motion, inclusive span, then earliest start.
+4. Require at least three observed-hand frames. Otherwise return a coded no-safe-window
+   decision.
+5. Rebase the selected view to frame and timestamp zero while preserving the original
+   inclusive frame bounds and source PTS as provenance.
+
+The same rebased view is passed to both quality assessment and feature derivation. The
+quality thresholds and policy resource were not changed.
+
+## Reproducibility evidence
+
+| Evidence | Value |
+| --- | --- |
+| Source corpus | `sha256:bd2e552d28792346b7c8e345f8387ebcc52938692cde7f0a316763aa09bdceb9` |
+| Source summary | `sha256:cfd760a6d73d8850199a25dae9a78827dea8e809b060724cbd9fc53bfa65be41` |
+| External dataset | `sha256:3eb0bb1e73cacddf3b59a84d5c946207c7cb973d6526edea8c75fe9138e8669c` |
+| Attempt-landmark inventory | `sha256:fa2028b212c342fe273b0afd9101114c157b4822f3cc95860535848d993f9f44` |
+| Landmark files / rows / bytes | 750 / 76,520 / 71,358,032 |
+| Extraction configuration | `sha256:7343cd8bb724313b4063a3ebd5d7f7470a78b00f2eeda275a15e5f9b2e66e94c` |
+| Hand model | `sha256:fbc2a30080c3c557093b5ddfc334698132eb341044ccee322ccf8bcf3607cde1` |
+| Pose model | `sha256:59929e1d1ee95287735ddd833b19cf4ac46d29bc7afddbbf6753c459690d574a` |
+| Unchanged quality policy | `sha256:680b0904e1cc5d8e03119032e92920a3a0185917a600c4293323b7925da9a545` |
+| MediaPipe executions during replay | 0 |
+
+All 750 source Parquets passed exact-byte, Arrow-schema, semantic-digest, row-count, and
+recording-identity verification. Window decisions were made from rows alone; manifest
+metadata was joined afterward for aggregate quota accounting.
+
+## Before and after
+
+`Usable` means `pass + warning`. A no-window decision is terminal and is not silently
+replaced by another rule.
+
+| Split | Gesture | Before usable | After pass | After warning | After quarantine | No window | After usable | Distinct usable signers | Required | Result |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| train | `hello` | 10 | 96 | 16 | 11 | 1 | 112 | 31 | 10 | ready |
+| train | `no` | 8 | 108 | 11 | 3 | 2 | 119 | 31 | 10 | ready |
+| train | `please` | 10 | 55 | 16 | 5 | 0 | 71 | 31 | 10 | ready |
+| train | `thank_you` | 10 | 72 | 24 | 10 | 0 | 96 | 31 | 10 | ready |
+| train | `yes` | 10 | 63 | 10 | 5 | 3 | 73 | 30 | 10 | ready |
+| val | `hello` | 1 | 26 | 9 | 3 | 0 | 35 | 8 | 3 | ready |
+| val | `no` | 3 | 15 | 3 | 0 | 0 | 18 | 8 | 3 | ready |
+| val | `please` | 3 | 20 | 0 | 0 | 1 | 20 | 8 | 3 | ready |
+| val | `thank_you` | 3 | 22 | 3 | 1 | 0 | 25 | 8 | 3 | ready |
+| val | `yes` | 1 | 32 | 4 | 1 | 0 | 36 | 8 | 3 | ready |
+| test | `hello` | 3 | 14 | 1 | 2 | 1 | 15 | 8 | 3 | ready |
+| test | `no` | 3 | 11 | 2 | 1 | 0 | 13 | 8 | 3 | ready |
+| test | `please` | 3 | 10 | 3 | 2 | 1 | 13 | 7 | 3 | ready |
+| test | `thank_you` | 2 | 28 | 7 | 1 | 1 | 35 | 8 | 3 | ready |
+| test | `yes` | 3 | 10 | 2 | 1 | 1 | 12 | 7 | 3 | ready |
+| **Total** |  | **73** | **582** | **111** | **46** | **11** | **693** |  | **80 selected clips** | **ready** |
+
+The before replay reproduced 36 pass, 37 warning, 140 quarantine, and 537 reject.
+The after replay accounts for all 750 attempts as 582 pass, 111 warning, 46 quarantine,
+and 11 `no_hand_observations` decisions. No real sequence ended in
+`episode_too_short`.
+
+## Fixed visual review
+
+The same 12 local clips selected before windowing for `#81` were reviewed again. They
+were not reranked using the new result, and no video, frame, path, or identity is
+published.
+
+| Coded observation | Result |
+| --- | ---: |
+| Selected bounds retain the complete visible labeled motion | 12 / 12 |
+| Selected bounds visibly truncate the labeled motion | 0 / 12 |
+| Window changed from the full source span | 10 / 12 |
+| Multi-episode trailing hand reappearances retained by mistake | 0 / 2 |
+| Corrupt or unreadable reviewed video | 0 / 12 |
+
+The excluded frames were quiet preparation, return-to-rest, or later unrelated hand
+motion. This visual gate supports the aggregate result but does not assess linguistic
+correctness or model suitability.
+
+## Limits
+
+- The replay proves data sufficiency for the bounded five-gesture isolated-sign smoke
+  corpus, not a production recognition claim.
+- PopSign remains public isolated-sign data; no continuous-sign or natural-use claim is
+  made.
+- The existing `#79` artifact remains an immutable record of the pre-window run.
+- No alternate window, threshold change, per-video exception, new provider, extraction
+  run, split generation, feature experiment, or training run was attempted.
+
+PopSign ASL v1.0 is provided by the Georgia Institute of Technology and Deaf
+Professional Arts Network under CC BY 4.0.

--- a/src/signlab/datasets/popsign_window.py
+++ b/src/signlab/datasets/popsign_window.py
@@ -1,0 +1,263 @@
+"""One bounded active-sign window for isolated PopSign landmark sequences."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final, Literal
+
+from signlab.contracts.extraction import (
+    HandSlotV1,
+    LandmarkFramesTableV1,
+    landmark_frames_table_digest,
+)
+
+POPSIGN_WINDOW_RULE_ID: Final = "popsign_longest_detected_hand_episode/1"
+
+_MAX_BRIDGED_MISSING_FRAMES: Final = 2
+_MAX_BRIDGE_US: Final = 100_000
+_MIN_OBSERVED_HAND_FRAMES: Final = 3
+_PALM_LANDMARK_INDICES: Final = (0, 5, 9, 17)
+_COORDINATE_QUANTIZATION: Final = 1_000_000
+
+type PopSignWindowReason = Literal[
+    "selected_longest_detected_hand_episode",
+    "no_hand_observations",
+    "episode_too_short",
+]
+
+
+class PopSignWindowError(ValueError):
+    """Raised when a window decision cannot be applied to its source table."""
+
+
+@dataclass(frozen=True, slots=True)
+class PopSignWindow:
+    """An auditable decision over original source-frame coordinates."""
+
+    rule_id: str
+    reason: PopSignWindowReason
+    source_table_sha256: str
+    source_frame_count: int
+    episode_count: int
+    observed_hand_frame_count: int
+    motion_l1_q: int
+    first_source_frame_index: int | None
+    last_source_frame_index: int | None
+    first_source_pts: int | None
+    last_source_pts: int | None
+    first_source_timestamp_us: int | None
+    last_source_timestamp_us: int | None
+
+    @property
+    def selected(self) -> bool:
+        """Return whether this decision contains a safe inclusive window."""
+
+        return self.reason == "selected_longest_detected_hand_episode"
+
+
+def _bridged_presence(table: LandmarkFramesTableV1) -> tuple[bool, ...]:
+    rows = table.rows
+    present = tuple(row.observed_hand_count > 0 for row in rows)
+    bridged = list(present)
+    index = 0
+    while index < len(rows):
+        if bridged[index]:
+            index += 1
+            continue
+        end = index
+        while end < len(rows) and not bridged[end]:
+            end += 1
+        if (
+            index > 0
+            and end < len(rows)
+            and end - index <= _MAX_BRIDGED_MISSING_FRAMES
+            and rows[end].relative_timestamp_us - rows[index - 1].relative_timestamp_us
+            <= _MAX_BRIDGE_US
+        ):
+            bridged[index:end] = [True] * (end - index)
+        index = end
+    return tuple(bridged)
+
+
+def _episodes(presence: tuple[bool, ...]) -> tuple[tuple[int, int], ...]:
+    episodes: list[tuple[int, int]] = []
+    index = 0
+    while index < len(presence):
+        if not presence[index]:
+            index += 1
+            continue
+        end = index
+        while end + 1 < len(presence) and presence[end + 1]:
+            end += 1
+        episodes.append((index, end))
+        index = end + 1
+    return tuple(episodes)
+
+
+def _palm_centroid_q(hand: HandSlotV1) -> tuple[int, int, int]:
+    if not hand.present or hand.image_landmarks is None:
+        raise PopSignWindowError("motion requires an observed hand")
+    points = tuple(hand.image_landmarks[index] for index in _PALM_LANDMARK_INDICES)
+    return tuple(
+        round(
+            sum(getattr(point, axis) for point in points) * _COORDINATE_QUANTIZATION / len(points)
+        )
+        for axis in ("x", "y", "z")
+    )
+
+
+def _episode_motion_l1_q(
+    table: LandmarkFramesTableV1,
+    start: int,
+    end: int,
+) -> int:
+    motion = 0
+    for slot_index in range(2):
+        previous: tuple[int, int, int] | None = None
+        for row in table.rows[start : end + 1]:
+            hand = row.hands[slot_index]
+            if not hand.present:
+                continue
+            current = _palm_centroid_q(hand)
+            if previous is not None:
+                motion += sum(
+                    abs(right - left) for left, right in zip(previous, current, strict=True)
+                )
+            previous = current
+    return motion
+
+
+def select_popsign_window(table: LandmarkFramesTableV1) -> PopSignWindow:
+    """Select one label-blind hand episode without changing the source table."""
+
+    if not isinstance(table, LandmarkFramesTableV1):
+        raise PopSignWindowError("PopSign window input must be a validated landmark table")
+    source_table_sha256 = landmark_frames_table_digest(table)
+    source_presence = tuple(row.observed_hand_count > 0 for row in table.rows)
+    episodes = _episodes(_bridged_presence(table))
+    if not episodes:
+        return PopSignWindow(
+            rule_id=POPSIGN_WINDOW_RULE_ID,
+            reason="no_hand_observations",
+            source_table_sha256=source_table_sha256,
+            source_frame_count=len(table.rows),
+            episode_count=0,
+            observed_hand_frame_count=0,
+            motion_l1_q=0,
+            first_source_frame_index=None,
+            last_source_frame_index=None,
+            first_source_pts=None,
+            last_source_pts=None,
+            first_source_timestamp_us=None,
+            last_source_timestamp_us=None,
+        )
+
+    ranked = tuple(
+        (
+            sum(source_presence[start : end + 1]),
+            _episode_motion_l1_q(table, start, end),
+            end - start + 1,
+            -start,
+            start,
+            end,
+        )
+        for start, end in episodes
+    )
+    observed_count, motion_l1_q, _span, _earliest, start, end = max(ranked)
+    if observed_count < _MIN_OBSERVED_HAND_FRAMES:
+        return PopSignWindow(
+            rule_id=POPSIGN_WINDOW_RULE_ID,
+            reason="episode_too_short",
+            source_table_sha256=source_table_sha256,
+            source_frame_count=len(table.rows),
+            episode_count=len(episodes),
+            observed_hand_frame_count=observed_count,
+            motion_l1_q=motion_l1_q,
+            first_source_frame_index=None,
+            last_source_frame_index=None,
+            first_source_pts=None,
+            last_source_pts=None,
+            first_source_timestamp_us=None,
+            last_source_timestamp_us=None,
+        )
+
+    first = table.rows[start]
+    last = table.rows[end]
+    return PopSignWindow(
+        rule_id=POPSIGN_WINDOW_RULE_ID,
+        reason="selected_longest_detected_hand_episode",
+        source_table_sha256=source_table_sha256,
+        source_frame_count=len(table.rows),
+        episode_count=len(episodes),
+        observed_hand_frame_count=observed_count,
+        motion_l1_q=motion_l1_q,
+        first_source_frame_index=first.frame_index,
+        last_source_frame_index=last.frame_index,
+        first_source_pts=first.source_pts,
+        last_source_pts=last.source_pts,
+        first_source_timestamp_us=first.relative_timestamp_us,
+        last_source_timestamp_us=last.relative_timestamp_us,
+    )
+
+
+def materialize_popsign_window(
+    table: LandmarkFramesTableV1,
+    window: PopSignWindow,
+) -> LandmarkFramesTableV1:
+    """Create the explicit rebased view consumed by unchanged quality and feature code."""
+
+    if not window.selected:
+        raise PopSignWindowError("a failed PopSign window decision cannot be materialized")
+    if window.source_table_sha256 != landmark_frames_table_digest(table):
+        raise PopSignWindowError("PopSign window source content changed")
+    if window.source_frame_count != len(table.rows):
+        raise PopSignWindowError("PopSign window source frame count changed")
+    start = window.first_source_frame_index
+    end = window.last_source_frame_index
+    if start is None or end is None or not 0 <= start <= end < len(table.rows):
+        raise PopSignWindowError("PopSign window bounds are invalid")
+    if (
+        table.rows[start].source_pts != window.first_source_pts
+        or table.rows[end].source_pts != window.last_source_pts
+        or table.rows[start].relative_timestamp_us != window.first_source_timestamp_us
+        or table.rows[end].relative_timestamp_us != window.last_source_timestamp_us
+    ):
+        raise PopSignWindowError("PopSign window does not match its source table")
+
+    first = table.rows[start]
+    rows = []
+    previous_task_ms: int | None = None
+    for frame_index, row in enumerate(table.rows[start : end + 1]):
+        relative_timestamp_us = (
+            (row.source_pts - first.source_pts)
+            * row.source_time_base_numerator
+            * 1_000_000
+            // row.source_time_base_denominator
+        )
+        task_timestamp_ms = max(
+            relative_timestamp_us // 1_000,
+            0 if previous_task_ms is None else previous_task_ms + 1,
+        )
+        rows.append(
+            row.model_copy(
+                update={
+                    "frame_index": frame_index,
+                    "relative_timestamp_us": relative_timestamp_us,
+                    "task_timestamp_ms": task_timestamp_ms,
+                }
+            )
+        )
+        previous_task_ms = task_timestamp_ms
+    return LandmarkFramesTableV1(
+        schema_version="landmark-frames-table/1",
+        rows=tuple(rows),
+    )
+
+
+__all__ = [
+    "POPSIGN_WINDOW_RULE_ID",
+    "PopSignWindow",
+    "PopSignWindowError",
+    "materialize_popsign_window",
+    "select_popsign_window",
+]

--- a/src/signlab/datasets/public_corpus.py
+++ b/src/signlab/datasets/public_corpus.py
@@ -29,6 +29,11 @@ from signlab.contracts.features import landmark_feature_plan_digest
 from signlab.contracts.quality import landmark_quality_policy_digest
 from signlab.datasets.external_resources import load_popsign_source
 from signlab.datasets.popsign import validate_external_dataset_bundle
+from signlab.datasets.popsign_window import (
+    POPSIGN_WINDOW_RULE_ID,
+    materialize_popsign_window,
+    select_popsign_window,
+)
 from signlab.extraction.batch import ExtractionBatchError, extract_media_landmarks
 from signlab.extraction.parquet import write_landmark_frames
 from signlab.extraction.resources import load_packaged_default_extraction_config
@@ -269,6 +274,7 @@ def _summary_markdown(summary: dict[str, object]) -> str:
         f"- Hand model: `{summary['hand_model_sha256']}`",
         f"- Pose model: `{summary['pose_model_sha256']}`",
         f"- Quality policy: `{summary['quality_policy_sha256']}`",
+        f"- Active-sign window: `{summary['active_window_rule_id']}`",
         f"- Feature plan: `{summary['feature_plan_sha256']}`",
         f"- Source orientation basis: `{summary['source_orientation_basis']}`",
         "",
@@ -330,6 +336,7 @@ def _trainable_summary_markdown(summary: dict[str, object]) -> str:
         f"- Hand model: `{summary['hand_model_sha256']}`",
         f"- Pose model: `{summary['pose_model_sha256']}`",
         f"- Quality policy: `{summary['quality_policy_sha256']}`",
+        f"- Active-sign window: `{summary['active_window_rule_id']}`",
         f"- Feature plan: `{summary['feature_plan_sha256']}`",
         f"- Source orientation basis: `{summary['source_orientation_basis']}`",
         "",
@@ -434,6 +441,19 @@ def build_public_corpus(
             return None
         _verify_media_bytes(source_path, media)
 
+        source_content_sha256 = landmark_frames_table_digest(table)
+        source_parquet_path = _content_path(
+            destination,
+            "source-landmarks",
+            source_content_sha256,
+            ".parquet",
+        )
+        source_parquet = write_landmark_frames(table, source_parquet_path)
+        active_window = select_popsign_window(table)
+        if not active_window.selected:
+            exclusions[f"window.{active_window.reason}"] += 1
+            return None
+        table = materialize_popsign_window(table, active_window)
         content_sha256 = landmark_frames_table_digest(table)
         parquet_path = _content_path(destination, "landmarks", content_sha256, ".parquet")
         parquet = write_landmark_frames(table, parquet_path)
@@ -489,6 +509,19 @@ def build_public_corpus(
                 "source_mirror_state": _SOURCE_MIRROR_STATE,
                 "source_orientation_basis": _SOURCE_ORIENTATION_BASIS,
                 "expected_hand_count": 1,
+                "source_landmark_content_sha256": source_content_sha256,
+                "source_landmark_parquet_sha256": source_parquet.sha256,
+                "source_landmark_parquet_size_bytes": source_parquet.size_bytes,
+                "source_landmark_frame_count": source_parquet.row_count,
+                "source_landmark_path": source_parquet_path.relative_to(destination).as_posix(),
+                "active_window": {
+                    "rule_id": active_window.rule_id,
+                    "reason": active_window.reason,
+                    "first_source_frame_index": active_window.first_source_frame_index,
+                    "last_source_frame_index": active_window.last_source_frame_index,
+                    "first_source_pts": active_window.first_source_pts,
+                    "last_source_pts": active_window.last_source_pts,
+                },
                 "landmark_content_sha256": content_sha256,
                 "landmark_parquet_sha256": parquet.sha256,
                 "landmark_parquet_size_bytes": parquet.size_bytes,
@@ -637,6 +670,7 @@ def build_public_corpus(
         "hand_model_sha256": assets.hand_model_sha256,
         "pose_model_sha256": assets.pose_model_sha256,
         "quality_policy_sha256": policy_sha256,
+        "active_window_rule_id": POPSIGN_WINDOW_RULE_ID,
         "feature_plan_id": feature_plan.plan_id,
         "feature_plan_sha256": feature_plan_sha256,
         "selected": selected,
@@ -688,6 +722,7 @@ def build_public_corpus(
         "hand_model_sha256": assets.hand_model_sha256,
         "pose_model_sha256": assets.pose_model_sha256,
         "quality_policy_sha256": policy_sha256,
+        "active_window_rule_id": POPSIGN_WINDOW_RULE_ID,
         "feature_plan_id": feature_plan.plan_id,
         "feature_plan_sha256": feature_plan_sha256,
         "source_orientation_basis": _SOURCE_ORIENTATION_BASIS,

--- a/tests/test_popsign_window.py
+++ b/tests/test_popsign_window.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any, cast
+
+import pytest
+
+from feature_fixtures import make_feature_fixture, make_hand_row
+from signlab.contracts.extraction import LandmarkFramesTableV1, landmark_frames_table_digest
+from signlab.contracts.quality import landmark_quality_policy_digest
+from signlab.datasets.popsign_window import (
+    POPSIGN_WINDOW_RULE_ID,
+    PopSignWindowError,
+    materialize_popsign_window,
+    select_popsign_window,
+)
+from signlab.quality.policy import assess_landmark_source
+from signlab.quality.resources import build_default_quality_policy
+
+
+def _table(
+    presence: tuple[bool, ...],
+    *,
+    centers: tuple[tuple[float, float], ...] | None = None,
+) -> LandmarkFramesTableV1:
+    timestamps = tuple(index * 33_333 for index in range(len(presence)))
+    hand_rows = tuple(
+        make_hand_row(
+            timestamp_us=timestamp,
+            first_present=present,
+            first_center=(0.42, 0.58) if centers is None else centers[index],
+        )
+        for index, (timestamp, present) in enumerate(zip(timestamps, presence, strict=True))
+    )
+    return make_feature_fixture(timestamps, hand_rows=hand_rows).table
+
+
+def _quality(table: LandmarkFramesTableV1) -> str:
+    digest = landmark_frames_table_digest(table)
+    return assess_landmark_source(
+        table,
+        build_default_quality_policy(),
+        source_recording_id=table.rows[0].source_recording_id,
+        source_sequence_content_sha256=digest,
+        source_landmark_parquet_sha256="sha256:" + "a" * 64,
+        declared_duration_us=max(table.rows[-1].relative_timestamp_us + 33_333, 1),
+        expected_hand_count=1,
+    ).disposition
+
+
+def test_window_removes_inactive_edges_without_changing_quality_policy() -> None:
+    source = _table((False, False, True, True, True, True, False, False, False))
+    source_digest = landmark_frames_table_digest(source)
+    policy_digest = landmark_quality_policy_digest(build_default_quality_policy())
+
+    window = select_popsign_window(source)
+    materialized = materialize_popsign_window(source, window)
+
+    assert window.rule_id == POPSIGN_WINDOW_RULE_ID
+    assert window.reason == "selected_longest_detected_hand_episode"
+    assert window.source_table_sha256 == source_digest
+    assert (window.first_source_frame_index, window.last_source_frame_index) == (2, 5)
+    assert _quality(source) == "reject"
+    assert _quality(materialized) == "pass"
+    assert landmark_frames_table_digest(source) == source_digest
+    assert policy_digest == (
+        "sha256:680b0904e1cc5d8e03119032e92920a3a0185917a600c4293323b7925da9a545"
+    )
+
+
+def test_window_returns_coded_failures_for_no_hands_and_short_detection() -> None:
+    no_hands = select_popsign_window(_table((False, False, False, False)))
+    short = select_popsign_window(_table((False, True, True, False)))
+
+    assert no_hands.reason == "no_hand_observations"
+    assert no_hands.selected is False
+    assert no_hands.first_source_frame_index is None
+    assert short.reason == "episode_too_short"
+    assert short.observed_hand_frame_count == 2
+    assert short.selected is False
+    with pytest.raises(PopSignWindowError):
+        materialize_popsign_window(_table((False, True, True, False)), short)
+
+
+def test_window_bridges_only_the_existing_policy_sized_gap() -> None:
+    source = _table((False, True, True, False, True, True, False, False, False, True, True, True))
+
+    window = select_popsign_window(source)
+
+    assert window.episode_count == 2
+    assert window.observed_hand_frame_count == 4
+    assert (window.first_source_frame_index, window.last_source_frame_index) == (1, 5)
+
+
+def test_window_uses_motion_then_earliest_for_equal_length_episodes() -> None:
+    presence = (True, True, True, False, False, False, True, True, True)
+    centers = (
+        (0.42, 0.58),
+        (0.42, 0.58),
+        (0.42, 0.58),
+        (0.42, 0.58),
+        (0.42, 0.58),
+        (0.42, 0.58),
+        (0.42, 0.58),
+        (0.48, 0.58),
+        (0.54, 0.58),
+    )
+    moving = select_popsign_window(_table(presence, centers=centers))
+    tied = select_popsign_window(_table(presence))
+
+    assert (moving.first_source_frame_index, moving.last_source_frame_index) == (6, 8)
+    assert (tied.first_source_frame_index, tied.last_source_frame_index) == (0, 2)
+
+
+def test_window_excludes_a_short_trailing_reappearance_and_rebases_the_view() -> None:
+    source = _table((False, True, True, True, True, False, False, False, False, True))
+
+    window = select_popsign_window(source)
+    materialized = materialize_popsign_window(source, window)
+
+    assert window.episode_count == 2
+    assert (window.first_source_frame_index, window.last_source_frame_index) == (1, 4)
+    assert window.first_source_pts == source.rows[1].source_pts
+    assert window.last_source_pts == source.rows[4].source_pts
+    assert tuple(row.frame_index for row in materialized.rows) == (0, 1, 2, 3)
+    assert materialized.rows[0].relative_timestamp_us == 0
+    assert materialized.rows[0].task_timestamp_ms == 0
+    assert materialized.rows[0].source_pts == source.rows[1].source_pts
+    assert materialized.rows[-1].source_pts == source.rows[4].source_pts
+
+
+def test_window_cannot_be_applied_after_its_source_changes() -> None:
+    source = _table((False, True, True, True, False))
+    window = select_popsign_window(source)
+    changed_content = _table(
+        (False, True, True, True, False),
+        centers=((0.42, 0.58), (0.43, 0.58), (0.44, 0.58), (0.45, 0.58), (0.42, 0.58)),
+    )
+
+    with pytest.raises(PopSignWindowError):
+        select_popsign_window(cast(Any, object()))
+    with pytest.raises(PopSignWindowError):
+        materialize_popsign_window(source, replace(window, source_frame_count=99))
+    with pytest.raises(PopSignWindowError):
+        materialize_popsign_window(changed_content, window)
+    with pytest.raises(PopSignWindowError):
+        materialize_popsign_window(source, replace(window, first_source_frame_index=None))
+    with pytest.raises(PopSignWindowError):
+        materialize_popsign_window(source, replace(window, first_source_pts=-1))

--- a/tests/test_public_corpus.py
+++ b/tests/test_public_corpus.py
@@ -129,14 +129,23 @@ def test_public_corpus_tries_next_candidate_and_repeats_identically(
             ),
         ),
     )
-    timestamps = (0, 33_333, 66_667)
+    timestamps = (0, 33_333, 66_667, 100_000, 133_333, 166_667, 200_000)
     rejected_fixture = make_feature_fixture(
         timestamps,
         hand_rows=tuple(
             make_hand_row(timestamp_us=timestamp, first_present=False) for timestamp in timestamps
         ),
     )
-    accepted_fixture = make_feature_fixture(timestamps)
+    accepted_fixture = make_feature_fixture(
+        timestamps,
+        hand_rows=tuple(
+            make_hand_row(
+                timestamp_us=timestamp,
+                first_present=2 <= index <= 4,
+            )
+            for index, timestamp in enumerate(timestamps)
+        ),
+    )
     tables = {
         candidates[0].recording_id: _with_recording_id(
             rejected_fixture.table, candidates[0].recording_id
@@ -190,14 +199,26 @@ def test_public_corpus_tries_next_candidate_and_repeats_identically(
     assert first.group_count == 2
     assert first.summary["exclusions"] == {
         "extraction.failed": 5,
-        "quality.reject": 1,
         "selection.attempt_limit": 1,
         "selection.not_needed_after_accepted": 1,
+        "window.no_hand_observations": 1,
     }
     assert progress == [(1, 2, True), (2, 2, False)]
     corpus = json.loads(first_corpus)
-    assert corpus["selected"][0]["sample_id"] == candidates[1].sample_id
-    assert corpus["selected"][0]["feature_sequence_sha256"].startswith("sha256:")
+    selected = corpus["selected"][0]
+    assert selected["sample_id"] == candidates[1].sample_id
+    assert selected["feature_sequence_sha256"].startswith("sha256:")
+    assert selected["active_window"] == {
+        "first_source_frame_index": 2,
+        "first_source_pts": accepted_fixture.table.rows[2].source_pts,
+        "last_source_frame_index": 4,
+        "last_source_pts": accepted_fixture.table.rows[4].source_pts,
+        "reason": "selected_longest_detected_hand_episode",
+        "rule_id": "popsign_longest_detected_hand_episode/1",
+    }
+    assert selected["source_landmark_content_sha256"] != selected["landmark_content_sha256"]
+    assert (output / selected["source_landmark_path"]).is_file()
+    assert (output / selected["landmark_path"]).is_file()
     assert (output / "public-corpus-summary.md").is_file()
 
 


### PR DESCRIPTION
Closes #83

## Outcome

- Adds one fixed, deterministic, label-blind active-sign window before unchanged quality assessment and feature derivation.
- Replays all 750 stored landmark files without rerunning MediaPipe: 693 are usable after windowing, and all 15 split/gesture groups exceed their 10/3/3 quota.
- Rechecks the same preselected 12-video visual set: 12/12 retain the complete visible labeled motion, with 0 visible truncations.
- Retains both original and rebased landmark Parquets plus auditable source bounds and content identities.
- Commits only aggregate evidence in `docs/reports/popsign-active-window-v1.md`.

## Scope guard

No quality-threshold change, MediaPipe rerun, alternate window strategy, new provider, split generation, model training, API, or UI work.

## Verification

- Full local suite before the final source-binding guard: 1,321 passed, 13 platform-specific skipped, 90.11% coverage.
- After the guard: 14 focused tests passed.
- Ruff check and format check passed.
- Mypy passed.
- Independent code, test/scope, and report reviews found no remaining merge-blocking issue.