### PR TITLE
feat(experiments): add local MLflow lineage ledger

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,8 +181,9 @@ PopSign execution now produces one deterministic, leakage-checked 80-sample publ
 smoke split from the verified retained landmark inventory without rerunning MediaPipe.
 A responsive React/Vite shell now exposes the planned public routes without a backend;
 camera access, replay, feedback storage, and model inference remain explicitly
-unconnected. Baseline experiment loading and evaluation remain the next research
-bridge.
+unconnected. A minimal local MLflow ledger can now log, query, and byte-verify one
+portable baseline result without a server or custom dashboard. Baseline training and
+evaluation remain the next research bridge.
 The registered DVC graph remains the Story #14 fixture receipt scaffold rather
 than a production extraction runner. No headline model result is considered valid
 until the remaining licensed-corpus and grouped-evaluation foundations are complete.

--- a/docs/data-versioning.md
+++ b/docs/data-versioning.md
@@ -195,7 +195,10 @@ uv run --locked signlab data capture-reproduction-snapshot \
 ```
 
 `dvc_experiment_metadata()` exposes the commit, DVC lock/snapshot identities, and
-per-stage hashes as tracker-neutral strings. Story #27 is responsible for recording
-that mapping on an actual experiment run together with dataset, split,
-preprocessing, environment, seed, hardware, metrics, and artifact metadata. Story
-#14 does not select or integrate the tracker.
+per-stage hashes as tracker-neutral strings for a run actually governed by that DVC
+snapshot. The minimal Story #27 ledger records the explicit corpus, split, feature,
+configuration, code, environment, seed, hardware, metric, and artifact identities
+used by the licensed public baseline. It deliberately does not claim that the
+fixture-only DVC snapshot governs that separate corpus. A future DVC-backed run must
+carry the tracker-neutral DVC mapping in its portable configuration/report before
+logging it. Story #14 does not select or integrate the tracker.

--- a/docs/development.md
+++ b/docs/development.md
@@ -41,6 +41,11 @@ workflow installs all extras so Linux and Windows exercise that boundary; consum
 that do not extract video can install the base wheel. The future browser runtime is
 separately pinned to `@mediapipe/tasks-vision@1.0.1` by the extraction contract.
 
+The local experiment ledger is a separate optional `experiments` extra. It contains
+the tracking-only MLflow package and exact SQLite support pins, not the MLflow
+server, model registry, dashboard, or training libraries. Importing the SignLab CLI
+does not load MLflow.
+
 The browser application is an independent npm project under `apps/web/`. Node.js
 24.20.0 LTS and npm 11.19.0 are pinned through `.node-version`, `package.json`, and the
 committed npm lockfile. It does not share dependencies or runtime state with the
@@ -85,6 +90,27 @@ configured `/signlab/` subpath. Hash-based routes keep every page usable on a pl
 static host without rewrite rules. Story #38 provides the responsive, honest shell
 only: it does not request camera access, load a model, process replay inputs, save
 feedback, or call a backend.
+
+## Local experiment ledger
+
+Install the optional tracker and run its single end-to-end proof with:
+
+```shell
+uv sync --locked --extra experiments
+uv run --locked --extra experiments pytest tests/test_experiment_tracking.py --no-cov
+```
+
+`log_reference_run()` is the one small interface that the baseline in Story #24
+calls after it has produced a configuration, concise JSON report, confusion matrix,
+and per-example predictions. It records those four files plus a portable lineage
+file, and `verify_reference_run()` finds the run and re-hashes every referenced
+artifact. Training remains outside the tracker.
+
+The sole store setting is `SIGNLAB_MLFLOW_TRACKING_URI`, defaulting to
+`sqlite:///runs/mlflow.sqlite`. Only persistent local SQLite URIs are accepted. The
+adapter derives a local `mlflow-artifacts` directory beside that database, disables
+MLflow telemetry before loading the optional dependency, and never starts a server
+or requires a live service. Both generated locations are ignored by Git.
 
 Before a pull request:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,11 @@ extraction = [
   "av==18.1.0",
   "mediapipe==1.0.1",
 ]
+experiments = [
+  "alembic==1.19.1",
+  "mlflow-skinny==3.15.2",
+  "SQLAlchemy==2.0.52",
+]
 
 [project.urls]
 Homepage = "https://github.com/peterbucci/signlab"

--- a/src/signlab/experiments/__init__.py
+++ b/src/signlab/experiments/__init__.py
@@ -1,0 +1,1 @@
+"""Optional, UI-independent experiment utilities."""

