### PR TITLE
feat(data): freeze and validate exact PopSign smoke split

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,9 @@ quality boundary records deterministic timing, gap, pose, continuity, and triage
 evidence without rewriting extraction. A pure portable-feature service now derives
 three exact representation variants, optional geometry and elapsed-time kinematics,
 masked training-only statistics, and content-addressed cache objects. Licensed
-PopSign execution and corpus publication remain the next data-foundation bridge.
+PopSign execution now produces one deterministic, leakage-checked 80-sample public
+smoke split from the verified retained landmark inventory without rerunning MediaPipe.
+Baseline experiment loading and evaluation remain the next bridge.
 The registered DVC graph remains the Story #14 fixture receipt scaffold rather
 than a production extraction runner. No headline model result is considered valid
 until the remaining licensed-corpus and grouped-evaluation foundations are complete.

--- a/docs/external-datasets.md
+++ b/docs/external-datasets.md
@@ -152,6 +152,23 @@ explicitly rebased windowed Parquet are both retained; quality and features cons
 same windowed view. The 750-file no-extraction evaluation is recorded in
 [`popsign-active-window-v1.md`](reports/popsign-active-window-v1.md).
 
+After that evaluation succeeds, freeze the exact experiment membership from those
+same retained Parquets; this command has no video or MediaPipe input:
+
+```shell
+uv run signlab data freeze-public-corpus-split \
+  data/raw/external/popsign-v1/external-dataset-manifest.json \
+  --source-root LOCAL_IMMUTABLE_79_CORPUS_ROOT \
+  --output LOCAL_FROZEN_SPLIT_ROOT
+```
+
+The command requires the pinned 750-file inventory and exact 582 pass / 111 warning /
+46 quarantine / 11 no-window replay. It then applies the fixed offline rule, writes
+only the 80 portable feature files and their leakage-checked split manifest, and
+reconciles every feature before success. The completed real-data verification is
+recorded in
+[`popsign-frozen-smoke-split-v1.md`](reports/popsign-frozen-smoke-split-v1.md).
+
 ## Import and security guarantees
 
 The importer treats every tar as hostile input. It streams regular MP4 members and

--- a/docs/landmark-representations.md
+++ b/docs/landmark-representations.md
@@ -139,8 +139,9 @@ observations uses mean zero and scale one; a constant channel uses scale one. Th
 statistics artifact records the verified split-manifest digest and sorted
 training-sequence identities, and standardized outputs bind its digest.
 
-Story #25 creates the authoritative train/validation/test splits. Story #22 verifies
-caller-supplied split evidence; it does not invent or revise split membership.
+Story #25 now freezes the authoritative PopSign smoke train/validation/test membership.
+The participant-backed `SplitManifestV1` remains a separate governed contract. Story
+#22 verifies caller-supplied split evidence; it does not invent or revise membership.
 
 ## Cache behavior
 

--- a/docs/reports/popsign-active-window-v1.md
+++ b/docs/reports/popsign-active-window-v1.md
@@ -8,8 +8,9 @@ Every split/gesture group has more distinct usable signers than the required 10 
 3 validation, or 3 test clips.
 
 This result resolves the seven-clip shortfall reported by `#79`. It does not claim model
-performance and does not overwrite the immutable `#79` corpus. The exact 80-clip corpus
-and leakage-resistant split manifest remain downstream artifacts.
+performance and does not overwrite the immutable `#79` corpus. The downstream exact
+80-sample result is recorded separately in
+[`popsign-frozen-smoke-split-v1.md`](popsign-frozen-smoke-split-v1.md).
 
 ## Frozen rule
 

--- a/docs/reports/popsign-frozen-smoke-split-v1.md
+++ b/docs/reports/popsign-frozen-smoke-split-v1.md
@@ -1,0 +1,103 @@
+# Frozen PopSign smoke split
+
+## Decision
+
+**READY for the first bounded experiment.** The exact immutable 750-attempt landmark
+inventory from `#79` was replayed with the fixed active-sign window from `#83`, and
+one deterministic offline rule selected 80 feature-ready clips: 50 train, 15
+validation, and 15 test.
+
+This is a data-readiness result, not a model-performance result. The local split
+manifest contains opaque licensed-source identities and stays outside the public Git
+repository; this report contains only aggregate evidence.
+
+## Frozen selection rule
+
+Rule ID:
+`first_usable_distinct_signer_by_stable_sample_id_per_split_target/1`
+
+1. Replay every one of the 750 retained landmark Parquets; do not run MediaPipe or
+   select new videos.
+2. Apply `popsign_longest_detected_hand_episode/1`, then the unchanged quality policy.
+3. Treat `pass` and `warning` as equally eligible. Do not quality-rank candidates.
+4. Within each official source split and target gesture, sort usable rows only by
+   stable opaque sample ID.
+5. Walk that order and retain the first row for each unseen signer until reaching 10
+   train or 3 validation/test rows.
+6. Preserve PopSign's official signer-disjoint split assignments; map source `val` to
+   experiment partition `validation`.
+
+This is deliberately not a replay of `#79`'s acceptance-dependent online attempt
+loop. The window changed which attempts are usable, so claiming the old loop was
+replayed would be false.
+
+## Reproduced source evidence
+
+| Evidence | Value |
+| --- | --- |
+| Source corpus | `sha256:bd2e552d28792346b7c8e345f8387ebcc52938692cde7f0a316763aa09bdceb9` |
+| External dataset | `sha256:3eb0bb1e73cacddf3b59a84d5c946207c7cb973d6526edea8c75fe9138e8669c` |
+| Attempt-landmark inventory | `sha256:fa2028b212c342fe273b0afd9101114c157b4822f3cc95860535848d993f9f44` |
+| Attempt landmarks | 750 |
+| Active-sign window | `popsign_longest_detected_hand_episode/1` |
+| Pass | 582 |
+| Warning | 111 |
+| Quarantine | 46 |
+| No safe window | 11 |
+| Usable (`pass + warning`) | 693 |
+| MediaPipe executions | 0 |
+
+The replay matched the `#83` result exactly. Every retained Parquet was byte-hashed,
+schema-checked, semantically decoded, joined to one unique external recording, and
+reassessed. No fallback rule, quality exception, threshold change, or feature failure
+was used.
+
+## Exact selected membership
+
+| Source split | Gesture | Selected | Distinct signers | Pass | Warning |
+| --- | --- | ---: | ---: | ---: | ---: |
+| train | `hello` | 10 | 10 | 9 | 1 |
+| train | `no` | 10 | 10 | 10 | 0 |
+| train | `please` | 10 | 10 | 6 | 4 |
+| train | `thank_you` | 10 | 10 | 9 | 1 |
+| train | `yes` | 10 | 10 | 10 | 0 |
+| validation | `hello` | 3 | 3 | 3 | 0 |
+| validation | `no` | 3 | 3 | 3 | 0 |
+| validation | `please` | 3 | 3 | 3 | 0 |
+| validation | `thank_you` | 3 | 3 | 3 | 0 |
+| validation | `yes` | 3 | 3 | 3 | 0 |
+| test | `hello` | 3 | 3 | 3 | 0 |
+| test | `no` | 3 | 3 | 3 | 0 |
+| test | `please` | 3 | 3 | 2 | 1 |
+| test | `thank_you` | 3 | 3 | 2 | 1 |
+| test | `yes` | 3 | 3 | 3 | 0 |
+| **Total** |  | **80** |  | **72** | **8** |
+
+The manifest contains 40 distinct signers. No signer crosses partitions, and no
+recording or feature-sequence identity is repeated.
+
+## Reproducibility result
+
+| Evidence | Value |
+| --- | --- |
+| Frozen split | `sha256:673c777c67e47715127b75f2bf18aaa794a15e1604458d30da164ec7f90ead20` |
+| Independent fresh freezes | 2 |
+| Files per freeze | 82 (80 features, 1 manifest, 1 aggregate report) |
+| Bytes per freeze | 14,887,227 |
+| Relative path / SHA-256 / size differences | 0 |
+| Reconciled feature bindings | 80 / 80 |
+
+The validator rejects stale split hashes, wrong quotas, noncanonical membership,
+within-group signer reuse, cross-partition signers, repeated recording or feature
+identities, unsafe/non-content-addressed feature paths, changed feature bytes, and
+feature lineage that disagrees with the frozen configuration, quality policy, or
+feature plan.
+
+## Scope limit
+
+This split is sufficient to exercise the bounded five-gesture isolated-sign training
+and evaluation path. It does not establish participant-study coverage, natural or
+continuous signing performance, production generalization, or any accuracy claim.
+
+PopSign ASL v1.0 is provided by the Georgia Institute of Technology and Deaf
+Professional Arts Network under CC BY 4.0.