--- a/src/signlab/experiments/tracking.py
+++ b/src/signlab/experiments/tracking.py
@@ -1,0 +1,376 @@
+"""One-run local MLflow ledger used by the first baseline story."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import json
+import os
+import platform
+import re
+from collections.abc import Mapping
+from contextlib import suppress
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any, Final, Self, cast
+
+from pydantic import Field, model_validator
+
+from signlab import __version__
+from signlab.contracts.canonical import canonical_json_bytes, parse_json_object
+from signlab.contracts.core import (
+    DottedId,
+    FiniteFloat,
+    GitCommit,
+    ParameterScalar,
+    SafeInteger,
+    StableId,
+    StrictContractModel,
+)
+from signlab.contracts.taxonomy import Sha256Digest
+
+DEFAULT_TRACKING_URI: Final = "sqlite:///runs/mlflow.sqlite"
+TRACKING_URI_ENV: Final = "SIGNLAB_MLFLOW_TRACKING_URI"
+EXPERIMENT_NAME: Final = "signlab-reference-baselines"
+LINEAGE_FORMAT: Final = "signlab-baseline-lineage/1"
+_ARTIFACT_PATHS: Final = {
+    "configuration.json": "configuration_path",
+    "report.json": "report_path",
+    "confusion-matrix.json": "confusion_matrix_path",
+    "predictions.csv": "predictions_path",
+}
+_RUN_ID = re.compile(r"^[0-9a-f]{32}$")
+_ARTIFACT_ERROR = "reference-run artifacts are unavailable or invalid"
+_DEPENDENCY_ERROR = "install the SignLab experiments extra to use tracking"
+_LEDGER_ERROR = "the local experiment ledger operation failed"
+_RUN_ERROR = "the tracked reference run is unavailable or invalid"
+_URI_ERROR = "tracking URI must identify a persistent local SQLite file"
+_VERIFICATION_ERROR = "reference-run artifact verification failed"
+
+
+class ExperimentTrackingError(ValueError):
+    """A stable, path-free failure from the optional experiment boundary."""
+
+
+class ReferenceRunInput(StrictContractModel):
+    """The exact small input that Story #24 supplies after evaluating its baselines."""
+
+    run_name: StableId
+    git_commit: GitCommit
+    git_dirty: bool
+    corpus_sha256: Sha256Digest
+    split_sha256: Sha256Digest
+    feature_plan_sha256: Sha256Digest
+    seed: SafeInteger
+    parameters: dict[DottedId, ParameterScalar] = Field(min_length=1, max_length=256)
+    metrics: dict[DottedId, FiniteFloat] = Field(min_length=1, max_length=256)
+    configuration_path: Path
+    report_path: Path
+    confusion_matrix_path: Path
+    predictions_path: Path
+
+    @model_validator(mode="after")
+    def _reserve_seed_parameter(self) -> Self:
+        if "seed" in self.parameters:
+            raise ValueError("seed is a dedicated reference-run field")
+        return self
+
+
+class ReferenceRunReceipt(StrictContractModel):
+    """Small tracker-neutral result returned after logging or verification."""
+
+    run_id: str = Field(pattern=r"^[0-9a-f]{32}$")
+    experiment_id: str = Field(min_length=1, max_length=64)
+    artifact_sha256: dict[str, Sha256Digest]
+
+
+def _sha256(payload: bytes) -> str:
+    return f"sha256:{hashlib.sha256(payload).hexdigest()}"
+
+
+def _local_store(raw_uri: str) -> tuple[str, str]:
+    prefix = "sqlite:///"
+    if not raw_uri.startswith(prefix):
+        raise ExperimentTrackingError(_URI_ERROR)
+    database_text = raw_uri.removeprefix(prefix)
+    if (
+        not database_text
+        or database_text == ":memory:"
+        or any(character in database_text for character in ("?", "#", "%", "\\"))
+    ):
+        raise ExperimentTrackingError(_URI_ERROR)
+    database = Path(database_text)
+    if not database.is_absolute():
+        database = Path.cwd() / database
+    try:
+        database = database.resolve()
+        database.parent.mkdir(parents=True, exist_ok=True)
+        artifact_root = database.parent / "mlflow-artifacts"
+        artifact_root.mkdir(parents=True, exist_ok=True)
+    except OSError as error:
+        raise ExperimentTrackingError(_URI_ERROR) from error
+    return f"{prefix}{database.as_posix()}", artifact_root.resolve().as_uri()
+
+
+def _mlflow_client(tracking_uri: str) -> Any:
+    os.environ["MLFLOW_DISABLE_TELEMETRY"] = "true"
+    try:
+        mlflow = importlib.import_module("mlflow")
+    except (ImportError, ModuleNotFoundError) as error:
+        raise ExperimentTrackingError(_DEPENDENCY_ERROR) from error
+    try:
+        return mlflow.MlflowClient(tracking_uri=tracking_uri)
+    except Exception as error:
+        raise ExperimentTrackingError(_LEDGER_ERROR) from error
+
+
+def _artifact_payloads(run: ReferenceRunInput) -> dict[str, bytes]:
+    payloads: dict[str, bytes] = {}
+    try:
+        for logical_name, field_name in _ARTIFACT_PATHS.items():
+            path = getattr(run, field_name)
+            if not path.is_file():
+                raise OSError
+            payload = path.read_bytes()
+            if not payload or b"\0" in payload:
+                raise OSError
+            payloads[logical_name] = payload
+    except OSError as error:
+        raise ExperimentTrackingError(_ARTIFACT_ERROR) from error
+    return payloads
+
+
+def _parameter_text(value: object) -> str:
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, ensure_ascii=True, separators=(",", ":"))
+
+
+def _runtime_identity() -> tuple[dict[str, str], dict[str, str | int]]:
+    os_family = {"darwin": "macos"}.get(platform.system().casefold(), platform.system().casefold())
+    environment = {
+        "signlab_version": __version__,
+        "python_version": platform.python_version(),
+        "os_family": os_family or "unknown",
+    }
+    hardware: dict[str, str | int] = {
+        "architecture": platform.machine().casefold() or "unknown",
+        "logical_cpu_count": os.cpu_count() or 0,
+    }
+    return environment, hardware
+
+
+def _lineage_document(
+    run: ReferenceRunInput,
+    payloads: dict[str, bytes],
+) -> tuple[dict[str, object], dict[str, str]]:
+    environment, hardware = _runtime_identity()
+    artifact_sha256 = {name: _sha256(payload) for name, payload in sorted(payloads.items())}
+    document: dict[str, object] = {
+        "format": LINEAGE_FORMAT,
+        "run_name": run.run_name,
+        "source": {"git_commit": run.git_commit, "git_dirty": run.git_dirty},
+        "identities": {
+            "configuration_sha256": artifact_sha256["configuration.json"],
+            "corpus_sha256": run.corpus_sha256,
+            "feature_plan_sha256": run.feature_plan_sha256,
+            "split_sha256": run.split_sha256,
+        },
+        "seed": run.seed,
+        "environment": environment,
+        "hardware": hardware,
+        "parameters": dict(sorted(run.parameters.items())),
+        "metrics": dict(sorted(run.metrics.items())),
+        "artifact_sha256": artifact_sha256,
+    }
+    return document, artifact_sha256
+
+
+def _tracking_values(
+    lineage: Mapping[str, object],
+    lineage_sha256: str,
+) -> tuple[dict[str, str], dict[str, str], dict[str, float]]:
+    source = lineage.get("source")
+    identities = lineage.get("identities")
+    environment = lineage.get("environment")
+    hardware = lineage.get("hardware")
+    parameters = lineage.get("parameters")
+    metrics = lineage.get("metrics")
+    artifact_sha256 = lineage.get("artifact_sha256")
+    if not all(
+        isinstance(value, dict)
+        for value in (
+            source,
+            identities,
+            environment,
+            hardware,
+            parameters,
+            metrics,
+            artifact_sha256,
+        )
+    ):
+        raise ExperimentTrackingError(_RUN_ERROR)
+    source = cast(dict[str, object], source)
+    identities = cast(dict[str, object], identities)
+    environment = cast(dict[str, object], environment)
+    hardware = cast(dict[str, object], hardware)
+    parameters = cast(dict[str, object], parameters)
+    metrics = cast(dict[str, object], metrics)
+    artifact_sha256 = cast(dict[str, object], artifact_sha256)
+    seed = lineage.get("seed")
+    if type(seed) is not int or not all(
+        type(value) in (bool, int, float, str) for value in parameters.values()
+    ):
+        raise ExperimentTrackingError(_RUN_ERROR)
+    if not all(type(value) in (int, float) for value in metrics.values()):
+        raise ExperimentTrackingError(_RUN_ERROR)
+    tags = {
+        "signlab.format": LINEAGE_FORMAT,
+        "signlab.git_commit": str(source.get("git_commit")),
+        "signlab.git_dirty": str(source.get("git_dirty")).casefold(),
+        **{f"signlab.{key}": str(value) for key, value in identities.items()},
+        **{f"signlab.environment.{key}": str(value) for key, value in environment.items()},
+        **{f"signlab.hardware.{key}": str(value) for key, value in hardware.items()},
+        **{
+            f"signlab.artifact_sha256.{name}": str(digest)
+            for name, digest in artifact_sha256.items()
+        },
+        "signlab.lineage_sha256": lineage_sha256,
+    }
+    logged_parameters = {
+        name: _parameter_text(value) for name, value in {**parameters, "seed": seed}.items()
+    }
+    logged_metrics = {name: float(cast(int | float, value)) for name, value in metrics.items()}
+    return tags, logged_parameters, logged_metrics
+
+
+def _experiment_id(client: Any, artifact_location: str) -> str:
+    experiment = client.get_experiment_by_name(EXPERIMENT_NAME)
+    if experiment is not None:
+        if str(experiment.artifact_location).rstrip("/") != artifact_location.rstrip("/"):
+            raise ExperimentTrackingError(_LEDGER_ERROR)
+        return str(experiment.experiment_id)
+    return str(client.create_experiment(EXPERIMENT_NAME, artifact_location=artifact_location))
+
+
+def log_reference_run(
+    run: ReferenceRunInput,
+    *,
+    tracking_uri: str | None = None,
+) -> ReferenceRunReceipt:
+    """Log one completed baseline run to the local ledger and return its identity."""
+
+    checked = ReferenceRunInput.model_validate(run)
+    raw_uri = tracking_uri or os.environ.get(TRACKING_URI_ENV, DEFAULT_TRACKING_URI)
+    local_uri, artifact_location = _local_store(raw_uri)
+    payloads = _artifact_payloads(checked)
+    lineage, artifact_sha256 = _lineage_document(checked, payloads)
+    lineage_bytes = canonical_json_bytes(lineage) + b"\n"
+    tags, parameters, metrics = _tracking_values(lineage, _sha256(lineage_bytes))
+    client = _mlflow_client(local_uri)
+    active_run_id: str | None = None
+    try:
+        experiment_id = _experiment_id(client, artifact_location)
+        active = client.create_run(experiment_id, tags=tags, run_name=checked.run_name)
+        active_run_id = str(active.info.run_id)
+        for name, parameter_value in sorted(parameters.items()):
+            client.log_param(active_run_id, name, parameter_value)
+        for name, metric_value in sorted(metrics.items()):
+            client.log_metric(active_run_id, name, metric_value)
+        with TemporaryDirectory(prefix="signlab-mlflow-artifacts-") as staging_text:
+            staging = Path(staging_text)
+            for name, payload in payloads.items():
+                (staging / name).write_bytes(payload)
+            (staging / "lineage.json").write_bytes(lineage_bytes)
+            client.log_artifacts(active_run_id, str(staging), artifact_path="evidence")
+        client.set_terminated(active_run_id, status="FINISHED")
+    except Exception as error:
+        if active_run_id is not None:
+            with suppress(Exception):
+                client.set_terminated(active_run_id, status="FAILED")
+        raise ExperimentTrackingError(_LEDGER_ERROR) from error
+    return ReferenceRunReceipt(
+        run_id=active_run_id,
+        experiment_id=experiment_id,
+        artifact_sha256=artifact_sha256,
+    )
+
+
+def verify_reference_run(
+    run_id: str,
+    *,
+    tracking_uri: str | None = None,
+) -> ReferenceRunReceipt:
+    """Query one completed run and re-hash every artifact named by its lineage file."""
+
+    if _RUN_ID.fullmatch(run_id) is None:
+        raise ExperimentTrackingError(_RUN_ERROR)
+    raw_uri = tracking_uri or os.environ.get(TRACKING_URI_ENV, DEFAULT_TRACKING_URI)
+    local_uri, artifact_location = _local_store(raw_uri)
+    client = _mlflow_client(local_uri)
+    try:
+        experiment = client.get_experiment_by_name(EXPERIMENT_NAME)
+        if experiment is None or str(experiment.artifact_location).rstrip(
+            "/"
+        ) != artifact_location.rstrip("/"):
+            raise ExperimentTrackingError(_RUN_ERROR)
+        matches = client.search_runs(
+            experiment_ids=[str(experiment.experiment_id)],
+            filter_string=f"attributes.run_id = '{run_id}'",
+        )
+        if len(matches) != 1 or matches[0].info.status != "FINISHED":
+            raise ExperimentTrackingError(_RUN_ERROR)
+        tracked = matches[0]
+        if tracked.data.tags.get("signlab.format") != LINEAGE_FORMAT:
+            raise ExperimentTrackingError(_RUN_ERROR)
+        with TemporaryDirectory(prefix="signlab-mlflow-verification-") as destination:
+            lineage_path = Path(
+                client.download_artifacts(run_id, "evidence/lineage.json", dst_path=destination)
+            )
+            lineage_bytes = lineage_path.read_bytes()
+            if _sha256(lineage_bytes) != tracked.data.tags.get("signlab.lineage_sha256"):
+                raise ExperimentTrackingError(_VERIFICATION_ERROR)
+            lineage = parse_json_object(lineage_bytes)
+            tags, parameters, metrics = _tracking_values(lineage, _sha256(lineage_bytes))
+            if (
+                tracked.info.run_name != lineage.get("run_name")
+                or tracked.data.params != parameters
+                or tracked.data.metrics != metrics
+                or any(tracked.data.tags.get(key) != value for key, value in tags.items())
+            ):
+                raise ExperimentTrackingError(_RUN_ERROR)
+            artifact_sha256 = lineage.get("artifact_sha256")
+            if lineage.get("format") != LINEAGE_FORMAT or not isinstance(artifact_sha256, dict):
+                raise ExperimentTrackingError(_RUN_ERROR)
+            if set(artifact_sha256) != set(_ARTIFACT_PATHS):
+                raise ExperimentTrackingError(_RUN_ERROR)
+            for name, expected_sha256 in artifact_sha256.items():
+                if tracked.data.tags.get(f"signlab.artifact_sha256.{name}") != expected_sha256:
+                    raise ExperimentTrackingError(_VERIFICATION_ERROR)
+                artifact_path = Path(
+                    client.download_artifacts(run_id, f"evidence/{name}", dst_path=destination)
+                )
+                if _sha256(artifact_path.read_bytes()) != expected_sha256:
+                    raise ExperimentTrackingError(_VERIFICATION_ERROR)
+    except ExperimentTrackingError:
+        raise
+    except Exception as error:
+        raise ExperimentTrackingError(_RUN_ERROR) from error
+    return ReferenceRunReceipt(
+        run_id=run_id,
+        experiment_id=str(tracked.info.experiment_id),
+        artifact_sha256=cast(dict[str, str], artifact_sha256),
+    )
+
+
+__all__ = [
+    "DEFAULT_TRACKING_URI",
+    "EXPERIMENT_NAME",
+    "LINEAGE_FORMAT",
+    "TRACKING_URI_ENV",
+    "ExperimentTrackingError",
+    "ReferenceRunInput",
+    "ReferenceRunReceipt",
+    "log_reference_run",
+    "verify_reference_run",
+]

--- a/tests/test_experiment_tracking.py
+++ b/tests/test_experiment_tracking.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from signlab.experiments import tracking
+from signlab.experiments.tracking import (
+    ExperimentTrackingError,
+    ReferenceRunInput,
+    log_reference_run,
+    verify_reference_run,
+)
+
+pytestmark = pytest.mark.skipif(
+    importlib.util.find_spec("mlflow") is None,
+    reason="the experiments extra is not installed",
+)
+
+
+def _sha(character: str) -> str:
+    return f"sha256:{character * 64}"
+
+
+def _reference_input(root: Path) -> ReferenceRunInput:
+    artifacts = {
+        "configuration_path": (
+            '{"format":"signlab-baseline-config/1","seed":20260828,'
+            f'"corpus_sha256":"{_sha("a")}","split_sha256":"{_sha("b")}",'
+            f'"feature_plan_sha256":"{_sha("c")}"}}\n'
+        ).encode(),
+        "report_path": b'{"format":"signlab-baseline-report/1","macro_f1":0.5}\n',
+        "confusion_matrix_path": b'{"labels":["hello","other"],"matrix":[[1,0],[0,1]]}\n',
+        "predictions_path": b"sample_id,actual,predicted\nsample_1,hello,hello\n",
+    }
+    paths: dict[str, Path] = {}
+    for field_name, payload in artifacts.items():
+        path = root / f"{field_name}.fixture"
+        path.write_bytes(payload)
+        paths[field_name] = path
+    return ReferenceRunInput(
+        run_name="reference_smoke",
+        git_commit="d" * 40,
+        git_dirty=True,
+        corpus_sha256=_sha("a"),
+        split_sha256=_sha("b"),
+        feature_plan_sha256=_sha("c"),
+        seed=20260828,
+        parameters={"baseline_count": 3, "solver": "lbfgs"},
+        metrics={"test.macro_f1": 0.5, "validation.macro_f1": 0.625},
+        **paths,
+    )
+
+
+@pytest.mark.integration
+def test_one_reference_run_logs_queries_verifies_and_detects_corruption(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run = _reference_input(tmp_path)
+    tracking_uri = f"sqlite:///{(tmp_path / 'tracking.sqlite').resolve().as_posix()}"
+    monkeypatch.setenv("MLFLOW_DISABLE_TELEMETRY", "false")
+
+    logged = log_reference_run(run, tracking_uri=tracking_uri)
+    verified = verify_reference_run(logged.run_id, tracking_uri=tracking_uri)
+
+    assert verified == logged
+    assert os.environ["MLFLOW_DISABLE_TELEMETRY"] == "true"
+    mlflow = __import__("mlflow")
+    client = mlflow.MlflowClient(tracking_uri=tracking_uri)
+    matches = client.search_runs(
+        [logged.experiment_id],
+        filter_string=f"tags.`signlab.corpus_sha256` = '{run.corpus_sha256}'",
+    )
+    assert [match.info.run_id for match in matches] == [logged.run_id]
+    tracked = matches[0]
+    assert tracked.data.params == {
+        "baseline_count": "3",
+        "seed": "20260828",
+        "solver": "lbfgs",
+    }
+    assert tracked.data.metrics == run.metrics
+    assert tracked.data.tags["signlab.git_commit"] == run.git_commit
+    assert tracked.data.tags["signlab.git_dirty"] == "true"
+    assert tracked.data.tags["signlab.feature_plan_sha256"] == run.feature_plan_sha256
+    assert tracked.data.tags["signlab.environment.python_version"]
+    assert tracked.data.tags["signlab.hardware.architecture"]
+    assert tracked.data.tags["signlab.lineage_sha256"].startswith("sha256:")
+
+    client.set_tag(logged.run_id, "signlab.split_sha256", _sha("f"))
+    client.log_metric(logged.run_id, "test.macro_f1", 0.0)
+    with pytest.raises(ExperimentTrackingError, match="tracked reference run is unavailable"):
+        verify_reference_run(logged.run_id, tracking_uri=tracking_uri)
+    client.set_tag(logged.run_id, "signlab.split_sha256", run.split_sha256)
+    client.log_metric(logged.run_id, "test.macro_f1", run.metrics["test.macro_f1"])
+
+    evidence = tmp_path / "mlflow-artifacts" / logged.run_id / "artifacts" / "evidence"
+    stored_lineage = evidence / "lineage.json"
+    original_lineage = stored_lineage.read_bytes()
+    stored_lineage.write_bytes(original_lineage.replace(b'"git_dirty":true', b'"git_dirty":false'))
+    with pytest.raises(
+        ExperimentTrackingError,
+        match="reference-run artifact verification failed",
+    ):
+        verify_reference_run(logged.run_id, tracking_uri=tracking_uri)
+    stored_lineage.write_bytes(original_lineage)
+
+    stored_report = evidence / "report.json"
+    stored_report.write_bytes(b"corrupted\n")
+    with pytest.raises(
+        ExperimentTrackingError,
+        match="reference-run artifact verification failed",
+    ):
+        verify_reference_run(logged.run_id, tracking_uri=tracking_uri)
+
+
+@pytest.mark.parametrize(
+    "tracking_uri",
+    ["file:///runs/mlflow", "sqlite:///:memory:", "sqlite:///runs/mlflow.sqlite?mode=ro"],
+)
+def test_non_persistent_or_non_local_tracking_uri_is_rejected(tracking_uri: str) -> None:
+    with pytest.raises(ExperimentTrackingError, match="persistent local SQLite"):
+        tracking._local_store(tracking_uri)
+
+
+def test_relative_tracking_uri_resolves_beneath_the_working_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    tracking_uri, artifact_uri = tracking._local_store("sqlite:///tracking.sqlite")
+
+    assert tracking_uri == f"sqlite:///{(tmp_path / 'tracking.sqlite').as_posix()}"
+    assert artifact_uri == (tmp_path / "mlflow-artifacts").as_uri()
+
+
+def test_missing_experiment_dependency_has_a_stable_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unavailable(_name: str) -> None:
+        raise ModuleNotFoundError
+
+    monkeypatch.setattr(importlib, "import_module", unavailable)
+    with pytest.raises(ExperimentTrackingError, match="experiments extra"):
+        tracking._mlflow_client("sqlite:///unused.sqlite")
+
+
+def test_missing_artifact_fails_before_a_run_is_created(tmp_path: Path) -> None:
+    run = _reference_input(tmp_path)
+    run.report_path.unlink()
+
+    with pytest.raises(ExperimentTrackingError, match="artifacts are unavailable"):
+        log_reference_run(
+            run,
+            tracking_uri=f"sqlite:///{(tmp_path / 'tracking.sqlite').resolve().as_posix()}",
+        )
+
+
+def test_nul_containing_artifact_is_rejected(tmp_path: Path) -> None:
+    run = _reference_input(tmp_path)
+    run.predictions_path.write_bytes(b"invalid\0predictions")
+
+    with pytest.raises(ExperimentTrackingError, match="artifacts are unavailable"):
+        tracking._artifact_payloads(run)
+
+
+def test_seed_is_reserved_for_the_dedicated_lineage_field(tmp_path: Path) -> None:
+    values = _reference_input(tmp_path).model_dump()
+    values["parameters"] = {"seed": 1}
+
+    with pytest.raises(ValueError, match="dedicated reference-run field"):
+        ReferenceRunInput.model_validate(values)
+
+
+def test_existing_experiment_must_use_the_derived_artifact_store() -> None:
+    expected = SimpleNamespace(experiment_id="1", artifact_location="file:///expected-store")
+    assert (
+        tracking._experiment_id(
+            SimpleNamespace(get_experiment_by_name=lambda _name: expected),
+            "file:///expected-store",
+        )
+        == "1"
+    )
+    client = SimpleNamespace(
+        get_experiment_by_name=lambda _name: SimpleNamespace(
+            experiment_id="1",
+            artifact_location="file:///wrong-store",
+        )
+    )
+
+    with pytest.raises(ExperimentTrackingError, match="ledger operation failed"):
+        tracking._experiment_id(client, "file:///expected-store")
+
+
+def test_invalid_or_unknown_run_is_rejected(tmp_path: Path) -> None:
+    with pytest.raises(ExperimentTrackingError, match="tracked reference run is unavailable"):
+        verify_reference_run("not-a-run-id")
+    with pytest.raises(ExperimentTrackingError, match="tracked reference run is unavailable"):
+        verify_reference_run(
+            "f" * 32,
+            tracking_uri=f"sqlite:///{(tmp_path / 'tracking.sqlite').resolve().as_posix()}",
+        )
+
+
+def test_corrupt_tracking_database_has_a_sanitized_failure(tmp_path: Path) -> None:
+    database = tmp_path / "corrupt.sqlite"
+    database.write_bytes(b"not a SQLite database")
+
+    with pytest.raises(ExperimentTrackingError, match="ledger operation failed"):
+        log_reference_run(
+            _reference_input(tmp_path),
+            tracking_uri=f"sqlite:///{database.resolve().as_posix()}",
+        )
+
+
+def test_failed_logging_marks_the_created_run_failed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    statuses: list[str] = []
+
+    class FailingClient:
+        def get_experiment_by_name(self, _name: str) -> None:
+            return None
+
+        def create_experiment(self, _name: str, *, artifact_location: str) -> str:
+            assert artifact_location.startswith("file:")
+            return "1"
+
+        def create_run(self, _experiment_id: str, **_kwargs: object) -> SimpleNamespace:
+            return SimpleNamespace(info=SimpleNamespace(run_id="e" * 32))
+
+        def log_param(self, _run_id: str, _name: str, _value: str) -> None:
+            raise RuntimeError
+
+        def set_terminated(self, _run_id: str, *, status: str) -> None:
+            statuses.append(status)
+
+    monkeypatch.setattr(tracking, "_mlflow_client", lambda _uri: FailingClient())
+    with pytest.raises(ExperimentTrackingError, match="ledger operation failed"):
+        log_reference_run(
+            _reference_input(tmp_path),
+            tracking_uri=f"sqlite:///{(tmp_path / 'tracking.sqlite').resolve().as_posix()}",
+        )
+    assert statuses == ["FAILED"]
+
+
+def test_tracking_module_import_does_not_load_mlflow() -> None:
+    probe = (
+        "import sys; import signlab.experiments.tracking; "
+        "raise SystemExit('mlflow imported' if 'mlflow' in sys.modules else 0)"
+    )
+    subprocess.run([sys.executable, "-c", probe], check=True)

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -16,5 +16,10 @@ def test_distribution_metadata_is_complete() -> None:
     assert package_metadata["Requires-Python"] == "<3.13,>=3.12"
     requirements = tuple(package_metadata.get_all("Requires-Dist") or ())
     assert not any(
-        requirement.casefold().startswith(("dvc", "dvc-s3")) for requirement in requirements
+        requirement.casefold().startswith(
+            ("alembic", "dvc", "dvc-s3", "mlflow-skinny", "sqlalchemy")
+        )
+        and "extra ==" not in requirement.casefold()
+        for requirement in requirements
     )
+    assert set(package_metadata.get_all("Provides-Extra") or ()) == {"experiments", "extraction"}

--- a/uv.lock
+++ b/uv.lock
@@ -109,6 +109,20 @@ wheels = [
 ]
 
 [[package]]
+name = "alembic"
+version = "1.19.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mako" },
+    { name = "sqlalchemy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/2b/e4153978368de59918115c9e01d3ebf58a558a7285efa7e960c383c4b59a/alembic-1.19.1.tar.gz", hash = "sha256:e0fca0518118c78acc493e31bcb5402f190057aaf6df8b5b95ce94c4789cf648", size = 2070816, upload-time = "2026-08-08T16:32:01.565Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/89/e62cc37b69ad357cc8ecd6e7367f5245f523d3cbb338a66197212bdf6749/alembic-1.19.1-py3-none-any.whl", hash = "sha256:b39018cb3d9413a19cbd54cf3c02ad33998641f0538eb77413a488a21c3e14be", size = 265946, upload-time = "2026-08-08T16:32:03.153Z" },
+]
+
+[[package]]
 name = "amqp"
 version = "5.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -143,6 +157,19 @@ name = "antlr4-python3-runtime"
 version = "4.9.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3e/38/7859ff46355f76f8d19459005ca000b6e7012f2f1ca597746cbcd1fbfe5e/antlr4-python3-runtime-4.9.3.tar.gz", hash = "sha256:f224469b4168294902bb1efa80a8bf7855f24c99aef99cbefc1bcd3cce77881b", size = 117034, upload-time = "2021-11-06T17:52:23.524Z" }