--- a/src/signlab/commands/data.py
+++ b/src/signlab/commands/data.py
@@ -494,6 +494,55 @@ def build_public_corpus_command(
     typer.echo("Claim scope: licensed isolated public data only.")
 
 
+@app.command("freeze-public-corpus-split")
+def freeze_public_corpus_split_command(
+    manifest: Annotated[
+        Path,
+        typer.Argument(help="External-dataset-manifest/1 JSON document."),
+    ],
+    source_root: Annotated[
+        Path,
+        typer.Option(
+            "--source-root",
+            help="Immutable #79 corpus root containing the 750 retained landmarks.",
+        ),
+    ],
+    output: Annotated[
+        Path,
+        typer.Option("--output", help="New exact-80 public split directory."),
+    ],
+) -> None:
+    """Freeze the exact PopSign split from retained landmarks without MediaPipe."""
+
+    from signlab.datasets.public_split import freeze_public_corpus_split
+
+    def show_progress(index: int, total: int) -> None:
+        if index == 1 or index % 50 == 0 or index == total:
+            typer.echo(f"Retained landmark replay: {index}/{total}.")
+
+    try:
+        result = freeze_public_corpus_split(
+            manifest,
+            source_root=source_root,
+            output_root=output,
+            progress=show_progress,
+        )
+    except (OSError, TypeError, ValueError) as error:
+        typer.echo("Public corpus split freeze failed.", err=True)
+        raise typer.Exit(code=1) from error
+    typer.echo("Public corpus split: frozen and verified.")
+    typer.echo(f"Attempt landmarks: {result.attempt_count} verified.")
+    typer.echo(
+        "Window and quality: "
+        f"{result.pass_count} pass, {result.warning_count} warning, "
+        f"{result.quarantine_count} quarantine, {result.no_window_count} no window."
+    )
+    typer.echo(f"Selected usable clips: {result.selected_count}/80.")
+    typer.echo("Partitions: 50 train, 15 validation, 15 test.")
+    typer.echo(f"Public split SHA-256: {result.split_sha256}")
+    typer.echo("Claim scope: licensed isolated public data only.")
+
+
 def _echo_landmark_extraction_summary(
     *,
     status: str,

--- a/src/signlab/datasets/public_split.py
+++ b/src/signlab/datasets/public_split.py
@@ -1,0 +1,720 @@
+"""Freeze the exact PopSign smoke split from retained landmark attempts."""
+
+from __future__ import annotations
+
+import hashlib
+import tempfile
+from collections import Counter, defaultdict
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Annotated, Literal, Self, cast
+
+import pyarrow as pa  # type: ignore[import-untyped]
+import pyarrow.parquet as pq  # type: ignore[import-untyped]
+from pydantic import Field, ValidationError, model_validator
+
+from signlab.contracts.canonical import (
+    CanonicalizationError,
+    canonical_json_bytes,
+    canonical_sha256,
+    parse_json_object,
+)
+from signlab.contracts.core import StrictContractModel, WorkspaceRelativeLocatorV1
+from signlab.contracts.external_dataset import (
+    ExternalDatasetManifestV1,
+    ExternalMediaRecordV1,
+    ExternalSplit,
+    ExternalTargetLabel,
+    OpaqueParticipantId,
+    OpaqueRecordingId,
+    OpaqueSampleId,
+    validate_external_dataset_manifest,
+)
+from signlab.contracts.extraction import (
+    landmark_frames_table_digest,
+    mediapipe_extraction_config_digest,
+)
+from signlab.contracts.features import (
+    LandmarkFeaturePlanV1,
+    PortableFeatureSequenceV1,
+    landmark_feature_plan_digest,
+    validate_portable_feature_sequence,
+)
+from signlab.contracts.quality import (
+    LandmarkQualityPolicyV1,
+    landmark_quality_policy_digest,
+)
+from signlab.contracts.taxonomy import Sha256Digest
+from signlab.datasets.popsign_window import (
+    POPSIGN_WINDOW_RULE_ID,
+    PopSignWindow,
+    materialize_popsign_window,
+    select_popsign_window,
+)
+from signlab.datasets.public_corpus import (
+    _SOURCE_MIRROR_STATE,
+    _content_path,
+    _duration_us,
+    _fresh_output_root,
+    _write_bytes,
+)
+from signlab.extraction.parquet import read_landmark_frames, write_landmark_frames
+from signlab.extraction.resources import load_packaged_default_extraction_config
+from signlab.features.resources import load_packaged_default_feature_plan
+from signlab.features.transforms import derive_feature_source
+from signlab.quality.policy import assess_landmark_source
+from signlab.quality.resources import load_packaged_default_quality_policy
+
+type PublicPartition = Literal["train", "validation", "test"]
+type PublicSplitInput = str | bytes | bytearray | Mapping[str, object]
+type ExternalManifestInput = ExternalDatasetManifestV1 | PublicSplitInput
+
+_SOURCE_CORPUS_SHA256 = "sha256:bd2e552d28792346b7c8e345f8387ebcc52938692cde7f0a316763aa09bdceb9"
+_ATTEMPT_INVENTORY_SHA256 = (
+    "sha256:fa2028b212c342fe273b0afd9101114c157b4822f3cc95860535848d993f9f44"
+)
+_EXPECTED_REPLAY = {"no_window": 11, "pass": 582, "quarantine": 46, "warning": 111}
+_ATTEMPT_COUNT = 750
+_TARGETS: tuple[ExternalTargetLabel, ...] = ("hello", "no", "please", "thank_you", "yes")
+_QUOTAS: dict[ExternalSplit, int] = {"train": 10, "val": 3, "test": 3}
+_PARTITION_BY_SOURCE: dict[ExternalSplit, PublicPartition] = {
+    "train": "train",
+    "val": "validation",
+    "test": "test",
+}
+_PARTITION_ORDER = {"train": 0, "validation": 1, "test": 2}
+_SELECTION_RULE = "first_usable_distinct_signer_by_stable_sample_id_per_split_target/1"
+_FORMAT = "signlab-public-corpus-split/1"
+_INVENTORY_DOMAIN = "signlab.popsign.quality-diagnostic.landmark-inventory/1"
+
+
+class PublicCorpusSplitError(ValueError):
+    """Raised when the frozen public split cannot be trusted."""
+
+
+class PublicReplayCountsV1(StrictContractModel):
+    """Exact post-window outcomes for the immutable 750 attempts."""
+
+    pass_count: int = Field(ge=0)
+    warning_count: int = Field(ge=0)
+    quarantine_count: int = Field(ge=0)
+    no_window_count: int = Field(ge=0)
+    usable_count: int = Field(ge=0)
+
+    @model_validator(mode="after")
+    def _require_frozen_replay(self) -> Self:
+        observed = {
+            "no_window": self.no_window_count,
+            "pass": self.pass_count,
+            "quarantine": self.quarantine_count,
+            "warning": self.warning_count,
+        }
+        if (
+            observed != _EXPECTED_REPLAY
+            or self.usable_count != self.pass_count + self.warning_count
+        ):
+            raise ValueError("public split replay counts changed from frozen evidence")
+        return self
+
+
+class PublicSplitAssignmentV1(StrictContractModel):
+    """One selected sample and the exact artifacts used by experiments."""
+
+    sample_id: OpaqueSampleId
+    source_recording_id: OpaqueRecordingId
+    source_signer_id: OpaqueParticipantId
+    source_split: ExternalSplit
+    partition: PublicPartition
+    target_label_id: ExternalTargetLabel
+    quality_disposition: Literal["pass", "warning"]
+    feature_sequence_sha256: Sha256Digest
+    feature_path: str
+
+    @model_validator(mode="after")
+    def _require_partition_and_path(self) -> Self:
+        if self.partition != _PARTITION_BY_SOURCE[self.source_split]:
+            raise ValueError("public partition does not preserve the official source split")
+        value = self.feature_sequence_sha256.removeprefix("sha256:")
+        if self.feature_path != f"features/sha256/{value[:2]}/{value}.json":
+            raise ValueError("public split feature path is not content-addressed")
+        return self
+
+
+class PublicCorpusSplitV1(StrictContractModel):
+    """One immutable 80-sample public split; no participant records are implied."""
+
+    format: Literal["signlab-public-corpus-split/1"]
+    split_id: Literal["popsign-five-isolated-smoke-v1"]
+    version: Literal["1.0.0"]
+    source_corpus_sha256: Sha256Digest
+    external_dataset_sha256: Sha256Digest
+    attempt_inventory_sha256: Sha256Digest
+    extraction_config_sha256: Sha256Digest
+    quality_policy_sha256: Sha256Digest
+    feature_plan_id: Literal["combined_64_frames"]
+    feature_plan_sha256: Sha256Digest
+    active_window_rule_id: Literal["popsign_longest_detected_hand_episode/1"]
+    selection_rule: Literal["first_usable_distinct_signer_by_stable_sample_id_per_split_target/1"]
+    replay: PublicReplayCountsV1
+    assignments: Annotated[tuple[PublicSplitAssignmentV1, ...], Field(min_length=80, max_length=80)]
+    split_sha256: Sha256Digest
+
+    @model_validator(mode="after")
+    def _require_exact_leakage_free_membership(self) -> Self:
+        keys = tuple(
+            (_PARTITION_ORDER[row.partition], row.target_label_id, row.sample_id)
+            for row in self.assignments
+        )
+        if keys != tuple(sorted(keys)):
+            raise ValueError("public split assignments are not in canonical order")
+        counts = Counter((row.source_split, row.target_label_id) for row in self.assignments)
+        expected = {
+            (source_split, target): quota
+            for source_split, quota in _QUOTAS.items()
+            for target in _TARGETS
+        }
+        if counts != expected:
+            raise ValueError("public split does not meet exact split-target quotas")
+        for label, values in (
+            ("sample", tuple(row.sample_id for row in self.assignments)),
+            ("recording", tuple(row.source_recording_id for row in self.assignments)),
+            ("feature", tuple(row.feature_sequence_sha256 for row in self.assignments)),
+        ):
+            if len(values) != len(set(values)):
+                raise ValueError(f"public split repeats a {label} identity")
+        signer_partitions: dict[str, PublicPartition] = {}
+        group_signers: dict[tuple[str, str], set[str]] = defaultdict(set)
+        for row in self.assignments:
+            prior = signer_partitions.setdefault(row.source_signer_id, row.partition)
+            if prior != row.partition:
+                raise ValueError("public split signer crosses partitions")
+            group = (row.source_split, row.target_label_id)
+            if row.source_signer_id in group_signers[group]:
+                raise ValueError("public split repeats a signer within one split-target group")
+            group_signers[group].add(row.source_signer_id)
+        if self.split_sha256 != public_corpus_split_digest(self):
+            raise ValueError("public split digest does not match canonical content")
+        return self
+
+
+@dataclass(frozen=True, slots=True)
+class PublicSelectionCandidate:
+    """Fields used by the fixed selection rule; disposition is never a rank."""
+
+    sample_id: str
+    source_recording_id: str
+    source_signer_id: str
+    source_split: ExternalSplit
+    target_label_id: ExternalTargetLabel
+    quality_disposition: Literal["pass", "warning"]
+
+
+@dataclass(frozen=True, slots=True)
+class PublicCorpusSample:
+    """One fully reconciled input for the later experiment loader."""
+
+    partition: PublicPartition
+    target_label_id: ExternalTargetLabel
+    sample_id: str
+    source_recording_id: str
+    source_signer_id: str
+    quality_disposition: Literal["pass", "warning"]
+    feature: PortableFeatureSequenceV1
+
+
+@dataclass(frozen=True, slots=True)
+class PublicCorpusSplitFreezeResult:
+    """Aggregate, path-free result returned by the CLI."""
+
+    split_sha256: str
+    attempt_count: int
+    pass_count: int
+    warning_count: int
+    quarantine_count: int
+    no_window_count: int
+    selected_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class _Attempt:
+    path: Path
+    content_sha256: str
+    parquet_sha256: str
+    size_bytes: int
+    row_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class _UsableAttempt:
+    candidate: PublicSelectionCandidate
+    artifact: _Attempt
+    media: ExternalMediaRecordV1
+    window: PopSignWindow
+
+
+def public_corpus_split_digest(document: PublicCorpusSplitV1 | Mapping[str, object]) -> str:
+    """Hash split content without its self-referential digest."""
+
+    payload = (
+        cast(dict[str, object], document.model_dump(mode="json", round_trip=True))
+        if isinstance(document, PublicCorpusSplitV1)
+        else dict(document)
+    )
+    payload.pop("split_sha256", None)
+    return canonical_sha256(payload, domain=_FORMAT)
+
+
+def validate_public_corpus_split(document: PublicSplitInput) -> PublicCorpusSplitV1:
+    """Validate exact quotas, canonical identity, and leakage barriers."""
+
+    try:
+        payload = parse_json_object(document)
+        return PublicCorpusSplitV1.model_validate_json(canonical_json_bytes(payload), strict=True)
+    except (CanonicalizationError, ValidationError) as error:
+        raise PublicCorpusSplitError("invalid public corpus split") from error
+
+
+def _resolve_artifact(root: Path, path: str) -> Path:
+    try:
+        locator = WorkspaceRelativeLocatorV1(kind="workspace_relative", path=path)
+        resolved = root.joinpath(*locator.path.split("/")).resolve(strict=True)
+    except (OSError, ValidationError) as error:
+        raise PublicCorpusSplitError("public split artifact is unavailable") from error
+    if not resolved.is_relative_to(root) or not resolved.is_file():
+        raise PublicCorpusSplitError("public split artifact escapes its root")
+    return resolved
+
+
+def reconcile_public_corpus_split(
+    document: PublicSplitInput,
+    *,
+    external_manifest_document: ExternalManifestInput,
+    corpus_root: str | Path,
+) -> tuple[PublicCorpusSample, ...]:
+    """Verify assignment metadata and every selected feature against their sources."""
+
+    split = validate_public_corpus_split(document)
+    try:
+        manifest = validate_external_dataset_manifest(external_manifest_document)
+    except (TypeError, ValueError) as error:
+        raise PublicCorpusSplitError("public split external manifest is invalid") from error
+    if manifest.content_sha256 != split.external_dataset_sha256:
+        raise PublicCorpusSplitError("public split external dataset identity does not match")
+    media_by_recording = {row.recording_id: row for row in manifest.media}
+    if len(media_by_recording) != len(manifest.media):
+        raise PublicCorpusSplitError("public split external recording identities repeat")
+    try:
+        root = Path(corpus_root).resolve(strict=True)
+    except OSError as error:
+        raise PublicCorpusSplitError("public split root is unavailable") from error
+    if not root.is_dir():
+        raise PublicCorpusSplitError("public split root is invalid")
+    samples: list[PublicCorpusSample] = []
+    for row in split.assignments:
+        media = media_by_recording.get(row.source_recording_id)
+        if media is None or (
+            media.sample_id,
+            media.participant_id,
+            media.source_split,
+            media.target_label_id,
+        ) != (
+            row.sample_id,
+            row.source_signer_id,
+            row.source_split,
+            row.target_label_id,
+        ):
+            raise PublicCorpusSplitError("public split assignment metadata does not match")
+        try:
+            feature = validate_portable_feature_sequence(
+                _resolve_artifact(root, row.feature_path).read_bytes()
+            )
+        except (OSError, TypeError, ValueError) as error:
+            raise PublicCorpusSplitError("public split artifact is invalid") from error
+        expected = (
+            (feature.sequence_sha256, row.feature_sequence_sha256),
+            (feature.source_recording_id, row.source_recording_id),
+            (feature.source_media_sha256, media.sha256),
+            (feature.extraction_config_sha256, split.extraction_config_sha256),
+            (feature.quality_policy_sha256, split.quality_policy_sha256),
+            (feature.feature_plan_sha256, split.feature_plan_sha256),
+        )
+        if any(actual != claimed for actual, claimed in expected):
+            raise PublicCorpusSplitError("public split feature lineage does not match")
+        samples.append(
+            PublicCorpusSample(
+                partition=row.partition,
+                target_label_id=row.target_label_id,
+                sample_id=row.sample_id,
+                source_recording_id=row.source_recording_id,
+                source_signer_id=row.source_signer_id,
+                quality_disposition=row.quality_disposition,
+                feature=feature,
+            )
+        )
+    return tuple(samples)
+
+
+def _source_corpus(path: Path) -> dict[str, object]:
+    try:
+        payload = cast(dict[str, object], parse_json_object(path.read_bytes()))
+        claimed = payload.get("corpus_sha256")
+        unhashed = dict(payload)
+        unhashed.pop("corpus_sha256", None)
+        if (
+            payload.get("format") != "signlab-public-corpus/1"
+            or claimed != _SOURCE_CORPUS_SHA256
+            or canonical_sha256(unhashed, domain="signlab-public-corpus/1") != claimed
+        ):
+            raise ValueError
+        return payload
+    except (CanonicalizationError, OSError, ValueError) as error:
+        raise PublicCorpusSplitError("source public corpus identity does not match") from error
+
+
+def _attempt_inventory(root: Path) -> tuple[tuple[_Attempt, ...], str]:
+    try:
+        paths = tuple(sorted(root.resolve(strict=True).rglob("*.parquet")))
+        artifacts: list[_Attempt] = []
+        items: list[dict[str, object]] = []
+        for path in paths:
+            if path.is_symlink() or not path.is_file() or len(path.stem) != 64:
+                raise ValueError
+            int(path.stem, 16)
+            captured = path.read_bytes()
+            content_sha256 = f"sha256:{path.stem}"
+            parquet_sha256 = f"sha256:{hashlib.sha256(captured).hexdigest()}"
+            row_count = pq.ParquetFile(pa.BufferReader(captured)).metadata.num_rows
+            artifacts.append(
+                _Attempt(path, content_sha256, parquet_sha256, len(captured), row_count)
+            )
+            items.append(
+                {
+                    "content_sha256": content_sha256,
+                    "parquet_sha256": parquet_sha256,
+                    "row_count": row_count,
+                    "size_bytes": len(captured),
+                }
+            )
+        digest = canonical_sha256({"items": items}, domain=_INVENTORY_DOMAIN)
+    except (OSError, pa.ArrowException, TypeError, ValueError) as error:
+        raise PublicCorpusSplitError("attempt landmark inventory is invalid") from error
+    if len(artifacts) != _ATTEMPT_COUNT or digest != _ATTEMPT_INVENTORY_SHA256:
+        raise PublicCorpusSplitError("attempt landmark inventory identity does not match")
+    return tuple(artifacts), digest
+
+
+def _select_candidates(
+    candidates: Sequence[PublicSelectionCandidate],
+) -> tuple[PublicSelectionCandidate, ...]:
+    grouped: dict[tuple[ExternalSplit, ExternalTargetLabel], list[PublicSelectionCandidate]] = (
+        defaultdict(list)
+    )
+    for candidate in candidates:
+        grouped[(candidate.source_split, candidate.target_label_id)].append(candidate)
+    expected = {(source_split, target) for source_split in _QUOTAS for target in _TARGETS}
+    if set(grouped) != expected:
+        raise PublicCorpusSplitError("usable attempts do not cover every split-target group")
+    selected: list[PublicSelectionCandidate] = []
+    for source_split in ("train", "val", "test"):
+        for target in _TARGETS:
+            group: list[PublicSelectionCandidate] = []
+            signers: set[str] = set()
+            for candidate in sorted(
+                grouped[(source_split, target)], key=lambda item: item.sample_id
+            ):
+                if candidate.source_signer_id in signers:
+                    continue
+                signers.add(candidate.source_signer_id)
+                group.append(candidate)
+                if len(group) == _QUOTAS[source_split]:
+                    break
+            if len(group) != _QUOTAS[source_split]:
+                raise PublicCorpusSplitError("usable attempts cannot meet an exact quota")
+            selected.extend(group)
+    return tuple(selected)
+
+
+def _evaluate_attempts(
+    artifacts: Sequence[_Attempt],
+    media_by_recording: Mapping[str, ExternalMediaRecordV1],
+    policy: LandmarkQualityPolicyV1,
+    progress: Callable[[int, int], None] | None,
+) -> tuple[tuple[_UsableAttempt, ...], Counter[str]]:
+    usable: list[_UsableAttempt] = []
+    outcomes: Counter[str] = Counter()
+    seen: set[str] = set()
+    with tempfile.TemporaryDirectory(prefix="signlab-popsign-window-") as scratch_name:
+        scratch = Path(scratch_name) / "window.parquet"
+        for index, artifact in enumerate(artifacts, start=1):
+            table = read_landmark_frames(
+                artifact.path,
+                expected_size_bytes=artifact.size_bytes,
+                expected_sha256=artifact.parquet_sha256,
+                expected_content_sha256=artifact.content_sha256,
+                expected_row_count=artifact.row_count,
+            )
+            window = select_popsign_window(table)
+            recording_id = table.rows[0].source_recording_id
+            media = media_by_recording.get(recording_id)
+            if media is None or recording_id in seen:
+                raise PublicCorpusSplitError("attempt recording identity is invalid")
+            seen.add(recording_id)
+            if not window.selected:
+                outcomes["no_window"] += 1
+            else:
+                windowed = materialize_popsign_window(table, window)
+                parquet = write_landmark_frames(windowed, scratch)
+                quality = assess_landmark_source(
+                    windowed,
+                    policy,
+                    source_recording_id=recording_id,
+                    source_sequence_content_sha256=parquet.content_sha256,
+                    source_landmark_parquet_sha256=parquet.sha256,
+                    declared_duration_us=_duration_us(windowed.rows),
+                    expected_hand_count=1,
+                )
+                outcomes[quality.disposition] += 1
+                if quality.disposition in {"pass", "warning"}:
+                    if quality.metrics.timestamp_discontinuity_count:
+                        raise PublicCorpusSplitError("usable attempt is not feature-ready")
+                    candidate = PublicSelectionCandidate(
+                        media.sample_id,
+                        media.recording_id,
+                        media.participant_id,
+                        media.source_split,
+                        media.target_label_id,
+                        quality.disposition,
+                    )
+                    usable.append(_UsableAttempt(candidate, artifact, media, window))
+            if progress is not None:
+                progress(index, len(artifacts))
+    return tuple(usable), outcomes
+
+
+def _materialize_assignment(
+    attempt: _UsableAttempt,
+    destination: Path,
+    scratch: Path,
+    policy: LandmarkQualityPolicyV1,
+    feature_plan: LandmarkFeaturePlanV1,
+    extraction_config_sha256: str,
+) -> PublicSplitAssignmentV1:
+    artifact = attempt.artifact
+    table = read_landmark_frames(
+        artifact.path,
+        expected_size_bytes=artifact.size_bytes,
+        expected_sha256=artifact.parquet_sha256,
+        expected_content_sha256=artifact.content_sha256,
+        expected_row_count=artifact.row_count,
+    )
+    window = select_popsign_window(table)
+    if window != attempt.window:
+        raise PublicCorpusSplitError("active window changed during materialization")
+    windowed = materialize_popsign_window(table, window)
+    content_sha256 = landmark_frames_table_digest(windowed)
+    parquet = write_landmark_frames(windowed, scratch)
+    quality = assess_landmark_source(
+        windowed,
+        policy,
+        source_recording_id=attempt.media.recording_id,
+        source_sequence_content_sha256=content_sha256,
+        source_landmark_parquet_sha256=parquet.sha256,
+        declared_duration_us=_duration_us(windowed.rows),
+        expected_hand_count=1,
+    )
+    if quality.disposition != attempt.candidate.quality_disposition:
+        raise PublicCorpusSplitError("quality result changed during materialization")
+    feature = derive_feature_source(
+        windowed,
+        quality,
+        feature_plan,
+        source_recording_id=attempt.media.recording_id,
+        source_media_sha256=attempt.media.sha256,
+        source_landmarks_sha256=content_sha256,
+        source_landmark_parquet_sha256=parquet.sha256,
+        source_mirror_state=_SOURCE_MIRROR_STATE,
+        extraction_config_sha256=extraction_config_sha256,
+    )
+    feature_path = _content_path(destination, "features", feature.sequence_sha256, ".json")
+    _write_bytes(feature_path, canonical_json_bytes(feature) + b"\n")
+    return PublicSplitAssignmentV1(
+        sample_id=attempt.media.sample_id,
+        source_recording_id=attempt.media.recording_id,
+        source_signer_id=attempt.media.participant_id,
+        source_split=attempt.media.source_split,
+        partition=_PARTITION_BY_SOURCE[attempt.media.source_split],
+        target_label_id=attempt.media.target_label_id,
+        quality_disposition=quality.disposition,
+        feature_sequence_sha256=feature.sequence_sha256,
+        feature_path=feature_path.relative_to(destination).as_posix(),
+    )
+
+
+def _summary_markdown(summary: Mapping[str, object]) -> str:
+    return "\n".join(
+        (
+            "# Frozen PopSign smoke split",
+            "",
+            "The immutable 750-attempt landmark inventory was replayed without MediaPipe.",
+            "One label-blind window rule and one offline selection rule produced the exact",
+            "feature-ready 50 train / 15 validation / 15 test split.",
+            "",
+            "| Result | Count |",
+            "| --- | ---: |",
+            f"| Pass | {summary['pass_count']} |",
+            f"| Warning | {summary['warning_count']} |",
+            f"| Quarantine | {summary['quarantine_count']} |",
+            f"| No safe window | {summary['no_window_count']} |",
+            f"| Usable | {summary['usable_count']} |",
+            f"| Selected | {summary['selected_count']} |",
+            "",
+            f"- Source corpus: `{summary['source_corpus_sha256']}`",
+            f"- Attempt inventory: `{summary['attempt_inventory_sha256']}`",
+            f"- Frozen split: `{summary['split_sha256']}`",
+            f"- Selection rule: `{summary['selection_rule']}`",
+            "- MediaPipe executions: 0",
+            "",
+            "Pass and warning rows were equally eligible; quality was not used for ranking.",
+            "Signer uniqueness is enforced within each split/gesture group, and the official",
+            "PopSign signer-disjoint train, validation, and test assignments are preserved.",
+            "",
+            "This proves a bounded licensed isolated-sign data path, not model performance.",
+            "",
+        )
+    )
+
+
+def freeze_public_corpus_split(
+    external_manifest_path: str | Path,
+    *,
+    source_root: str | Path,
+    output_root: str | Path,
+    progress: Callable[[int, int], None] | None = None,
+) -> PublicCorpusSplitFreezeResult:
+    """Create and verify the exact split without rerunning MediaPipe."""
+
+    try:
+        source = Path(source_root).resolve(strict=True)
+        source_corpus = _source_corpus(source / "public-corpus.json")
+        manifest = validate_external_dataset_manifest(Path(external_manifest_path).read_bytes())
+        config_sha256 = mediapipe_extraction_config_digest(
+            load_packaged_default_extraction_config()
+        )
+        policy = load_packaged_default_quality_policy()
+        feature_plan = load_packaged_default_feature_plan("combined")
+        policy_sha256 = landmark_quality_policy_digest(policy)
+        feature_plan_sha256 = landmark_feature_plan_digest(feature_plan)
+        expected = (
+            ("external_dataset_sha256", manifest.content_sha256),
+            ("extraction_config_sha256", config_sha256),
+            ("quality_policy_sha256", policy_sha256),
+            ("feature_plan_sha256", feature_plan_sha256),
+        )
+        if any(source_corpus.get(field) != value for field, value in expected):
+            raise ValueError
+        media_by_recording = {row.recording_id: row for row in manifest.media}
+        if len(media_by_recording) != len(manifest.media):
+            raise ValueError
+    except (OSError, TypeError, ValueError) as error:
+        raise PublicCorpusSplitError("public split inputs could not be verified") from error
+
+    artifacts, inventory_sha256 = _attempt_inventory(source / "landmarks")
+    usable, outcomes = _evaluate_attempts(artifacts, media_by_recording, policy, progress)
+    observed = {key: outcomes[key] for key in _EXPECTED_REPLAY}
+    expected_usable = _EXPECTED_REPLAY["pass"] + _EXPECTED_REPLAY["warning"]
+    if observed != _EXPECTED_REPLAY or outcomes["reject"] or len(usable) != expected_usable:
+        raise PublicCorpusSplitError("window and quality replay changed from frozen evidence")
+    selected = _select_candidates(tuple(row.candidate for row in usable))
+    by_sample = {row.candidate.sample_id: row for row in usable}
+    destination = _fresh_output_root(output_root)
+    with tempfile.TemporaryDirectory(prefix="signlab-popsign-selected-") as scratch_name:
+        scratch = Path(scratch_name) / "window.parquet"
+        assignments = [
+            _materialize_assignment(
+                by_sample[candidate.sample_id],
+                destination,
+                scratch,
+                policy,
+                feature_plan,
+                config_sha256,
+            )
+            for candidate in selected
+        ]
+    assignments.sort(
+        key=lambda row: (_PARTITION_ORDER[row.partition], row.target_label_id, row.sample_id)
+    )
+    payload: dict[str, object] = {
+        "format": _FORMAT,
+        "split_id": "popsign-five-isolated-smoke-v1",
+        "version": "1.0.0",
+        "source_corpus_sha256": _SOURCE_CORPUS_SHA256,
+        "external_dataset_sha256": manifest.content_sha256,
+        "attempt_inventory_sha256": inventory_sha256,
+        "extraction_config_sha256": config_sha256,
+        "quality_policy_sha256": policy_sha256,
+        "feature_plan_id": feature_plan.plan_id,
+        "feature_plan_sha256": feature_plan_sha256,
+        "active_window_rule_id": POPSIGN_WINDOW_RULE_ID,
+        "selection_rule": _SELECTION_RULE,
+        "replay": {
+            "pass_count": outcomes["pass"],
+            "warning_count": outcomes["warning"],
+            "quarantine_count": outcomes["quarantine"],
+            "no_window_count": outcomes["no_window"],
+            "usable_count": len(usable),
+        },
+        "assignments": [row.model_dump(mode="json", round_trip=True) for row in assignments],
+    }
+    payload["split_sha256"] = public_corpus_split_digest(payload)
+    split = validate_public_corpus_split(payload)
+    _write_bytes(destination / "public-corpus-split.json", canonical_json_bytes(split) + b"\n")
+    summary: dict[str, object] = {
+        "format": "signlab-public-corpus-split-summary/1",
+        "source_corpus_sha256": _SOURCE_CORPUS_SHA256,
+        "attempt_inventory_sha256": inventory_sha256,
+        "split_sha256": split.split_sha256,
+        "selection_rule": _SELECTION_RULE,
+        "attempt_count": len(artifacts),
+        "pass_count": outcomes["pass"],
+        "warning_count": outcomes["warning"],
+        "quarantine_count": outcomes["quarantine"],
+        "no_window_count": outcomes["no_window"],
+        "usable_count": len(usable),
+        "selected_count": len(assignments),
+        "mediapipe_execution_count": 0,
+    }
+    _write_bytes(
+        destination / "public-corpus-split-summary.md",
+        _summary_markdown(summary).encode(),
+    )
+    reconciled = reconcile_public_corpus_split(
+        split.model_dump(mode="json"),
+        external_manifest_document=manifest,
+        corpus_root=destination,
+    )
+    if len(reconciled) != 80:
+        raise PublicCorpusSplitError("frozen public split did not reconcile")
+    return PublicCorpusSplitFreezeResult(
+        split_sha256=split.split_sha256,
+        attempt_count=len(artifacts),
+        pass_count=outcomes["pass"],
+        warning_count=outcomes["warning"],
+        quarantine_count=outcomes["quarantine"],
+        no_window_count=outcomes["no_window"],
+        selected_count=len(assignments),
+    )
+
+
+__all__ = [
+    "PublicCorpusSample",
+    "PublicCorpusSplitError",
+    "PublicCorpusSplitFreezeResult",
+    "PublicCorpusSplitV1",
+    "PublicSelectionCandidate",
+    "PublicSplitAssignmentV1",
+    "freeze_public_corpus_split",
+    "public_corpus_split_digest",
+    "reconcile_public_corpus_split",
+    "validate_public_corpus_split",
+]

--- a/tests/test_external_dataset_cli.py
+++ b/tests/test_external_dataset_cli.py
@@ -8,7 +8,7 @@ import pytest
 from typer.testing import CliRunner
 
 from signlab import cli
-from signlab.datasets import popsign, public_corpus
+from signlab.datasets import popsign, public_corpus, public_split
 
 
 @pytest.fixture
@@ -270,6 +270,59 @@ def test_build_public_corpus_delegates_and_reports_aggregate_progress(
     assert "Attempted videos: 2/750." in trainable.output
 
 
+def test_freeze_public_corpus_split_delegates_and_reports_only_aggregates(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = tmp_path / "private-manifest.json"
+    source_root = tmp_path / "private-source"
+    output = tmp_path / "private-output"
+    calls: list[tuple[Path, Path, Path]] = []
+
+    def freeze(
+        manifest_path: Path,
+        *,
+        source_root: Path,
+        output_root: Path,
+        progress: Callable[[int, int], None],
+    ) -> object:
+        calls.append((manifest_path, source_root, output_root))
+        progress(1, 750)
+        progress(750, 750)
+        return SimpleNamespace(
+            split_sha256="sha256:" + "f" * 64,
+            attempt_count=750,
+            pass_count=582,
+            warning_count=111,
+            quarantine_count=46,
+            no_window_count=11,
+            selected_count=80,
+        )
+
+    monkeypatch.setattr(public_split, "freeze_public_corpus_split", freeze)
+    result = runner.invoke(
+        cli.app,
+        [
+            "data",
+            "freeze-public-corpus-split",
+            str(manifest),
+            "--source-root",
+            str(source_root),
+            "--output",
+            str(output),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert calls == [(manifest, source_root, output)]
+    assert "Retained landmark replay: 1/750." in result.output
+    assert "Retained landmark replay: 750/750." in result.output
+    assert "Selected usable clips: 80/80." in result.output
+    assert "Partitions: 50 train, 15 validation, 15 test." in result.output
+    assert str(tmp_path) not in result.output
+
+
 @pytest.mark.parametrize(
     ("command", "expected"),
     [
@@ -321,6 +374,18 @@ def test_build_public_corpus_delegates_and_reports_aggregate_progress(
             ],
             "Public corpus build failed.",
         ),
+        (
+            [
+                "data",
+                "freeze-public-corpus-split",
+                "private-manifest.json",
+                "--source-root",
+                "private-source",
+                "--output",
+                "private-output",
+            ],
+            "Public corpus split freeze failed.",
+        ),
     ],
 )
 def test_external_dataset_commands_redact_private_failures(
@@ -339,6 +404,7 @@ def test_external_dataset_commands_redact_private_failures(
     monkeypatch.setattr(popsign, "import_popsign_v1_archives", fail)
     monkeypatch.setattr(popsign, "validate_external_dataset_bundle", fail)
     monkeypatch.setattr(public_corpus, "build_public_corpus", fail)
+    monkeypatch.setattr(public_split, "freeze_public_corpus_split", fail)
 
     result = runner.invoke(cli.app, command)
 

--- a/tests/test_public_split.py
+++ b/tests/test_public_split.py
@@ -1,0 +1,361 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import Counter
+from copy import deepcopy
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Literal
+
+import pytest
+
+from feature_fixtures import make_feature_fixture
+from signlab.contracts.canonical import canonical_json_bytes, canonical_sha256
+from signlab.contracts.core import WorkspaceRelativeLocatorV1
+from signlab.contracts.external_dataset import (
+    ExternalMediaRecordV1,
+    ExternalSplit,
+    ExternalTargetLabel,
+)
+from signlab.contracts.extraction import (
+    LandmarkFramesTableV1,
+    landmark_frames_table_digest,
+    mediapipe_extraction_config_digest,
+)
+from signlab.contracts.features import landmark_feature_plan_digest
+from signlab.contracts.quality import landmark_quality_policy_digest
+from signlab.datasets import public_split
+from signlab.extraction.parquet import write_landmark_frames
+from signlab.extraction.resources import load_packaged_default_extraction_config
+from signlab.features.resources import load_packaged_default_feature_plan
+from signlab.quality.resources import load_packaged_default_quality_policy
+
+_TARGETS: tuple[ExternalTargetLabel, ...] = ("hello", "no", "please", "thank_you", "yes")
+_QUOTAS: dict[ExternalSplit, int] = {"train": 10, "val": 3, "test": 3}
+
+
+def _candidate(
+    index: int,
+    *,
+    source_split: ExternalSplit,
+    target: ExternalTargetLabel,
+    signer: int,
+    disposition: Literal["pass", "warning"] = "pass",
+) -> public_split.PublicSelectionCandidate:
+    return public_split.PublicSelectionCandidate(
+        sample_id=f"sample_{index:032x}",
+        source_recording_id=f"recording_{index:032x}",
+        source_signer_id=f"participant_{signer:032x}",
+        source_split=source_split,
+        target_label_id=target,
+        quality_disposition=disposition,
+    )
+
+
+def test_offline_selector_is_exact_order_independent_and_quality_rank_blind() -> None:
+    candidates: list[public_split.PublicSelectionCandidate] = []
+    index = 1
+    warning_id = ""
+    for split_index, (source_split, quota) in enumerate(_QUOTAS.items()):
+        for target in _TARGETS:
+            for position in range(quota):
+                disposition: Literal["pass", "warning"] = "warning" if index == 1 else "pass"
+                candidate = _candidate(
+                    index,
+                    source_split=source_split,
+                    target=target,
+                    signer=split_index * 100 + position,
+                    disposition=disposition,
+                )
+                if disposition == "warning":
+                    warning_id = candidate.sample_id
+                candidates.append(candidate)
+                index += 1
+                if position == 0:
+                    candidates.append(
+                        _candidate(
+                            index,
+                            source_split=source_split,
+                            target=target,
+                            signer=split_index * 100,
+                        )
+                    )
+                    index += 1
+
+    first = public_split._select_candidates(candidates)
+    second = public_split._select_candidates(tuple(reversed(candidates)))
+
+    assert first == second
+    assert len(first) == 80
+    assert warning_id in {row.sample_id for row in first}
+    assert Counter(row.source_split for row in first) == {"train": 50, "val": 15, "test": 15}
+    assert Counter(row.target_label_id for row in first) == {target: 16 for target in _TARGETS}
+    assert Counter((row.source_split, row.target_label_id) for row in first) == {
+        (source_split, target): quota
+        for source_split, quota in _QUOTAS.items()
+        for target in _TARGETS
+    }
+
+
+def _with_recording_id(table: LandmarkFramesTableV1, recording_id: str) -> LandmarkFramesTableV1:
+    payload = table.model_dump(mode="json", round_trip=True)
+    for row in payload["rows"]:
+        row["source_recording_id"] = recording_id
+    return LandmarkFramesTableV1.model_validate_json(canonical_json_bytes(payload), strict=True)
+
+
+def _synthetic_source(source: Path) -> tuple[tuple[ExternalMediaRecordV1, ...], str]:
+    base = make_feature_fixture().table
+    stored: list[tuple[Path, dict[str, object]]] = []
+    media: list[ExternalMediaRecordV1] = []
+    index = 1
+    split_offset: dict[ExternalSplit, int] = {"train": 100, "val": 200, "test": 300}
+    for source_split, quota in _QUOTAS.items():
+        for target in _TARGETS:
+            for position in range(quota):
+                recording_id = f"recording_{index:032x}"
+                table = _with_recording_id(base, recording_id)
+                content_sha256 = landmark_frames_table_digest(table)
+                value = content_sha256.removeprefix("sha256:")
+                path = source / "landmarks" / "sha256" / value[:2] / f"{value}.parquet"
+                written = write_landmark_frames(table, path)
+                stored.append(
+                    (
+                        path,
+                        {
+                            "content_sha256": content_sha256,
+                            "parquet_sha256": written.sha256,
+                            "row_count": written.row_count,
+                            "size_bytes": written.size_bytes,
+                        },
+                    )
+                )
+                media_bytes = f"media-{index}".encode()
+                media_sha256 = f"sha256:{hashlib.sha256(media_bytes).hexdigest()}"
+                media_value = media_sha256.removeprefix("sha256:")
+                media.append(
+                    ExternalMediaRecordV1(
+                        schema_version="external-media-record/1",
+                        sample_id=f"sample_{index:032x}",
+                        recording_id=recording_id,
+                        participant_id=(
+                            f"participant_{split_offset[source_split] + position:032x}"
+                        ),
+                        archive_id=f"fixture_{source_split}_{target}",
+                        source_member_fingerprint=(
+                            f"sha256:{hashlib.sha256(f'fingerprint-{index}'.encode()).hexdigest()}"
+                        ),
+                        category="game",
+                        source_split=source_split,
+                        source_label=target.replace("_", "-"),
+                        target_label_id=target,
+                        media_type="video/mp4",
+                        sha256=media_sha256,
+                        size_bytes=len(media_bytes),
+                        locator=WorkspaceRelativeLocatorV1(
+                            kind="workspace_relative",
+                            path=f"media/sha256/{media_value[:2]}/{media_value}.mp4",
+                        ),
+                        eligible_for_extraction=True,
+                    )
+                )
+                index += 1
+    items = [item for _path, item in sorted(stored, key=lambda pair: pair[0])]
+    inventory_sha256 = canonical_sha256(
+        {"items": items},
+        domain="signlab.popsign.quality-diagnostic.landmark-inventory/1",
+    )
+    return tuple(media), inventory_sha256
+
+
+def test_freeze_is_deterministic_reconciled_and_rejects_contamination(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    media, inventory_sha256 = _synthetic_source(source)
+    external_sha256 = "sha256:" + "d" * 64
+    config_sha256 = mediapipe_extraction_config_digest(load_packaged_default_extraction_config())
+    policy_sha256 = landmark_quality_policy_digest(load_packaged_default_quality_policy())
+    feature_sha256 = landmark_feature_plan_digest(load_packaged_default_feature_plan("combined"))
+    monkeypatch.setattr(public_split, "_ATTEMPT_COUNT", 80)
+    monkeypatch.setattr(public_split, "_ATTEMPT_INVENTORY_SHA256", inventory_sha256)
+    monkeypatch.setattr(
+        public_split,
+        "_EXPECTED_REPLAY",
+        {"no_window": 0, "pass": 80, "quarantine": 0, "warning": 0},
+    )
+    monkeypatch.setattr(
+        public_split,
+        "_source_corpus",
+        lambda _path: {
+            "external_dataset_sha256": external_sha256,
+            "extraction_config_sha256": config_sha256,
+            "quality_policy_sha256": policy_sha256,
+            "feature_plan_sha256": feature_sha256,
+        },
+    )
+    monkeypatch.setattr(
+        public_split,
+        "validate_external_dataset_manifest",
+        lambda _document: SimpleNamespace(content_sha256=external_sha256, media=media),
+    )
+    manifest = tmp_path / "external.json"
+    manifest.write_text("{}", encoding="utf-8")
+    first_root = tmp_path / "first"
+    second_root = tmp_path / "second"
+
+    first = public_split.freeze_public_corpus_split(
+        manifest, source_root=source, output_root=first_root
+    )
+    second = public_split.freeze_public_corpus_split(
+        manifest, source_root=source, output_root=second_root
+    )
+
+    first_document = (first_root / "public-corpus-split.json").read_bytes()
+    assert first.split_sha256 == second.split_sha256
+    assert first_document == (second_root / "public-corpus-split.json").read_bytes()
+    assert (first_root / "public-corpus-split-summary.md").read_bytes() == (
+        second_root / "public-corpus-split-summary.md"
+    ).read_bytes()
+    samples = public_split.reconcile_public_corpus_split(
+        first_document,
+        external_manifest_document=b"{}",
+        corpus_root=first_root,
+    )
+    assert Counter(row.partition for row in samples) == {
+        "train": 50,
+        "validation": 15,
+        "test": 15,
+    }
+
+    original = json.loads(first_document)
+
+    replay_drift = deepcopy(original)
+    replay_drift["replay"]["usable_count"] = 79
+    replay_drift["split_sha256"] = public_split.public_corpus_split_digest(replay_drift)
+
+    partition_drift = deepcopy(original)
+    partition_drift["assignments"][0]["partition"] = "validation"
+    partition_drift["split_sha256"] = public_split.public_corpus_split_digest(partition_drift)
+
+    order_drift = deepcopy(original)
+    order_drift["assignments"][0], order_drift["assignments"][1] = (
+        order_drift["assignments"][1],
+        order_drift["assignments"][0],
+    )
+    order_drift["split_sha256"] = public_split.public_corpus_split_digest(order_drift)
+
+    quota_drift = deepcopy(original)
+    moved = quota_drift["assignments"].pop(0)
+    moved["target_label_id"] = "no"
+    quota_drift["assignments"].insert(9, moved)
+    quota_drift["split_sha256"] = public_split.public_corpus_split_digest(quota_drift)
+
+    signer_drift = deepcopy(original)
+    signer_drift["assignments"][1]["source_signer_id"] = signer_drift["assignments"][0][
+        "source_signer_id"
+    ]
+    signer_drift["split_sha256"] = public_split.public_corpus_split_digest(signer_drift)
+
+    digest_drift = deepcopy(original)
+    digest_drift["split_sha256"] = "sha256:" + "0" * 64
+
+    for drifted in (
+        replay_drift,
+        partition_drift,
+        order_drift,
+        quota_drift,
+        signer_drift,
+        digest_drift,
+    ):
+        with pytest.raises(public_split.PublicCorpusSplitError):
+            public_split.validate_public_corpus_split(drifted)
+
+    with pytest.raises(public_split.PublicCorpusSplitError):
+        public_split._select_candidates(
+            [_candidate(1, source_split="train", target="hello", signer=1)]
+        )
+    one_candidate_per_group = [
+        _candidate(index, source_split=source_split, target=target, signer=index)
+        for index, (source_split, target) in enumerate(
+            ((source_split, target) for source_split in _QUOTAS for target in _TARGETS),
+            start=1,
+        )
+    ]
+    with pytest.raises(public_split.PublicCorpusSplitError):
+        public_split._select_candidates(one_candidate_per_group)
+
+    with pytest.raises(public_split.PublicCorpusSplitError):
+        public_split._resolve_artifact(tmp_path, "missing.json")
+    directory = tmp_path / "directory"
+    directory.mkdir()
+    with pytest.raises(public_split.PublicCorpusSplitError):
+        public_split._resolve_artifact(tmp_path, directory.name)
+
+    train = next(row for row in original["assignments"] if row["partition"] == "train")
+    validation_index = next(
+        index
+        for index, row in enumerate(original["assignments"])
+        if row["partition"] == "validation"
+    )
+    for field in ("source_signer_id", "source_recording_id", "feature_sequence_sha256"):
+        contaminated = deepcopy(original)
+        row = contaminated["assignments"][validation_index]
+        row[field] = train[field]
+        if field == "feature_sequence_sha256":
+            row["feature_path"] = train["feature_path"]
+        contaminated["split_sha256"] = public_split.public_corpus_split_digest(contaminated)
+        with pytest.raises(public_split.PublicCorpusSplitError):
+            public_split.validate_public_corpus_split(contaminated)
+
+    metadata_drift = deepcopy(original)
+    left = metadata_drift["assignments"][0]
+    right = metadata_drift["assignments"][validation_index]
+    for field in ("source_recording_id", "feature_sequence_sha256", "feature_path"):
+        left[field], right[field] = right[field], left[field]
+    metadata_drift["split_sha256"] = public_split.public_corpus_split_digest(metadata_drift)
+    public_split.validate_public_corpus_split(metadata_drift)
+    with pytest.raises(public_split.PublicCorpusSplitError):
+        public_split.reconcile_public_corpus_split(
+            metadata_drift,
+            external_manifest_document=b"{}",
+            corpus_root=first_root,
+        )
+
+    lineage_drift = deepcopy(original)
+    lineage_drift["extraction_config_sha256"] = "sha256:" + "c" * 64
+    lineage_drift["split_sha256"] = public_split.public_corpus_split_digest(lineage_drift)
+    public_split.validate_public_corpus_split(lineage_drift)
+    with pytest.raises(public_split.PublicCorpusSplitError):
+        public_split.reconcile_public_corpus_split(
+            lineage_drift,
+            external_manifest_document=b"{}",
+            corpus_root=first_root,
+        )
+
+    unsafe_path = deepcopy(original)
+    unsafe_path["assignments"][0]["feature_path"] = "../escaped.json"
+    unsafe_path["split_sha256"] = public_split.public_corpus_split_digest(unsafe_path)
+    with pytest.raises(public_split.PublicCorpusSplitError):
+        public_split.validate_public_corpus_split(unsafe_path)
+
+    feature_path = first_root.joinpath(*original["assignments"][0]["feature_path"].split("/"))
+    feature_path.write_bytes(feature_path.read_bytes() + b"tampered")
+    with pytest.raises(public_split.PublicCorpusSplitError):
+        public_split.reconcile_public_corpus_split(
+            first_document,
+            external_manifest_document=b"{}",
+            corpus_root=first_root,
+        )
+
+    source_parquet = next((source / "landmarks").rglob("*.parquet"))
+    source_parquet.write_bytes(source_parquet.read_bytes() + b"tampered")
+    rejected_output = tmp_path / "rejected"
+    with pytest.raises(public_split.PublicCorpusSplitError):
+        public_split.freeze_public_corpus_split(
+            manifest, source_root=source, output_root=rejected_output
+        )
+    assert not rejected_output.exists()


### PR DESCRIPTION
Closes #25

## Summary

- Verify the pinned 750-attempt landmark inventory and replay the fixed #83 active-window and quality rules without rerunning MediaPipe.
- Apply the one documented offline rule: stable sample order, first distinct signer per official split/target group, with pass and warning equally eligible.
- Materialize exactly 80 content-addressed feature records and one canonical hashed split manifest: 50 train, 15 validation, and 15 test.
- Add the read-only loader/validator needed by #24, including external-manifest and feature-lineage reconciliation.
- Reject quota drift, signer crossings, repeated recordings/features, metadata swaps, unsafe paths, changed feature bytes, policy/config drift, and source-inventory tampering.
- Publish aggregate evidence while keeping licensed identities and feature artifacts outside Git.

## Verification

- Replayed all 750 retained landmark files: 582 pass, 111 warning, 46 quarantine, 11 no safe window; 693 usable.
- Selected 80/80 with exact 10/3/3 quotas for each of five targets.
- Result: 50 train, 15 validation, 15 test; 40 distinct signers; 72 pass and 8 warning.
- Zero cross-partition signers, repeated recordings, or repeated feature identities.
- Two fresh real-data freezes produced the same 82 files and 14,887,227 bytes, with zero path, SHA-256, or size differences.
- Frozen split: `sha256:673c777c67e47715127b75f2bf18aaa794a15e1604458d30da164ec7f90ead20`.
- Read-only reconciliation passed for all 80 assignments.
- Full suite: 1,325 passed, 13 platform-only skips; 90.08% coverage.
- Ruff formatting/checks and mypy passed.
- Independent code/scope review found no release blockers.

Aggregate evidence: `docs/reports/popsign-frozen-smoke-split-v1.md`

## Deliberately out of scope

- No MediaPipe rerun, new videos, or candidates outside the fixed 750.
- No random, optimized, or quality-ranked split selection.
- No generalized split framework or participant split-contract changes.
- No training, model evaluation, MLflow, API, UI, production DVC, or performance claim.