+
+[[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
 
 [[package]]
 name = "appdirs"
@@ -280,6 +307,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/78/e0/df5e171f685f82f37b12e1f208064e24244911079d7b767447d1af7e0d70/build-1.5.0.tar.gz", hash = "sha256:302c22c3ba2a0fd5f3911918651341ebb3896176cbdec15bd421f80b1afc7647", size = 89796, upload-time = "2026-04-30T03:18:25.17Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl", hash = "sha256:13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f", size = 26018, upload-time = "2026-04-30T03:18:23.644Z" },
+]
+
+[[package]]
+name = "cachetools"
+version = "7.1.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/d2/47e8bc06fe2a06d3f5bdf20f1126ab66c4e99dc48d940e7ba873f7ac7131/cachetools-7.1.7.tar.gz", hash = "sha256:a3e2a00b14d8f8a6b70c1dae7b4685e7ad3bc965c5b42124a2d6ce895da6cf50", size = 40680, upload-time = "2026-08-01T21:20:40.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/d8/767faeda872075724b95dd675466a645f1b92aadcdcf2d1429dcfd76c176/cachetools-7.1.7-py3-none-any.whl", hash = "sha256:ef98ef375ad188819ef2f9b3645e3987f4b8c5b7550e436ad998c2de78296df0", size = 16830, upload-time = "2026-08-01T21:20:38.977Z" },
 ]
 
 [[package]]
@@ -431,6 +467,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -538,6 +583,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a9/95/a3dbbb5028f35eafb79008e7522a75244477d2838f38cbb722248dabc2a8/cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c", size = 7615, upload-time = "2023-10-07T05:32:18.335Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30", size = 8321, upload-time = "2023-10-07T05:32:16.783Z" },
+]
+
+[[package]]
+name = "databricks-sdk"
+version = "0.133.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "protobuf" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/f9/06ae3ac44172a4390483db78c0beef1794d69e82958a74ea9cef11314aef/databricks_sdk-0.133.0.tar.gz", hash = "sha256:00e99cd3aa31807d4c4835268eb9f5fbef8f4286f81b1c2b56cf13ac17cacc95", size = 1159796, upload-time = "2026-08-19T04:31:37.035Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/9e/be3efa4cacee78091dbfbfc2bbdf71220962528592539ccf337083fefa74/databricks_sdk-0.133.0-py3-none-any.whl", hash = "sha256:3733a0f2b45c6da5c628755df0d0d10a438cc7e1465546f641690561fd97bc9e", size = 1102159, upload-time = "2026-08-19T04:31:35.285Z" },
 ]
 
 [[package]]
@@ -773,6 +833,22 @@ wheels = [
 ]
 
 [[package]]
+name = "fastapi"
+version = "0.141.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/02/91e3416a8fdd715abb903a952a6bec7cdd8d14eed55d415fc8595524c319/fastapi-0.141.1.tar.gz", hash = "sha256:e8822fc40db1e1858054d7a949a888695bc9bdce70139178e33bd2871a453ca1", size = 425799, upload-time = "2026-07-29T17:18:05.568Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/03/10388a42375ee7e4ac9b94eb2c5c569c8b5795e377e701c9ac3ad63de890/fastapi-0.141.1-py3-none-any.whl", hash = "sha256:bfb91aa2d334c61cb35ba9a116fc123b3d3df31640b801cf57a7a78ec3f603b3", size = 131954, upload-time = "2026-07-29T17:18:04.364Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.32.4"
 source = { registry = "https://pypi.org/simple" }
@@ -904,6 +980,19 @@ wheels = [
 ]
 
 [[package]]
+name = "google-auth"
+version = "2.57.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/64/55f316b729f92a552d26e00aa3b1542b2e149d0a5efe2842afff0cac7af7/google_auth-2.57.0.tar.gz", hash = "sha256:9b4f96d6a1feb5f7201231f47cfb3de08d8f176f8a61f9e461555116e95a8789", size = 370794, upload-time = "2026-08-25T19:18:26.419Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/f3/8508a702c094af5f6e89773f4dfdeee74913df0f41a02c21b5e7dc3d75cd/google_auth-2.57.0-py3-none-any.whl", hash = "sha256:180dafe015cfb62193bea26b677500fab5b9fd51a1e825ebf3ad9b182047ae59", size = 259728, upload-time = "2026-08-24T21:55:08.449Z" },
+]
+
+[[package]]
 name = "grandalf"
 version = "0.8"
 source = { registry = "https://pypi.org/simple" }
@@ -913,6 +1002,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/95/0e/4ac934b416857969f9135dec17ac80660634327e003a870835dd1f382659/grandalf-0.8.tar.gz", hash = "sha256:2813f7aab87f0d20f334a3162ccfbcbf085977134a17a5b516940a93a77ea974", size = 38128, upload-time = "2023-01-26T07:37:06.668Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/61/30/44c7eb0a952478dbb5f2f67df806686d6a7e4b19f6204e091c4f49dc7c69/grandalf-0.8-py3-none-any.whl", hash = "sha256:793ca254442f4a79252ea9ff1ab998e852c1e071b863593e5383afee906b4185", size = 41802, upload-time = "2023-01-10T15:16:19.753Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.5.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/d8/7cc97c142388aef03f622e001c572c4f84e9252a439549d483f555771970/greenlet-3.5.5.tar.gz", hash = "sha256:adb4bae02e91a8e863e48b177e4014bdcac8a6b5e047ea1df687a61534b85e6c", size = 207585, upload-time = "2026-08-10T15:09:36.136Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/7e/9ecd0285e3153532ae07aeb88063c43c72b4221cf0d4d123b02f3682e3ff/greenlet-3.5.5-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:49520f0c95a48b42cf55414b8e8479beb274ea70431afc33e3f79903c71f4380", size = 295809, upload-time = "2026-08-10T13:25:34.023Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/60e4bbcc89252037b18087f2ec16405d5b2d5be42dde191bbf3667e96102/greenlet-3.5.5-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55272212cbc5f43d1d723725ab931f1939969b7e9523882ca58b55061769d053", size = 611910, upload-time = "2026-08-10T14:14:35.18Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/17/cd5134be659cd4a443e7a61ae670dabec165a814c51162916d637b6dd38e/greenlet-3.5.5-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:655bca754a2ef4efcb0eb48a94d3f4593536d0f3d48f8ed44343c01d16a92f95", size = 624198, upload-time = "2026-08-10T14:27:25.229Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ac/5c5b959999b6f09c3026b5dfe171575bc3121c5236ce74f495096f25b203/greenlet-3.5.5-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:147b25a42e5ca5be3d42356e8f608b37af715a1c196e9bf9d1627f3341adfe1d", size = 621439, upload-time = "2026-08-10T13:40:49.391Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/8b/6acf112ed8aee499f25b4d6949820fb02ac950ff9c1f3d793bd5be0599f2/greenlet-3.5.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:27493374cff1d1b7919dc8126547f2aea582737e3046147b434b1e12de56389b", size = 1581342, upload-time = "2026-08-10T14:15:05.653Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/d7/734e5f198888876b42d7616ff6644c075baf6b8a2412deadd6b0e1b8b20c/greenlet-3.5.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:12e2ee66c2aba86133f10fd99d6a8856c6d351ffb7be0e4d52ef2cc5fbb705b2", size = 1645744, upload-time = "2026-08-10T13:40:30.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/30/1f42b88dc587b5899ee50616ad56ee40cafaf225df4fb829f10183c62a5c/greenlet-3.5.5-cp312-cp312-win_amd64.whl", hash = "sha256:49ddacd36af37735fab103846f4ee4d18a492dde72730d1699c0c8ebe30d9f18", size = 324171, upload-time = "2026-08-10T13:28:44.472Z" },
+    { url = "https://files.pythonhosted.org/packages/76/e5/4dee4d8d2e603fe5fdd7b444e63219f7b9bd852c60c6214511c7157cbe88/greenlet-3.5.5-cp312-cp312-win_arm64.whl", hash = "sha256:5f1b1ff4828cdc1aba4266aff814085d04a1d07959287219af021b838b265d52", size = 308362, upload-time = "2026-08-10T13:26:46.839Z" },
 ]
 
 [[package]]
@@ -934,6 +1039,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/9c/cf74e391f76ff2afd7aee9bdd0f1b191c0522ba8190439bfa3b2672f222a/gto-1.10.1.tar.gz", hash = "sha256:e2a008650e7be42b7e3dd65e2eef360d466553e3b41d8f37dae38328d84fd224", size = 60033, upload-time = "2026-07-09T22:08:26.369Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/af/23fba84f3e03fcf58bd73e1d28ef9db7b46c5b48df95fae4b5f658db7993/gto-1.10.1-py3-none-any.whl", hash = "sha256:f357f7dee2cf91552408545e17f53a4ea54d0d16e676e35b92edf1291414d06d", size = 45713, upload-time = "2026-07-09T22:08:24.848Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
 ]
 
 [[package]]
@@ -982,6 +1096,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
+]
+
+[[package]]
+name = "importlib-metadata"
+version = "9.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6f/7e/1e7e8dc30634b93ebb3d58a3dea569ad146e656218d3960ab04f62047b29/importlib_metadata-9.0.1.tar.gz", hash = "sha256:ab830580bc0ef3db61ce8fae716389e5462b67e033018bab6d8f80ef17172f99", size = 59124, upload-time = "2026-08-28T15:30:34.646Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/55/ecca97ae19075f1fac62def77731e7f535e6c1fb8f92ff08160c5e6dade8/importlib_metadata-9.0.1-py3-none-any.whl", hash = "sha256:bba5600596a7e21f3eef53281cf28d6a5195634d2f2b78ff9501a3272c6eaab0", size = 27920, upload-time = "2026-08-28T15:30:33.433Z" },
 ]
 
 [[package]]
@@ -1110,6 +1236,18 @@ wheels = [
 ]
 
 [[package]]
+name = "mako"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/12/b5fa2353e2754cd67fb9f83793fa48ff42c213a5da7e719869d2301f6ab8/mako-1.4.1.tar.gz", hash = "sha256:d7904710b662996425a21627710c4777c45053146942cf8a7aebf757c92b8c27", size = 410165, upload-time = "2026-08-05T06:10:56.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/54/12ed58d458474aaab5c3d180173e745a4fe131bb330370596876d19ff60f/mako-1.4.1-py3-none-any.whl", hash = "sha256:a359d9a94a541213958742b2698d0a7757bb83551767bc468a74b9905aba9617", size = 80010, upload-time = "2026-08-05T06:10:58.248Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1119,6 +1257,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
 ]
 
 [[package]]
@@ -1175,6 +1332,37 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/58/bdd5bada89d7a132375df05e962bf702c148b47043dca98d820d9395152b/mediapipe-1.0.1-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:121522251afc3c135e4b7b0c341dd5e050ad1ec87631127484f3c389ae385044", size = 37881482, upload-time = "2026-08-14T18:24:01.091Z" },
     { url = "https://files.pythonhosted.org/packages/22/71/42365b0aec2a96dfbeb3441220fe8dccd9a833f36adfecf3aa9f211c449b/mediapipe-1.0.1-py3-none-win_amd64.whl", hash = "sha256:96dc9de6bd04a6315ef424fda5c48e0929f2d78317295e75bc32c0bceeab517b", size = 20103114, upload-time = "2026-08-14T18:24:03.861Z" },
     { url = "https://files.pythonhosted.org/packages/49/47/8a901eade7352051ae4d7b0b070ad8a84bde9cbf3092afd69088982842bb/mediapipe-1.0.1-py3-none-win_arm64.whl", hash = "sha256:4bbbb3838a99f7fdcd3cb0e071560120df45ddc48c1ad097ef1457f8600e0e77", size = 17700960, upload-time = "2026-08-14T18:24:06.172Z" },
+]
+
+[[package]]
+name = "mlflow-skinny"
+version = "3.15.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachetools" },
+    { name = "click" },
+    { name = "cloudpickle" },
+    { name = "databricks-sdk" },
+    { name = "fastapi" },
+    { name = "gitpython" },
+    { name = "importlib-metadata" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "sqlparse" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "uvicorn" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/a1/addfbab892f95b8bd3e8d6ce1166838f53782635270fe460631dc3a22781/mlflow_skinny-3.15.2.tar.gz", hash = "sha256:973f65f835de41ddb4dd8e2cf91c65028d0b928eb6fef988434243b6a77dfcaf", size = 3043569, upload-time = "2026-08-26T06:05:35.361Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/5e/0ffcb76a9f3efa25e62af012c95f43f5874004fb6ced1109ff69a62e3711/mlflow_skinny-3.15.2-py3-none-any.whl", hash = "sha256:4a0f236f1e7856e0bd4cf7f2af889f8cd33a4a45206b732a78028dd297fa3b14", size = 3622491, upload-time = "2026-08-26T06:05:33.306Z" },
 ]
 
 [[package]]
@@ -1305,6 +1493,57 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/01/40ac4ae9a149263cc52c2cee200ddd80cb6d8db1a4610abf8eabce0fe771/opentelemetry_proto-1.44.0.tar.gz", hash = "sha256:c547a79c2f8c0c515d31509154682e5921c7cfd5ca67b70e1f9266e2c3e103f3", size = 46488, upload-time = "2026-07-16T15:25:45.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/7c/8be563d68e93bbefa5c8affb82ddcff91b3ad858ce49957ba7b16fd3e0ab/opentelemetry_proto-1.44.0-py3-none-any.whl", hash = "sha256:898b155a0e1557afd867478fb6158e8122a46329ca0bb8dc53cc55e98f017f56", size = 72483, upload-time = "2026-07-16T15:25:28.429Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/77/a6592cbc7c8d9bcc9d6757a9df45e04a7c585e3e6e7a13456da522b21109/opentelemetry_sdk-1.44.0.tar.gz", hash = "sha256:cebe7f65dc12f26ead75c6064de12fd2a9052e5060c0272d402cfa203aae123b", size = 208624, upload-time = "2026-07-16T15:25:46.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/23/ff077e61886ee020a17ce9c8b6fa11c601c8d8345b09ea24f605445df62a/opentelemetry_sdk-1.44.0-py3-none-any.whl", hash = "sha256:df081c4c6bcfdb1211e3e86140376792643128a25f8d72d1d27675936e7e96ad", size = 137221, upload-time = "2026-07-16T15:25:29.534Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/73/0cbdebcb4cf545fdd328da14f5137e37d0770c3f26185e478b0d15d94f50/opentelemetry_semantic_conventions-0.65b0.tar.gz", hash = "sha256:f9b2b81e9d5b64f11bc952075e7e9c7fb0aab075c7fd1c46d597f1b919852d60", size = 148774, upload-time = "2026-07-16T15:25:46.902Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/0e/49df70d9b81fb5cbae4bbf2a49d865b09bcbcbc4eb53f5851b1027738d78/opentelemetry_semantic_conventions-0.65b0-py3-none-any.whl", hash = "sha256:1cacde7b0ad306f84c5ef08c3dbe1bbaf20165bba6f8bff43b670e555a086bcb", size = 204645, upload-time = "2026-07-16T15:25:30.688Z" },
+]
+
+[[package]]
 name = "orjson"
 version = "3.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1431,6 +1670,21 @@ wheels = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "6.33.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
+]
+
+[[package]]
 name = "psutil"
 version = "7.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1459,6 +1713,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/80/53/8fb8359ff17cfb6263a1cf3ebf7caec9fe197de118719e84fcb1d0618026/pyarrow-25.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d51592cb7561e87877c506113e7adbf1342ab579e6c21f0ef44b8ba41cb74c80", size = 49942424, upload-time = "2026-08-10T12:38:28.755Z" },
     { url = "https://files.pythonhosted.org/packages/e8/83/4e5ae02a9341571b18a6fca380ac7a58ce6ddae7ab3c060208c0a1e79f02/pyarrow-25.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6109c94d8b9f3b17a041daca16cacb2f651ad8f1ef70a4232c2c0f37a23da2a8", size = 53144206, upload-time = "2026-08-10T12:38:34.862Z" },
     { url = "https://files.pythonhosted.org/packages/65/ee/197cbf47e49f83e6ebeb946a5259a48a638dea27ac774db42fe78022179d/pyarrow-25.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:8858d7bfc22e3f51529aeaa4077225029724623e4595dc9eff8c793935c34140", size = 27953934, upload-time = "2026-08-10T12:38:39.808Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -1892,6 +2167,11 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+experiments = [
+    { name = "alembic" },
+    { name = "mlflow-skinny" },
+    { name = "sqlalchemy" },
+]
 extraction = [
     { name = "av" },
     { name = "mediapipe" },
@@ -1915,17 +2195,20 @@ reproducibility = [
 
 [package.metadata]
 requires-dist = [
+    { name = "alembic", marker = "extra == 'experiments'", specifier = "==1.19.1" },
     { name = "av", marker = "extra == 'extraction'", specifier = "==18.1.0" },
     { name = "jsonschema", specifier = ">=4.26,<5" },
     { name = "mediapipe", marker = "extra == 'extraction'", specifier = "==1.0.1" },
+    { name = "mlflow-skinny", marker = "extra == 'experiments'", specifier = "==3.15.2" },
     { name = "pyarrow", specifier = "==25.0.1" },
     { name = "pydantic", specifier = ">=2.13.4,<2.14" },
     { name = "pyyaml", specifier = "==6.0.3" },
     { name = "rfc8785", specifier = "==0.1.4" },
+    { name = "sqlalchemy", marker = "extra == 'experiments'", specifier = "==2.0.52" },
     { name = "typer", specifier = ">=0.27.1,<0.28" },
     { name = "tzdata", specifier = "==2026.3" },
 ]
-provides-extras = ["extraction"]
+provides-extras = ["experiments", "extraction"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1976,6 +2259,35 @@ wheels = [
 ]
 
 [[package]]
+name = "sqlalchemy"
+version = "2.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/21/77b4c147963073040dc3c3a5cb7a8c3001a1893c0209432cb77f9df836aa/sqlalchemy-2.0.52.tar.gz", hash = "sha256:5e2d46356ac2ccb7d268ab6c2319ac6a2b42f1b8d5fd8bd3d46855cd82abee97", size = 9945637, upload-time = "2026-08-11T19:07:09.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/d5/1b77a026d161f98a08f11af1a5f6c47b98ee7c7e2648af525a1004826c78/sqlalchemy-2.0.52-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:be8c49131665dfe2cc74c498aa1240ffb548d0fd901325dd11c2c7a18956f727", size = 2170940, upload-time = "2026-08-11T20:58:11.25Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bd/f444444adb37b5d53753fb1730ee7a421628e2e3b756c4da461af7e6394a/sqlalchemy-2.0.52-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b2d9e507a458832adcfbd8af6e2036ddf069b7710b799448542ebccae2dceee", size = 3383415, upload-time = "2026-08-11T21:02:38.534Z" },
+    { url = "https://files.pythonhosted.org/packages/be/57/2eadf93a552568c57e8680b7e58bb5e9770d80942a1bdbaf4f2f63f0d7c8/sqlalchemy-2.0.52-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8738008376d22f30f411ea3efecf39b51110b6996d80bb73786f30bcfdd5fd3b", size = 3398577, upload-time = "2026-08-11T21:16:59.092Z" },
+    { url = "https://files.pythonhosted.org/packages/15/c3/2887cf9dd111d1fbf05d22165b404c221ef43e029f7a2695e7302f27a7cc/sqlalchemy-2.0.52-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:37a4d548327b6cab9c7d8cdb4e0e82feabee0110c4d150059068e2d1cfbd99ee", size = 3328225, upload-time = "2026-08-11T21:02:40.183Z" },
+    { url = "https://files.pythonhosted.org/packages/02/0f/466bdf9e1feeeef5587f868c187d8687e21ff8c85b1775e9041130181132/sqlalchemy-2.0.52-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e49f51a5d59857a7a0dcaf9469febf7197d9394bd88f00d69c2c4e848112cdbf", size = 3357374, upload-time = "2026-08-11T21:17:01.076Z" },
+    { url = "https://files.pythonhosted.org/packages/22/20/5c2b4583904af4173076dda1c9e53c9e2ffc7a702d2efde0216bbacbf7cb/sqlalchemy-2.0.52-cp312-cp312-win32.whl", hash = "sha256:afda3ec521d0517d0de783fc70030775841900896d832de5bbd066549290470e", size = 2129366, upload-time = "2026-08-11T21:14:50.991Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/06/543dab8ef62d4e9fb96fb31a30c2b8b14a8763bccf48d428294d6b3041c0/sqlalchemy-2.0.52-cp312-cp312-win_amd64.whl", hash = "sha256:2d5e53e36e37129fe0be8b9d08b6e4052c10a963ee6cda56c8c10dcc194b99ca", size = 2157344, upload-time = "2026-08-11T21:14:52.453Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/3f/3582293d1e185e71d19d7c731c3e2ee20ba21981c4a1115c0806c1f62120/sqlalchemy-2.0.52-py3-none-any.whl", hash = "sha256:3b81b8363a919ce53453591cdb93702e6bd54ade6c4fa2f468fc053baee5ed89", size = 1950700, upload-time = "2026-08-11T20:47:21.603Z" },
+]
+
+[[package]]
+name = "sqlparse"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/d3/3f06a1006f2261d1342aefb3c71eed02f5d4ca5bdbecd86ebc12ad38306e/sqlparse-0.6.0.tar.gz", hash = "sha256:113c35c75365ab9cc9c7231d68c6428fb11c085fc8e9eb1ad659b7ddbf6cd2b9", size = 178477, upload-time = "2026-08-13T19:16:06.396Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/50/f00935da0ec7cbf325f8dc4f772ae46fbc7b672dd62876e73f0a94adda57/sqlparse-0.6.0-py3-none-any.whl", hash = "sha256:b861c0288ce2fa56209a9a6412d2e066ac664b3873b89c26c9d8415e8e32996f", size = 50070, upload-time = "2026-08-13T19:16:04.062Z" },
+]
+
+[[package]]
 name = "sqltrie"
 version = "0.11.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1987,6 +2299,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8a/e6/f3832264bcd98b9e71c93c579ab6b39eb1db659cab305e59f8f7c1adc777/sqltrie-0.11.2.tar.gz", hash = "sha256:4df47089b3abfe347bcf81044e633b8c7737ebda4ce1fec8b636a85954ac36da", size = 23551, upload-time = "2025-02-19T15:11:35.474Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0a/a7/96dd20ed6c4008ca57aa14bd89588eff1dfc163f45067cf715df290dc211/sqltrie-0.11.2-py3-none-any.whl", hash = "sha256:4afb1390bbe8a6900a53709b76213a436fbaf352de0b99ba9b0d395d4a0ca6b6", size = 17140, upload-time = "2025-02-19T15:11:34.044Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/b4/205b0d5241d934e8add0c38aa924c4f9fb7330834ff11e5444db964ec3f9/starlette-1.6.0.tar.gz", hash = "sha256:d4e3ac5e546444960c710297a3c9fc3f7ebae1b7e963f3d36173b49da535be9b", size = 2716969, upload-time = "2026-08-08T18:27:57.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/cb/6a6a47d5b464bd08695d254f3da6e7986cc70c9fa5d778eda57538edfe56/starlette-1.6.0-py3-none-any.whl", hash = "sha256:a86dd39d14bb45f85a3d18525215a9ef0cfd1f192ac793220e72598c90335f0c", size = 75969, upload-time = "2026-08-08T18:27:56.196Z" },
 ]
 
 [[package]]
@@ -2116,6 +2441,19 @@ wheels = [
 ]
 
 [[package]]
+name = "uvicorn"
+version = "0.52.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/0f/3f86e61397dd33bf2ccf28188c40db6a740658aeebbbf6e7dbc101a1f487/uvicorn-0.52.4.tar.gz", hash = "sha256:73acfee47a0b133c5de13d219492d62d8a31e935f4fe6e41a232451a15379f86", size = 100627, upload-time = "2026-08-19T06:27:41.821Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/79/4a20b54ab0491485ccd8c077db2d39187c7f12b3e15485d38a7be37c81b4/uvicorn-0.52.4-py3-none-any.whl", hash = "sha256:f86e41a149d7d05a9969337e3946a9c171c06a5d42680896daaba624aeac8da1", size = 79871, upload-time = "2026-08-19T06:27:40.36Z" },
+]
+
+[[package]]
 name = "vine"
 version = "5.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2218,4 +2556,13 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/10/9a/2fef89272d98b799e4daa50201c5582ec76bdd4e92a1a7e3deb74c52b7fa/zc_lockfile-4.0.tar.gz", hash = "sha256:d3ab0f53974296a806db3219b9191ba0e6d5cbbd1daa2e0d17208cb9b29d2102", size = 10956, upload-time = "2025-09-18T07:32:34.412Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/7f/3a614b65bc4b181578b1d50a78663ee02d5d2d3b859712f3d3597c8afe6f/zc_lockfile-4.0-py3-none-any.whl", hash = "sha256:aa3aa295257bebaa09ea9ad5cb288bf9f98f88de6932f96b6659f62715d83581", size = 9143, upload-time = "2025-09-18T07:32:33.517Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
 ]


### PR DESCRIPTION
Closes #27

## Summary

- add an optional, tracking-only MLflow dependency group
- log one completed reference baseline to a local SQLite ledger with source, data, split, feature, configuration, seed, environment, hardware, parameter, and metric identities
- store the configuration, report, confusion matrix, predictions, and portable lineage file as local artifacts
- query the run and byte-verify every artifact against hashes anchored in MLflow metadata

## Scope boundary

This is only the experiment-lineage seam needed by #24. It does **not** add training, a tracking server, a dashboard, model registry workflows, DVC claims for the licensed corpus, distributed execution, or frontend integration.

## Verification

- 1,340 passed, 13 skipped, 0 failed
- total coverage: 90.12%
- Ruff lint and formatting checks passed
- strict mypy passed
- lockfile, distribution build, repository hygiene, DVC graph, and feature resource checks passed
