### PR TITLE
Run MediaPipe landmark extraction in a Web Worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,9 @@ three exact representation variants, optional geometry and elapsed-time kinemati
 masked training-only statistics, and content-addressed cache objects. Licensed
 PopSign execution now produces one deterministic, leakage-checked 80-sample public
 smoke split from the verified retained landmark inventory without rerunning MediaPipe.
-A responsive React/Vite shell now exposes the planned public routes without a backend;
-camera access, replay, feedback storage, and model inference remain explicitly
+A responsive React/Vite shell now exposes the planned public routes without a backend
+and includes a dormant MediaPipe landmark-worker boundary; camera access, model-bundle
+delivery, replay, feedback storage, and gesture inference remain explicitly
 unconnected. A minimal local MLflow ledger can now log, query, and byte-verify one
 portable baseline result without a server or custom dashboard. The first frozen
 signer-disjoint benchmark now compares majority, seeded stratified-random, and

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "@signlab/web",
       "version": "0.1.0",
       "dependencies": {
+        "@mediapipe/tasks-vision": "1.0.1",
         "react": "19.2.8",
         "react-dom": "19.2.8",
         "react-router-dom": "7.18.3"
@@ -757,6 +758,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@mediapipe/tasks-vision": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@mediapipe/tasks-vision/-/tasks-vision-1.0.1.tgz",
+      "integrity": "sha512-rvRE2FmAZ6ZxKSw7wq+e+jQDpN3t1B/tD2mJz9SmAzb1msoDkd4dMoE4wAh8Z30Um0PQwLiHr9QtomhmXk3aUQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/@oxc-project/types": {
       "version": "0.147.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.app.json && tsc --noEmit -p tsconfig.node.json"
   },
   "dependencies": {
+    "@mediapipe/tasks-vision": "1.0.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "react-router-dom": "7.18.3"

--- a/apps/web/src/app/routeDefinitions.ts
+++ b/apps/web/src/app/routeDefinitions.ts
@@ -1,3 +1,5 @@
+import { supportsLandmarkWorkerRuntime } from "../landmarks/LandmarkWorkerClient";
+
 export interface StaticPageDefinition {
   path: string;
   label: string;
@@ -10,6 +12,10 @@ export interface StaticPageDefinition {
   note?: string;
 }
 
+const landmarkRuntimeSupport = supportsLandmarkWorkerRuntime()
+  ? "This browser exposes the Worker, ImageBitmap, OffscreenCanvas, WebAssembly, and SIMD capabilities needed by the later demo."
+  : "This browser does not expose every Worker, ImageBitmap, OffscreenCanvas, WebAssembly, and SIMD capability needed by the later demo.";
+
 export const staticPages = [
   {
     path: "/live",
@@ -19,12 +25,14 @@ export const staticPages = [
     summary:
       "This page will eventually recognize one completed gesture event at a time from five project prompts: Hello, No, Please, Thank you, and Yes.",
     status:
-      "Not available in this scaffold. No camera permission is requested, no frames are processed, and no model is loaded.",
-    detailsTitle: "Planned boundary",
+      "Landmark extraction is implemented off the UI thread but is not active on this page yet. No camera permission is requested, no frame is captured, and no model bundle is loaded.",
+    detailsTitle: "Current worker boundary",
     details: [
-      "Inference will run on the user’s device.",
-      "The system may abstain when evidence is uncertain.",
-      "Only five predefined prompts are in scope.",
+      "Once supplied with already-verified model bytes, MediaPipe initializes once inside a worker.",
+      "The worker returns typed hand and body landmarks and keeps only the newest waiting frame.",
+      "Processed or replaced frames are released, and image data is not logged.",
+      landmarkRuntimeSupport,
+      "Camera controls and gesture recognition remain separate follow-up work.",
     ],
     note: "These English labels are project prompts, not a validated claim about ASL vocabulary.",
   },

--- a/apps/web/src/landmarks/LandmarkWorkerClient.test.ts
+++ b/apps/web/src/landmarks/LandmarkWorkerClient.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  LandmarkWorkerClient,
+  type LandmarkClientEvent,
+  type LandmarkWorkerPort,
+} from "./LandmarkWorkerClient";
+import {
+  LANDMARK_WORKER_PROTOCOL_VERSION,
+  absentBodyAnchors,
+  absentHandSlots,
+  type LandmarkWorkerInputMessage,
+  type LandmarkWorkerOutputMessage,
+  type ProcessLandmarkFrame,
+} from "./protocol";
+
+class ManualWorkerPort implements LandmarkWorkerPort {
+  readonly posts: Array<{
+    message: LandmarkWorkerInputMessage;
+    transfer: readonly Transferable[];
+  }> = [];
+  readonly terminate = vi.fn();
+  private messageListener: ((message: LandmarkWorkerOutputMessage) => void) | undefined;
+  private errorListener: (() => void) | undefined;
+
+  post(message: LandmarkWorkerInputMessage, transfer: readonly Transferable[] = []): void {
+    this.posts.push({ message, transfer });
+  }
+
+  onMessage(listener: (message: LandmarkWorkerOutputMessage) => void): () => void {
+    this.messageListener = listener;
+    return () => {
+      this.messageListener = undefined;
+    };
+  }
+
+  onError(listener: () => void): () => void {
+    this.errorListener = listener;
+    return () => {
+      this.errorListener = undefined;
+    };
+  }
+
+  emit(message: LandmarkWorkerOutputMessage): void {
+    this.messageListener?.(message);
+  }
+
+  fail(): void {
+    this.errorListener?.();
+  }
+}
+
+interface TestFrame {
+  readonly bitmap: ImageBitmap;
+  readonly close: ReturnType<typeof vi.fn>;
+}
+
+function frame(): TestFrame {
+  const close = vi.fn();
+  return { bitmap: { close } as unknown as ImageBitmap, close };
+}
+
+function ready(): LandmarkWorkerOutputMessage {
+  return {
+    type: "ready",
+    protocolVersion: LANDMARK_WORKER_PROTOCOL_VERSION,
+    startupMs: 5,
+    failureCount: 0,
+  };
+}
+
+function completedFrame(message: ProcessLandmarkFrame): LandmarkWorkerOutputMessage {
+  return {
+    type: "frame",
+    protocolVersion: LANDMARK_WORKER_PROTOCOL_VERSION,
+    frameId: message.frameId,
+    relativeTimestampUs: message.relativeTimestampUs,
+    taskTimestampMs: message.taskTimestampMs,
+    valid: true,
+    invalidReason: null,
+    failureCode: null,
+    hands: absentHandSlots(),
+    bodyAnchors: absentBodyAnchors(),
+    processingMs: 4,
+    failureCount: 0,
+  };
+}
+
+function processMessages(port: ManualWorkerPort): ProcessLandmarkFrame[] {
+  return port.posts
+    .map(({ message }) => message)
+    .filter((message): message is ProcessLandmarkFrame => message.type === "process-frame");
+}
+
+describe("LandmarkWorkerClient", () => {
+  it("keeps only one in-flight frame and the newest waiting frame under load", async () => {
+    const port = new ManualWorkerPort();
+    const events: LandmarkClientEvent[] = [];
+    const client = new LandmarkWorkerClient(port, (event) => events.push(event));
+    const handModel = new ArrayBuffer(2);
+    const poseModel = new ArrayBuffer(3);
+    client.initialize(handModel, poseModel);
+    port.emit(ready());
+
+    const frames = Array.from({ length: 10_000 }, frame);
+    let maximumRetained = 0;
+    for (const current of frames) {
+      client.submitFrame(current.bitmap, 100);
+      const metrics = client.metrics();
+      maximumRetained = Math.max(maximumRetained, metrics.inFlightFrames + metrics.pendingFrames);
+    }
+
+    expect(port.posts[0]).toMatchObject({
+      message: { type: "initialize", handModelBuffer: handModel, poseModelBuffer: poseModel },
+      transfer: [handModel, poseModel],
+    });
+    expect(processMessages(port)).toHaveLength(1);
+    expect(client.metrics()).toEqual({
+      droppedFrames: 9_998,
+      failureEvents: 0,
+      inFlightFrames: 1,
+      pendingFrames: 1,
+    });
+    expect(maximumRetained).toBe(2);
+
+    const first = processMessages(port)[0];
+    expect(first).toMatchObject({ frameId: 0, relativeTimestampUs: 0, taskTimestampMs: 0 });
+    if (first === undefined) throw new Error("expected the first frame message");
+    port.emit(completedFrame(first));
+
+    const sent = processMessages(port);
+    expect(sent).toHaveLength(2);
+    expect(sent[1]).toMatchObject({
+      frameId: 9_999,
+      relativeTimestampUs: 0,
+      taskTimestampMs: 1,
+    });
+    expect(frames[0]?.close).not.toHaveBeenCalled();
+    expect(frames[9_999]?.close).not.toHaveBeenCalled();
+    expect(frames.slice(1, -1).every(({ close }) => close.mock.calls.length === 1)).toBe(true);
+
+    const dropped = events.filter(({ type }) => type === "frame-dropped");
+    expect(dropped).toHaveLength(9_998);
+    expect(dropped.at(-1)).toEqual({
+      type: "frame-dropped",
+      frameId: 9_998,
+      droppedFrames: 9_998,
+    });
+    expect(JSON.stringify(dropped)).not.toContain("bitmap");
+
+    const latest = sent[1];
+    if (latest === undefined) throw new Error("expected the newest frame message");
+    port.emit(completedFrame(latest));
+    const closing = client.close();
+    port.emit({
+      type: "stopped",
+      protocolVersion: LANDMARK_WORKER_PROTOCOL_VERSION,
+      failureCount: 0,
+    });
+    await closing;
+    expect(port.terminate).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes a waiting frame and terminates when the worker transport fails", async () => {
+    const port = new ManualWorkerPort();
+    const events: LandmarkClientEvent[] = [];
+    const client = new LandmarkWorkerClient(port, (event) => events.push(event));
+    client.initialize(new ArrayBuffer(1), new ArrayBuffer(1));
+    const waiting = frame();
+    client.submitFrame(waiting.bitmap, 0);
+
+    port.fail();
+
+    expect(waiting.close).toHaveBeenCalledTimes(1);
+    expect(events.at(-1)).toEqual({
+      type: "worker-transport-failure",
+      code: "extraction.worker.transport.failed",
+      failureCount: 1,
+    });
+    expect(port.terminate).toHaveBeenCalledTimes(1);
+    await expect(client.close()).resolves.toBeUndefined();
+    expect(port.terminate).toHaveBeenCalledTimes(1);
+  });
+
+  it("makes an early stopped message terminal and clears retained-frame metrics", async () => {
+    const port = new ManualWorkerPort();
+    const client = new LandmarkWorkerClient(port, vi.fn());
+    client.initialize(new ArrayBuffer(1), new ArrayBuffer(1));
+    port.emit(ready());
+    client.submitFrame(frame().bitmap, 0);
+
+    port.emit({
+      type: "stopped",
+      protocolVersion: LANDMARK_WORKER_PROTOCOL_VERSION,
+      failureCount: 0,
+    });
+
+    expect(client.metrics()).toMatchObject({ inFlightFrames: 0, pendingFrames: 0 });
+    const rejected = frame();
+    expect(() => client.submitFrame(rejected.bitmap, 1)).toThrow(
+      "The landmark worker is not accepting frames",
+    );
+    expect(rejected.close).toHaveBeenCalledTimes(1);
+    expect(port.terminate).toHaveBeenCalledTimes(1);
+    await expect(client.close()).resolves.toBeUndefined();
+  });
+});

--- a/apps/web/src/landmarks/LandmarkWorkerClient.ts
+++ b/apps/web/src/landmarks/LandmarkWorkerClient.ts
@@ -1,0 +1,356 @@
+import {
+  LANDMARK_WORKER_PROTOCOL_VERSION,
+  type LandmarkWorkerInputMessage,
+  type LandmarkWorkerOutputMessage,
+} from "./protocol";
+
+export interface LandmarkWorkerPort {
+  post(message: LandmarkWorkerInputMessage, transfer?: readonly Transferable[]): void;
+  onMessage(listener: (message: LandmarkWorkerOutputMessage) => void): () => void;
+  onError(listener: () => void): () => void;
+  terminate(): void;
+}
+
+export interface FrameDroppedEvent {
+  readonly type: "frame-dropped";
+  readonly frameId: number;
+  readonly droppedFrames: number;
+}
+
+export interface WorkerTransportFailureEvent {
+  readonly type: "worker-transport-failure";
+  readonly code: "extraction.worker.transport.failed";
+  readonly failureCount: number;
+}
+
+export type LandmarkClientEvent =
+  LandmarkWorkerOutputMessage | FrameDroppedEvent | WorkerTransportFailureEvent;
+
+export interface LandmarkWorkerMetrics {
+  readonly droppedFrames: number;
+  readonly failureEvents: number;
+  readonly inFlightFrames: 0 | 1;
+  readonly pendingFrames: 0 | 1;
+}
+
+interface PendingFrame {
+  readonly frameId: number;
+  readonly relativeTimestampUs: number;
+  readonly frame: ImageBitmap;
+}
+
+class BrowserLandmarkWorkerPort implements LandmarkWorkerPort {
+  private readonly worker = new Worker(new URL("./landmark.worker.ts", import.meta.url), {
+    name: "signlab-landmarks",
+    type: "module",
+  });
+
+  post(message: LandmarkWorkerInputMessage, transfer: readonly Transferable[] = []): void {
+    this.worker.postMessage(message, [...transfer]);
+  }
+
+  onMessage(listener: (message: LandmarkWorkerOutputMessage) => void): () => void {
+    const handler = (event: MessageEvent<LandmarkWorkerOutputMessage>) => {
+      listener(event.data);
+    };
+    this.worker.addEventListener("message", handler);
+    return () => {
+      this.worker.removeEventListener("message", handler);
+    };
+  }
+
+  onError(listener: () => void): () => void {
+    const handler = () => {
+      listener();
+    };
+    this.worker.addEventListener("error", handler);
+    return () => {
+      this.worker.removeEventListener("error", handler);
+    };
+  }
+
+  terminate(): void {
+    this.worker.terminate();
+  }
+}
+
+export function supportsLandmarkWorkerRuntime(): boolean {
+  const simdProbe = new Uint8Array([
+    0, 97, 115, 109, 1, 0, 0, 0, 1, 5, 1, 96, 0, 1, 123, 3, 2, 1, 0, 10, 10, 1, 8, 0, 65, 0, 253,
+    15, 253, 98, 11,
+  ]);
+  return (
+    typeof Worker !== "undefined" &&
+    typeof ImageBitmap !== "undefined" &&
+    typeof OffscreenCanvas !== "undefined" &&
+    typeof WebAssembly !== "undefined" &&
+    typeof WebAssembly.validate === "function" &&
+    WebAssembly.validate(simdProbe)
+  );
+}
+
+export function createLandmarkWorkerClient(
+  onEvent: (event: LandmarkClientEvent) => void,
+): LandmarkWorkerClient {
+  return new LandmarkWorkerClient(new BrowserLandmarkWorkerPort(), onEvent);
+}
+
+export class LandmarkWorkerClient {
+  private initialized = false;
+  private ready = false;
+  private acceptingFrames = true;
+  private failed = false;
+  private nextFrameId = 0;
+  private originTimestampUs: number | undefined;
+  private previousCaptureTimestampUs = -1;
+  private previousTaskTimestampMs = -1;
+  private inFlightFrameId: number | null = null;
+  private pendingFrame: PendingFrame | null = null;
+  private droppedFrames = 0;
+  private failureEvents = 0;
+  private closePromise: Promise<void> | undefined;
+  private finishClose: (() => void) | undefined;
+  private closeTimer: ReturnType<typeof setTimeout> | undefined;
+  private finalized = false;
+  private readonly removeMessageListener: () => void;
+  private readonly removeErrorListener: () => void;
+
+  constructor(
+    private readonly port: LandmarkWorkerPort,
+    private readonly onEvent: (event: LandmarkClientEvent) => void,
+  ) {
+    this.removeMessageListener = port.onMessage((message) => {
+      this.handleMessage(message);
+    });
+    this.removeErrorListener = port.onError(() => {
+      this.failTransport();
+    });
+  }
+
+  initialize(handModelBuffer: ArrayBuffer, poseModelBuffer: ArrayBuffer): void {
+    if (this.initialized || !this.acceptingFrames || this.failed) {
+      throw new Error("The landmark worker can only be initialized once");
+    }
+    this.initialized = true;
+    try {
+      this.port.post(
+        {
+          type: "initialize",
+          protocolVersion: LANDMARK_WORKER_PROTOCOL_VERSION,
+          handModelBuffer,
+          poseModelBuffer,
+        },
+        [handModelBuffer, poseModelBuffer],
+      );
+    } catch {
+      this.failTransport();
+    }
+  }
+
+  submitFrame(frame: ImageBitmap, captureTimestampMs: number): number {
+    if (!this.initialized || !this.acceptingFrames || this.failed) {
+      frame.close();
+      throw new Error("The landmark worker is not accepting frames");
+    }
+    if (!Number.isFinite(captureTimestampMs) || captureTimestampMs < 0) {
+      frame.close();
+      throw new Error("captureTimestampMs must be finite and non-negative");
+    }
+    const captureTimestampUs = Math.round(captureTimestampMs * 1_000);
+    if (
+      !Number.isSafeInteger(captureTimestampUs) ||
+      captureTimestampUs < this.previousCaptureTimestampUs
+    ) {
+      frame.close();
+      throw new Error("Frame capture timestamps must be safe and monotonic");
+    }
+    this.originTimestampUs ??= captureTimestampUs;
+    const relativeTimestampUs = captureTimestampUs - this.originTimestampUs;
+    this.previousCaptureTimestampUs = captureTimestampUs;
+
+    if (!Number.isSafeInteger(this.nextFrameId)) {
+      frame.close();
+      throw new Error("The landmark worker exhausted its frame identifiers");
+    }
+
+    const pending: PendingFrame = {
+      frameId: this.nextFrameId,
+      relativeTimestampUs,
+      frame,
+    };
+    this.nextFrameId += 1;
+
+    if (!this.ready || this.inFlightFrameId !== null) {
+      this.replacePending(pending);
+    } else {
+      this.send(pending);
+    }
+    return pending.frameId;
+  }
+
+  metrics(): LandmarkWorkerMetrics {
+    return {
+      droppedFrames: this.droppedFrames,
+      failureEvents: this.failureEvents,
+      inFlightFrames: this.inFlightFrameId === null ? 0 : 1,
+      pendingFrames: this.pendingFrame === null ? 0 : 1,
+    };
+  }
+
+  close(timeoutMs = 2_000): Promise<void> {
+    if (this.closePromise !== undefined) return this.closePromise;
+    if (this.finalized) {
+      this.closePromise = Promise.resolve();
+      return this.closePromise;
+    }
+    this.acceptingFrames = false;
+    this.releasePending();
+    this.closePromise = new Promise<void>((resolve) => {
+      this.finishClose = resolve;
+    });
+    if (!this.initialized || this.failed) {
+      this.finalizeClose();
+      return this.closePromise;
+    }
+    try {
+      this.port.post({
+        type: "stop",
+        protocolVersion: LANDMARK_WORKER_PROTOCOL_VERSION,
+      });
+    } catch {
+      this.failTransport();
+      return this.closePromise;
+    }
+    this.closeTimer = setTimeout(() => {
+      this.finalizeClose();
+    }, timeoutMs);
+    return this.closePromise;
+  }
+
+  private replacePending(frame: PendingFrame): void {
+    const replaced = this.pendingFrame;
+    this.pendingFrame = frame;
+    if (replaced !== null) {
+      replaced.frame.close();
+      this.droppedFrames += 1;
+      this.onEvent({
+        type: "frame-dropped",
+        frameId: replaced.frameId,
+        droppedFrames: this.droppedFrames,
+      });
+    }
+  }
+
+  private send(pending: PendingFrame): void {
+    this.pendingFrame = null;
+    this.inFlightFrameId = pending.frameId;
+    const taskTimestampMs = Math.max(
+      Math.floor(pending.relativeTimestampUs / 1_000),
+      this.previousTaskTimestampMs + 1,
+    );
+    this.previousTaskTimestampMs = taskTimestampMs;
+    try {
+      this.port.post(
+        {
+          type: "process-frame",
+          protocolVersion: LANDMARK_WORKER_PROTOCOL_VERSION,
+          frameId: pending.frameId,
+          relativeTimestampUs: pending.relativeTimestampUs,
+          taskTimestampMs,
+          frame: pending.frame,
+        },
+        [pending.frame],
+      );
+    } catch {
+      this.inFlightFrameId = null;
+      pending.frame.close();
+      this.failTransport();
+    }
+  }
+
+  private flushPending(): void {
+    if (
+      !this.ready ||
+      !this.acceptingFrames ||
+      this.inFlightFrameId !== null ||
+      this.pendingFrame === null
+    ) {
+      return;
+    }
+    this.send(this.pendingFrame);
+  }
+
+  private handleMessage(message: LandmarkWorkerOutputMessage): void {
+    if (message.protocolVersion !== LANDMARK_WORKER_PROTOCOL_VERSION) {
+      this.failTransport();
+      return;
+    }
+    this.failureEvents = Math.max(this.failureEvents, message.failureCount);
+
+    if (message.type === "ready") {
+      this.ready = true;
+      this.flushPending();
+      this.onEvent(message);
+      return;
+    }
+    if (message.type === "frame") {
+      if (message.frameId !== this.inFlightFrameId) {
+        this.failTransport();
+        return;
+      }
+      this.inFlightFrameId = null;
+      this.flushPending();
+      this.onEvent(message);
+      return;
+    }
+    if (message.type === "failure") {
+      this.failed = true;
+      this.ready = false;
+      this.acceptingFrames = false;
+      this.inFlightFrameId = null;
+      this.releasePending();
+      this.finalizeClose();
+      this.onEvent(message);
+      return;
+    }
+    this.finalizeClose();
+    this.onEvent(message);
+  }
+
+  private releasePending(): void {
+    this.pendingFrame?.frame.close();
+    this.pendingFrame = null;
+  }
+
+  private failTransport(): void {
+    if (this.failed) return;
+    this.failed = true;
+    this.ready = false;
+    this.acceptingFrames = false;
+    this.inFlightFrameId = null;
+    this.failureEvents += 1;
+    this.releasePending();
+    this.finalizeClose();
+    this.onEvent({
+      type: "worker-transport-failure",
+      code: "extraction.worker.transport.failed",
+      failureCount: this.failureEvents,
+    });
+  }
+
+  private finalizeClose(): void {
+    if (this.finalized) return;
+    this.finalized = true;
+    this.acceptingFrames = false;
+    this.ready = false;
+    this.inFlightFrameId = null;
+    this.releasePending();
+    if (this.closeTimer !== undefined) clearTimeout(this.closeTimer);
+    this.closeTimer = undefined;
+    this.removeMessageListener();
+    this.removeErrorListener();
+    this.port.terminate();
+    this.finishClose?.();
+    this.finishClose = undefined;
+  }
+}

--- a/apps/web/src/landmarks/landmark.worker.ts
+++ b/apps/web/src/landmarks/landmark.worker.ts
@@ -1,0 +1,21 @@
+import { createMediaPipeDetector } from "./mediapipeRuntime";
+import type { LandmarkWorkerInputMessage, LandmarkWorkerOutputMessage } from "./protocol";
+import { LandmarkWorkerSession } from "./workerSession";
+
+interface LandmarkWorkerScope {
+  onmessage: ((event: MessageEvent<LandmarkWorkerInputMessage>) => void) | null;
+  postMessage(message: LandmarkWorkerOutputMessage): void;
+  close(): void;
+}
+
+const workerScope = self as unknown as LandmarkWorkerScope;
+const session = new LandmarkWorkerSession(createMediaPipeDetector, (message) => {
+  workerScope.postMessage(message);
+});
+
+workerScope.onmessage = (event) => {
+  const stopAfterHandling = event.data.type === "stop";
+  void session.handle(event.data).finally(() => {
+    if (stopAfterHandling) workerScope.close();
+  });
+};

--- a/apps/web/src/landmarks/mediapipeRuntime.test.ts
+++ b/apps/web/src/landmarks/mediapipeRuntime.test.ts
@@ -1,0 +1,140 @@
+import { HandLandmarker, PoseLandmarker } from "@mediapipe/tasks-vision";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  PINNED_MEDIAPIPE_CONFIG,
+  createMediaPipeDetector,
+  normalizeHandResult,
+  normalizePoseResult,
+} from "./mediapipeRuntime";
+
+function points(count: number, x = 0.25) {
+  return Array.from({ length: count }, () => ({ x, y: 0.5, z: -0.1, visibility: 0.8 }));
+}
+
+function oneHandResult() {
+  return {
+    landmarks: [points(21)],
+    worldLandmarks: [points(21, 0.75)],
+    handedness: [[{ score: 0.91, index: 0, categoryName: "Left", displayName: "" }]],
+  };
+}
+
+function onePoseResult() {
+  return { landmarks: [points(33)], worldLandmarks: [points(33, 0.75)] };
+}
+
+describe("MediaPipe landmark normalization", () => {
+  it("returns two-hand-compatible observations and the six configured pose anchors", () => {
+    const hands = normalizeHandResult(oneHandResult());
+    const anchors = normalizePoseResult(onePoseResult());
+
+    expect(hands).toHaveLength(1);
+    expect(hands[0]).toMatchObject({
+      detectorIndex: 0,
+      reportedHandedness: "left",
+      handednessConfidence: 0.91,
+    });
+    expect(hands[0]?.imageLandmarks).toHaveLength(21);
+    expect(hands[0]?.imageLandmarks[0]).toEqual({
+      x: 0.25,
+      y: 0.5,
+      z: -0.1,
+      visibility: 0.8,
+      presence: null,
+    });
+    expect(anchors.map(({ name }) => name)).toEqual([
+      "left_shoulder",
+      "right_shoulder",
+      "left_elbow",
+      "right_elbow",
+      "left_wrist",
+      "right_wrist",
+    ]);
+    expect(anchors.every(({ present }) => present)).toBe(true);
+  });
+
+  it("represents an absent pose and fails closed on malformed observations", () => {
+    expect(normalizePoseResult({ landmarks: [], worldLandmarks: [] })).toMatchObject(
+      Array.from({ length: 6 }, () => ({ present: false })),
+    );
+    expect(() =>
+      normalizeHandResult({
+        ...oneHandResult(),
+        landmarks: [points(20)],
+      }),
+    ).toThrow("extraction.result.invalid");
+    expect(() =>
+      normalizeHandResult({
+        ...oneHandResult(),
+        handedness: [[{ score: Number.NaN, index: 0, categoryName: "Left", displayName: "" }]],
+      }),
+    ).toThrow("extraction.result.invalid");
+  });
+});
+
+describe("createMediaPipeDetector", () => {
+  it("initializes both pinned VIDEO tasks once and closes their resources once", async () => {
+    const handResult = oneHandResult();
+    const poseResult = { ...onePoseResult(), close: vi.fn() };
+    const handDetect = vi.fn(() => handResult);
+    const poseDetect = vi.fn(() => poseResult);
+    const handClose = vi.fn();
+    const poseClose = vi.fn();
+    const handTask = {
+      detectForVideo: handDetect,
+      close: handClose,
+    } as unknown as HandLandmarker;
+    const poseTask = {
+      detectForVideo: poseDetect,
+      close: poseClose,
+    } as unknown as PoseLandmarker;
+    const createHand = vi.spyOn(HandLandmarker, "createFromOptions").mockResolvedValue(handTask);
+    const createPose = vi.spyOn(PoseLandmarker, "createFromOptions").mockResolvedValue(poseTask);
+
+    const detector = await createMediaPipeDetector({
+      handModelBuffer: Uint8Array.from([1, 2]).buffer,
+      poseModelBuffer: Uint8Array.from([3, 4]).buffer,
+    });
+    const frame = {} as ImageBitmap;
+    const result = detector.infer(frame, 12);
+    handClose.mockImplementationOnce(() => {
+      throw new Error("close failed");
+    });
+    expect(() => detector.close()).toThrow("close failed");
+    detector.close();
+
+    expect(createHand).toHaveBeenCalledTimes(1);
+    expect(createPose).toHaveBeenCalledTimes(1);
+    expect(createHand.mock.calls[0]?.[0].wasmLoaderPath).not.toBe(
+      createPose.mock.calls[0]?.[0].wasmLoaderPath,
+    );
+    expect(createHand.mock.calls[0]?.[0].wasmBinaryPath).toBe(
+      createPose.mock.calls[0]?.[0].wasmBinaryPath,
+    );
+    expect(createHand.mock.calls[0]?.[1]).toMatchObject({
+      baseOptions: { delegate: "CPU" },
+      runningMode: "VIDEO",
+      numHands: 2,
+      minHandDetectionConfidence: 0.5,
+      minHandPresenceConfidence: 0.5,
+      minTrackingConfidence: 0.5,
+    });
+    expect(createPose.mock.calls[0]?.[1]).toMatchObject({
+      baseOptions: { delegate: "CPU" },
+      runningMode: "VIDEO",
+      numPoses: 1,
+      minPoseDetectionConfidence: 0.5,
+      minPosePresenceConfidence: 0.5,
+      minTrackingConfidence: 0.5,
+      outputSegmentationMasks: false,
+    });
+    expect(handDetect).toHaveBeenCalledWith(frame, 12);
+    expect(poseDetect).toHaveBeenCalledWith(frame, 12);
+    expect(result.hands).toHaveLength(1);
+    expect(result.bodyAnchors).toHaveLength(PINNED_MEDIAPIPE_CONFIG.bodyAnchorIndices.length);
+    expect(poseResult.close).toHaveBeenCalledTimes(1);
+    expect(handClose).toHaveBeenCalledTimes(1);
+    expect(poseClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/landmarks/mediapipeRuntime.ts
+++ b/apps/web/src/landmarks/mediapipeRuntime.ts
@@ -1,0 +1,260 @@
+import {
+  HandLandmarker,
+  PoseLandmarker,
+  type HandLandmarkerResult,
+  type Landmark,
+  type NormalizedLandmark,
+  type PoseLandmarkerResult,
+} from "@mediapipe/tasks-vision";
+import wasmBinaryUrl from "@mediapipe/tasks-vision/vision_wasm_module_internal.wasm?url";
+import wasmLoaderUrl from "@mediapipe/tasks-vision/vision_wasm_module_internal.js?url";
+
+import {
+  BODY_ANCHOR_NAMES,
+  type BodyAnchor,
+  type BodyAnchors,
+  type LandmarkPoint,
+  type ReportedHandedness,
+} from "./protocol";
+import type { HandDetection } from "./tracking";
+
+const BODY_ANCHOR_INDICES = [11, 12, 13, 14, 15, 16] as const;
+const HAND_LANDMARK_COUNT = 21;
+const POSE_LANDMARK_COUNT = 33;
+
+export const PINNED_MEDIAPIPE_CONFIG = {
+  packageVersion: "1.0.1",
+  delegate: "CPU",
+  runningMode: "VIDEO",
+  numHands: 2,
+  numPoses: 1,
+  minHandDetectionConfidence: 0.5,
+  minHandPresenceConfidence: 0.5,
+  minHandTrackingConfidence: 0.5,
+  minPoseDetectionConfidence: 0.5,
+  minPosePresenceConfidence: 0.5,
+  minPoseTrackingConfidence: 0.5,
+  bodyAnchorIndices: BODY_ANCHOR_INDICES,
+} as const;
+
+export interface LandmarkDetectorResult {
+  readonly hands: readonly HandDetection[];
+  readonly bodyAnchors: BodyAnchors;
+}
+
+export interface LandmarkDetector {
+  infer(frame: ImageBitmap, taskTimestampMs: number): LandmarkDetectorResult;
+  close(): void;
+}
+
+export interface LandmarkModelBuffers {
+  readonly handModelBuffer: ArrayBuffer;
+  readonly poseModelBuffer: ArrayBuffer;
+}
+
+type HandResultLike = Pick<HandLandmarkerResult, "landmarks" | "worldLandmarks" | "handedness">;
+type PoseResultLike = Pick<PoseLandmarkerResult, "landmarks" | "worldLandmarks">;
+type PointLike = Landmark | NormalizedLandmark;
+
+function requireFinite(value: number): number {
+  if (!Number.isFinite(value)) throw new Error("extraction.result.invalid");
+  return value;
+}
+
+function optionalUnitInterval(value: number | undefined): number | null {
+  if (value === undefined) return null;
+  if (!Number.isFinite(value) || value < 0 || value > 1) {
+    throw new Error("extraction.result.invalid");
+  }
+  return value;
+}
+
+function requiredUnitInterval(value: number | undefined): number {
+  const normalized = optionalUnitInterval(value);
+  if (normalized === null) throw new Error("extraction.result.invalid");
+  return normalized;
+}
+
+function normalizePoint(point: PointLike): LandmarkPoint {
+  return {
+    x: requireFinite(point.x),
+    y: requireFinite(point.y),
+    z: requireFinite(point.z),
+    visibility: optionalUnitInterval(point.visibility),
+    // The JavaScript 1.0.1 landmark API does not expose a presence channel.
+    presence: null,
+  };
+}
+
+function normalizePointList(
+  points: readonly PointLike[],
+  expectedCount: number,
+): readonly LandmarkPoint[] {
+  if (points.length !== expectedCount) throw new Error("extraction.result.invalid");
+  return points.map(normalizePoint);
+}
+
+function normalizeHandedness(label: string): ReportedHandedness {
+  const normalized = label.toLowerCase();
+  if (normalized !== "left" && normalized !== "right") {
+    throw new Error("extraction.result.invalid");
+  }
+  return normalized;
+}
+
+export function normalizeHandResult(result: HandResultLike): readonly HandDetection[] {
+  const { landmarks, worldLandmarks, handedness } = result;
+  if (
+    landmarks.length > PINNED_MEDIAPIPE_CONFIG.numHands ||
+    landmarks.length !== worldLandmarks.length ||
+    landmarks.length !== handedness.length
+  ) {
+    throw new Error("extraction.result.invalid");
+  }
+
+  return landmarks.map((imagePoints, detectorIndex) => {
+    const worldPoints = worldLandmarks[detectorIndex];
+    const categories = handedness[detectorIndex];
+    const category = categories?.[0];
+    if (worldPoints === undefined || category === undefined) {
+      throw new Error("extraction.result.invalid");
+    }
+    return {
+      detectorIndex,
+      imageLandmarks: normalizePointList(imagePoints, HAND_LANDMARK_COUNT),
+      worldLandmarks: normalizePointList(worldPoints, HAND_LANDMARK_COUNT),
+      reportedHandedness: normalizeHandedness(category.categoryName),
+      handednessConfidence: requiredUnitInterval(category.score),
+    };
+  });
+}
+
+function absentAnchor(name: (typeof BODY_ANCHOR_NAMES)[number]): BodyAnchor {
+  return { name, present: false, imagePoint: null, worldPoint: null };
+}
+
+export function normalizePoseResult(result: PoseResultLike): BodyAnchors {
+  const { landmarks, worldLandmarks } = result;
+  if (
+    landmarks.length > PINNED_MEDIAPIPE_CONFIG.numPoses ||
+    landmarks.length !== worldLandmarks.length
+  ) {
+    throw new Error("extraction.result.invalid");
+  }
+  if (landmarks.length === 0) {
+    return BODY_ANCHOR_NAMES.map(absentAnchor) as unknown as BodyAnchors;
+  }
+
+  const imagePose = landmarks[0];
+  const worldPose = worldLandmarks[0];
+  if (
+    imagePose === undefined ||
+    worldPose === undefined ||
+    imagePose.length !== POSE_LANDMARK_COUNT ||
+    worldPose.length !== POSE_LANDMARK_COUNT
+  ) {
+    throw new Error("extraction.result.invalid");
+  }
+
+  return BODY_ANCHOR_NAMES.map((name, anchorIndex) => {
+    const pointIndex = BODY_ANCHOR_INDICES[anchorIndex];
+    const imagePoint = pointIndex === undefined ? undefined : imagePose[pointIndex];
+    const worldPoint = pointIndex === undefined ? undefined : worldPose[pointIndex];
+    if (imagePoint === undefined || worldPoint === undefined) {
+      throw new Error("extraction.result.invalid");
+    }
+    return {
+      name,
+      present: true,
+      imagePoint: normalizePoint(imagePoint),
+      worldPoint: normalizePoint(worldPoint),
+    };
+  }) as unknown as BodyAnchors;
+}
+
+class BrowserMediaPipeDetector implements LandmarkDetector {
+  private closed = false;
+
+  constructor(
+    private readonly handLandmarker: HandLandmarker,
+    private readonly poseLandmarker: PoseLandmarker,
+  ) {}
+
+  infer(frame: ImageBitmap, taskTimestampMs: number): LandmarkDetectorResult {
+    if (this.closed) throw new Error("extraction.runtime.closed");
+    const handResult = this.handLandmarker.detectForVideo(frame, taskTimestampMs);
+    const poseResult = this.poseLandmarker.detectForVideo(frame, taskTimestampMs);
+    try {
+      return {
+        hands: normalizeHandResult(handResult),
+        bodyAnchors: normalizePoseResult(poseResult),
+      };
+    } finally {
+      poseResult.close();
+    }
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    closeTaskPair(this.handLandmarker, this.poseLandmarker);
+  }
+}
+
+function closeTaskPair(
+  handLandmarker: HandLandmarker | undefined,
+  poseLandmarker: PoseLandmarker | undefined,
+): void {
+  try {
+    handLandmarker?.close();
+  } finally {
+    poseLandmarker?.close();
+  }
+}
+
+export async function createMediaPipeDetector(
+  models: LandmarkModelBuffers,
+): Promise<LandmarkDetector> {
+  // MediaPipe clears its loader factory after each task is created. Distinct
+  // import URLs make the module loader execute once for each task.
+  const loaderSeparator = wasmLoaderUrl.includes("?") ? "&" : "?";
+  const wasmFileset = (task: "hand" | "pose") => ({
+    wasmLoaderPath: `${wasmLoaderUrl}${loaderSeparator}task=${task}`,
+    wasmBinaryPath: wasmBinaryUrl,
+  });
+  let handLandmarker: HandLandmarker | undefined;
+  let poseLandmarker: PoseLandmarker | undefined;
+  try {
+    handLandmarker = await HandLandmarker.createFromOptions(wasmFileset("hand"), {
+      baseOptions: {
+        modelAssetBuffer: new Uint8Array(models.handModelBuffer),
+        delegate: PINNED_MEDIAPIPE_CONFIG.delegate,
+      },
+      runningMode: PINNED_MEDIAPIPE_CONFIG.runningMode,
+      numHands: PINNED_MEDIAPIPE_CONFIG.numHands,
+      minHandDetectionConfidence: PINNED_MEDIAPIPE_CONFIG.minHandDetectionConfidence,
+      minHandPresenceConfidence: PINNED_MEDIAPIPE_CONFIG.minHandPresenceConfidence,
+      minTrackingConfidence: PINNED_MEDIAPIPE_CONFIG.minHandTrackingConfidence,
+    });
+    poseLandmarker = await PoseLandmarker.createFromOptions(wasmFileset("pose"), {
+      baseOptions: {
+        modelAssetBuffer: new Uint8Array(models.poseModelBuffer),
+        delegate: PINNED_MEDIAPIPE_CONFIG.delegate,
+      },
+      runningMode: PINNED_MEDIAPIPE_CONFIG.runningMode,
+      numPoses: PINNED_MEDIAPIPE_CONFIG.numPoses,
+      minPoseDetectionConfidence: PINNED_MEDIAPIPE_CONFIG.minPoseDetectionConfidence,
+      minPosePresenceConfidence: PINNED_MEDIAPIPE_CONFIG.minPosePresenceConfidence,
+      minTrackingConfidence: PINNED_MEDIAPIPE_CONFIG.minPoseTrackingConfidence,
+      outputSegmentationMasks: false,
+    });
+    return new BrowserMediaPipeDetector(handLandmarker, poseLandmarker);
+  } catch {
+    try {
+      closeTaskPair(handLandmarker, poseLandmarker);
+    } catch {
+      // Initialization still reports one stable public failure code.
+    }
+    throw new Error("extraction.runtime.initialization.failed");
+  }
+}

--- a/apps/web/src/landmarks/protocol.ts
+++ b/apps/web/src/landmarks/protocol.ts
@@ -1,0 +1,147 @@
+export const LANDMARK_WORKER_PROTOCOL_VERSION = "signlab-landmark-worker/1" as const;
+
+export const HAND_SLOT_IDS = ["hand_0", "hand_1"] as const;
+export const BODY_ANCHOR_NAMES = [
+  "left_shoulder",
+  "right_shoulder",
+  "left_elbow",
+  "right_elbow",
+  "left_wrist",
+  "right_wrist",
+] as const;
+
+export type HandSlotId = (typeof HAND_SLOT_IDS)[number];
+export type BodyAnchorName = (typeof BODY_ANCHOR_NAMES)[number];
+export type ReportedHandedness = "left" | "right";
+
+export interface LandmarkPoint {
+  readonly x: number;
+  readonly y: number;
+  readonly z: number;
+  readonly visibility: number | null;
+  readonly presence: number | null;
+}
+
+export interface HandSlot {
+  readonly slotId: HandSlotId;
+  readonly present: boolean;
+  readonly detectorIndex: number | null;
+  readonly trackingId: HandSlotId | null;
+  readonly handedness: ReportedHandedness | null;
+  readonly handednessConfidence: number | null;
+  readonly imageLandmarks: readonly LandmarkPoint[] | null;
+  readonly worldLandmarks: readonly LandmarkPoint[] | null;
+}
+
+export interface BodyAnchor {
+  readonly name: BodyAnchorName;
+  readonly present: boolean;
+  readonly imagePoint: LandmarkPoint | null;
+  readonly worldPoint: LandmarkPoint | null;
+}
+
+export type HandSlots = readonly [HandSlot, HandSlot];
+export type BodyAnchors = readonly [
+  BodyAnchor,
+  BodyAnchor,
+  BodyAnchor,
+  BodyAnchor,
+  BodyAnchor,
+  BodyAnchor,
+];
+
+export interface InitializeLandmarkWorker {
+  readonly type: "initialize";
+  readonly protocolVersion: typeof LANDMARK_WORKER_PROTOCOL_VERSION;
+  readonly handModelBuffer: ArrayBuffer;
+  readonly poseModelBuffer: ArrayBuffer;
+}
+
+export interface ProcessLandmarkFrame {
+  readonly type: "process-frame";
+  readonly protocolVersion: typeof LANDMARK_WORKER_PROTOCOL_VERSION;
+  readonly frameId: number;
+  readonly relativeTimestampUs: number;
+  readonly taskTimestampMs: number;
+  readonly frame: ImageBitmap;
+}
+
+export interface StopLandmarkWorker {
+  readonly type: "stop";
+  readonly protocolVersion: typeof LANDMARK_WORKER_PROTOCOL_VERSION;
+}
+
+export type LandmarkWorkerInputMessage =
+  InitializeLandmarkWorker | ProcessLandmarkFrame | StopLandmarkWorker;
+
+export interface LandmarkWorkerReady {
+  readonly type: "ready";
+  readonly protocolVersion: typeof LANDMARK_WORKER_PROTOCOL_VERSION;
+  readonly startupMs: number;
+  readonly failureCount: number;
+}
+
+interface LandmarkFrameBase {
+  readonly type: "frame";
+  readonly protocolVersion: typeof LANDMARK_WORKER_PROTOCOL_VERSION;
+  readonly frameId: number;
+  readonly relativeTimestampUs: number;
+  readonly taskTimestampMs: number;
+  readonly hands: HandSlots;
+  readonly bodyAnchors: BodyAnchors;
+  readonly processingMs: number;
+  readonly failureCount: number;
+}
+
+export interface ValidLandmarkFrame extends LandmarkFrameBase {
+  readonly valid: true;
+  readonly invalidReason: null;
+  readonly failureCode: null;
+}
+
+export interface InvalidLandmarkFrame extends LandmarkFrameBase {
+  readonly valid: false;
+  readonly invalidReason: "task_inference_failed";
+  readonly failureCode: "extraction.runtime.inference.failed";
+}
+
+export type LandmarkFrameMessage = ValidLandmarkFrame | InvalidLandmarkFrame;
+
+export interface LandmarkWorkerFailure {
+  readonly type: "failure";
+  readonly protocolVersion: typeof LANDMARK_WORKER_PROTOCOL_VERSION;
+  readonly stage: "initialization" | "protocol";
+  readonly code: "extraction.runtime.initialization.failed" | "extraction.protocol.invalid";
+  readonly failureCount: number;
+}
+
+export interface LandmarkWorkerStopped {
+  readonly type: "stopped";
+  readonly protocolVersion: typeof LANDMARK_WORKER_PROTOCOL_VERSION;
+  readonly failureCount: number;
+}
+
+export type LandmarkWorkerOutputMessage =
+  LandmarkWorkerReady | LandmarkFrameMessage | LandmarkWorkerFailure | LandmarkWorkerStopped;
+
+export function absentHandSlots(): HandSlots {
+  return HAND_SLOT_IDS.map((slotId) => ({
+    slotId,
+    present: false,
+    detectorIndex: null,
+    trackingId: null,
+    handedness: null,
+    handednessConfidence: null,
+    imageLandmarks: null,
+    worldLandmarks: null,
+  })) as unknown as HandSlots;
+}
+
+export function absentBodyAnchors(): BodyAnchors {
+  return BODY_ANCHOR_NAMES.map((name) => ({
+    name,
+    present: false,
+    imagePoint: null,
+    worldPoint: null,
+  })) as unknown as BodyAnchors;
+}

--- a/apps/web/src/landmarks/tracking.test.ts
+++ b/apps/web/src/landmarks/tracking.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import type { LandmarkPoint, ReportedHandedness } from "./protocol";
+import { HandIdentityTracker, type HandDetection } from "./tracking";
+
+function point(x: number): LandmarkPoint {
+  return { x, y: 0.5, z: 0, visibility: null, presence: null };
+}
+
+function hand(
+  detectorIndex: number,
+  x: number,
+  reportedHandedness: ReportedHandedness,
+): HandDetection {
+  const landmarks = Array.from({ length: 21 }, () => point(x));
+  return {
+    detectorIndex,
+    imageLandmarks: landmarks,
+    worldLandmarks: landmarks,
+    reportedHandedness,
+    handednessConfidence: 0.9,
+  };
+}
+
+function indices(result: ReturnType<HandIdentityTracker["track"]>): Array<number | null> {
+  return result.map((detection) => detection?.detectorIndex ?? null);
+}
+
+describe("HandIdentityTracker", () => {
+  it("initializes from geometry and keeps identities when detector order reverses", () => {
+    const tracker = new HandIdentityTracker();
+
+    expect(indices(tracker.track([hand(3, 0.8, "right"), hand(9, 0.2, "left")]))).toEqual([9, 3]);
+    expect(indices(tracker.track([hand(0, 0.78, "right"), hand(1, 0.22, "left")]))).toEqual([1, 0]);
+  });
+
+  it("uses handedness to resolve otherwise equal spatial assignments", () => {
+    const tracker = new HandIdentityTracker();
+    tracker.track([hand(0, 0.4, "left"), hand(1, 0.6, "right")]);
+
+    expect(indices(tracker.track([hand(0, 0.5, "right"), hand(1, 0.5, "left")]))).toEqual([1, 0]);
+  });
+
+  it("falls back deterministically when continuity is ambiguous", () => {
+    const tracker = new HandIdentityTracker();
+    tracker.track([hand(0, 0.25, "left"), hand(1, 0.75, "left")]);
+
+    expect(indices(tracker.track([hand(7, 0.5, "left"), hand(4, 0.5, "left")]))).toEqual([4, 7]);
+    expect(indices(tracker.track([hand(7, 0.7, "left"), hand(4, 0.3, "left")]))).toEqual([4, 7]);
+  });
+
+  it("retains identity across an empty frame and forgets it only on reset", () => {
+    const tracker = new HandIdentityTracker();
+    tracker.track([hand(0, 0.2, "left"), hand(1, 0.8, "right")]);
+
+    expect(indices(tracker.track([]))).toEqual([null, null]);
+    expect(indices(tracker.track([hand(5, 0.78, "right"), hand(6, 0.22, "left")]))).toEqual([6, 5]);
+
+    tracker.reset();
+    expect(indices(tracker.track([hand(9, 0.9, "left"), hand(3, 0.1, "right")]))).toEqual([3, 9]);
+  });
+});

--- a/apps/web/src/landmarks/tracking.ts
+++ b/apps/web/src/landmarks/tracking.ts
@@ -1,0 +1,315 @@
+import type { LandmarkPoint, ReportedHandedness } from "./protocol";
+
+const PALM_LANDMARK_INDICES = [0, 5, 9, 13, 17] as const;
+
+export const HAND_TRACKING_CONFIG = {
+  maxSpatialCost: 0.25,
+  handednessDisagreementPenalty: 0.05,
+  ambiguityMargin: 1e-9,
+} as const;
+
+export interface HandDetection {
+  readonly detectorIndex: number;
+  readonly imageLandmarks: readonly LandmarkPoint[];
+  readonly worldLandmarks: readonly LandmarkPoint[];
+  readonly reportedHandedness: ReportedHandedness;
+  readonly handednessConfidence: number;
+}
+
+export type TrackedDetections = readonly [HandDetection | null, HandDetection | null];
+
+interface Assignment {
+  readonly pairs: readonly (readonly [number, number])[];
+  readonly cost: number;
+}
+
+function squaredDistance(
+  first: readonly [number, number, number],
+  second: readonly [number, number, number],
+): number {
+  const x = first[0] - second[0];
+  const y = first[1] - second[1];
+  const z = first[2] - second[2];
+  return x * x + y * y + z * z;
+}
+
+function pointCoordinates(point: LandmarkPoint): readonly [number, number, number] {
+  return [point.x, point.y, point.z];
+}
+
+function palmCentroid(detection: HandDetection): readonly [number, number, number] {
+  let x = 0;
+  let y = 0;
+  let z = 0;
+  for (const index of PALM_LANDMARK_INDICES) {
+    const point = detection.imageLandmarks[index];
+    if (point === undefined) {
+      throw new Error("A hand detection must contain exactly 21 image landmarks");
+    }
+    x += point.x;
+    y += point.y;
+    z += point.z;
+  }
+  const count = PALM_LANDMARK_INDICES.length;
+  return [x / count, y / count, z / count];
+}
+
+function spatialCost(previous: HandDetection, current: HandDetection): number {
+  const previousWrist = previous.imageLandmarks[0];
+  const currentWrist = current.imageLandmarks[0];
+  if (previousWrist === undefined || currentWrist === undefined) {
+    throw new Error("A hand detection must contain exactly 21 image landmarks");
+  }
+  return (
+    squaredDistance(pointCoordinates(previousWrist), pointCoordinates(currentWrist)) +
+    squaredDistance(palmCentroid(previous), palmCentroid(current))
+  );
+}
+
+function assignmentCost(
+  previous: HandDetection,
+  current: HandDetection,
+): readonly [number, number] {
+  const spatial = spatialCost(previous, current);
+  const handednessPenalty =
+    previous.reportedHandedness === current.reportedHandedness
+      ? 0
+      : HAND_TRACKING_CONFIG.handednessDisagreementPenalty;
+  return [spatial, spatial + handednessPenalty];
+}
+
+function compareNumber(left: number, right: number): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function compareString(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function compareDetections(left: HandDetection, right: HandDetection): number {
+  const leftWrist = left.imageLandmarks[0];
+  const rightWrist = right.imageLandmarks[0];
+  if (leftWrist === undefined || rightWrist === undefined) {
+    throw new Error("A hand detection must contain exactly 21 image landmarks");
+  }
+  const leftPalm = palmCentroid(left);
+  const rightPalm = palmCentroid(right);
+  const numericComparisons = [
+    compareNumber(leftWrist.x, rightWrist.x),
+    compareNumber(leftWrist.y, rightWrist.y),
+    compareNumber(leftWrist.z, rightWrist.z),
+    compareNumber(leftPalm[0], rightPalm[0]),
+    compareNumber(leftPalm[1], rightPalm[1]),
+    compareNumber(leftPalm[2], rightPalm[2]),
+  ];
+  for (const comparison of numericComparisons) {
+    if (comparison !== 0) return comparison;
+  }
+  const handednessComparison = compareString(left.reportedHandedness, right.reportedHandedness);
+  return handednessComparison === 0
+    ? compareNumber(left.detectorIndex, right.detectorIndex)
+    : handednessComparison;
+}
+
+function comparePairSignatures(
+  left: readonly (readonly [number, number])[],
+  right: readonly (readonly [number, number])[],
+  detections: readonly HandDetection[],
+): number {
+  for (let index = 0; index < Math.min(left.length, right.length); index += 1) {
+    const leftPair = left[index];
+    const rightPair = right[index];
+    if (leftPair === undefined || rightPair === undefined) continue;
+    const slotComparison = compareNumber(leftPair[0], rightPair[0]);
+    if (slotComparison !== 0) return slotComparison;
+    const leftDetection = detections[leftPair[1]];
+    const rightDetection = detections[rightPair[1]];
+    if (leftDetection === undefined || rightDetection === undefined) {
+      throw new Error("Tracking assignment referenced a missing detection");
+    }
+    const detectionComparison = compareDetections(leftDetection, rightDetection);
+    if (detectionComparison !== 0) return detectionComparison;
+  }
+  return compareNumber(left.length, right.length);
+}
+
+function combinations(values: readonly number[], count: number): number[][] {
+  if (count === 0) return [[]];
+  const output: number[][] = [];
+  values.forEach((value, index) => {
+    for (const remainder of combinations(values.slice(index + 1), count - 1)) {
+      output.push([value, ...remainder]);
+    }
+  });
+  return output;
+}
+
+function permutations(values: readonly number[], count: number): number[][] {
+  if (count === 0) return [[]];
+  const output: number[][] = [];
+  values.forEach((value, index) => {
+    const remaining = [...values.slice(0, index), ...values.slice(index + 1)];
+    for (const remainder of permutations(remaining, count - 1)) {
+      output.push([value, ...remainder]);
+    }
+  });
+  return output;
+}
+
+function enumerateAssignments(
+  previous: TrackedDetections,
+  detections: readonly HandDetection[],
+): Assignment[] {
+  const activeSlots = [0, 1].filter((index) => previous[index] !== null);
+  const positions = detections.map((_, index) => index);
+  const assignments: Assignment[] = [];
+  const maximumPairs = Math.min(activeSlots.length, detections.length);
+
+  for (let pairCount = 0; pairCount <= maximumPairs; pairCount += 1) {
+    for (const slots of combinations(activeSlots, pairCount)) {
+      for (const orderedPositions of permutations(positions, pairCount)) {
+        const pairs = slots.map((slot, index) => [slot, orderedPositions[index] ?? -1] as const);
+        let cost = 0;
+        let valid = true;
+        for (const [slot, position] of pairs) {
+          const prior = previous[slot];
+          const current = detections[position];
+          if (prior === null || prior === undefined || current === undefined) {
+            valid = false;
+            break;
+          }
+          const [spatial, total] = assignmentCost(prior, current);
+          if (spatial > HAND_TRACKING_CONFIG.maxSpatialCost) {
+            valid = false;
+            break;
+          }
+          cost += total;
+        }
+        if (valid) assignments.push({ pairs, cost });
+      }
+    }
+  }
+  return assignments;
+}
+
+function unambiguousPairs(
+  assignments: readonly Assignment[],
+  detections: readonly HandDetection[],
+): readonly (readonly [number, number])[] {
+  const maximumPairCount = Math.max(...assignments.map(({ pairs }) => pairs.length));
+  const fullest = assignments.filter(({ pairs }) => pairs.length === maximumPairCount);
+  fullest.sort(
+    (left, right) =>
+      compareNumber(left.cost, right.cost) ||
+      comparePairSignatures(left.pairs, right.pairs, detections),
+  );
+  const best = fullest[0];
+  if (best === undefined) return [];
+  const competitive = fullest.filter(
+    ({ cost }) => cost <= best.cost + HAND_TRACKING_CONFIG.ambiguityMargin,
+  );
+  return best.pairs.filter(([slot, position]) =>
+    competitive.every(({ pairs }) =>
+      pairs.some(([candidateSlot, candidatePosition]) => {
+        return slot === candidateSlot && position === candidatePosition;
+      }),
+    ),
+  );
+}
+
+function fallbackPairs(
+  previous: TrackedDetections,
+  detections: readonly HandDetection[],
+  availableSlots: readonly number[],
+  detectionPositions: readonly number[],
+): readonly (readonly [number, number])[] {
+  const candidates: Array<{
+    overwrittenSlots: number;
+    cost: number;
+    pairs: readonly (readonly [number, number])[];
+  }> = [];
+  for (const slots of combinations(availableSlots, detectionPositions.length)) {
+    for (const orderedPositions of permutations(detectionPositions, detectionPositions.length)) {
+      const pairs = slots.map((slot, index) => [slot, orderedPositions[index] ?? -1] as const);
+      let overwrittenSlots = 0;
+      let cost = 0;
+      for (const [slot, position] of pairs) {
+        const prior = previous[slot];
+        const current = detections[position];
+        if (prior !== null && prior !== undefined && current !== undefined) {
+          overwrittenSlots += 1;
+          cost += assignmentCost(prior, current)[1];
+        }
+      }
+      candidates.push({ overwrittenSlots, cost, pairs });
+    }
+  }
+  candidates.sort(
+    (left, right) =>
+      compareNumber(left.overwrittenSlots, right.overwrittenSlots) ||
+      compareNumber(left.cost, right.cost) ||
+      comparePairSignatures(left.pairs, right.pairs, detections),
+  );
+  return candidates[0]?.pairs ?? [];
+}
+
+export class HandIdentityTracker {
+  private previous: TrackedDetections = [null, null];
+
+  reset(): void {
+    this.previous = [null, null];
+  }
+
+  track(detections: readonly HandDetection[]): TrackedDetections {
+    if (detections.length > 2) {
+      throw new Error("HandIdentityTracker accepts at most two detections per frame");
+    }
+    const detectorIndices = detections.map(({ detectorIndex }) => detectorIndex);
+    if (new Set(detectorIndices).size !== detectorIndices.length) {
+      throw new Error("detectorIndex values must be unique within a frame");
+    }
+    if (detections.length === 0) return [null, null];
+
+    const activeSlots = [0, 1].filter((index) => this.previous[index] !== null);
+    if (activeSlots.length === 0) {
+      const ordered = [...detections].sort(compareDetections);
+      const initialized: TrackedDetections = [ordered[0] ?? null, ordered[1] ?? null];
+      this.previous = initialized;
+      return initialized;
+    }
+
+    const pairs = unambiguousPairs(enumerateAssignments(this.previous, detections), detections);
+    const tracked: [HandDetection | null, HandDetection | null] = [null, null];
+    const nextPrevious: [HandDetection | null, HandDetection | null] = [...this.previous];
+    const usedSlots = new Set<number>();
+    const usedPositions = new Set<number>();
+
+    for (const [slot, position] of pairs) {
+      const detection = detections[position];
+      if (detection === undefined || (slot !== 0 && slot !== 1)) continue;
+      tracked[slot] = detection;
+      nextPrevious[slot] = detection;
+      usedSlots.add(slot);
+      usedPositions.add(position);
+    }
+
+    const fallbackPositions = detections
+      .map((_, index) => index)
+      .filter((index) => !usedPositions.has(index));
+    const fallbackSlots = [0, 1].filter((index) => !usedSlots.has(index));
+    for (const [slot, position] of fallbackPairs(
+      this.previous,
+      detections,
+      fallbackSlots,
+      fallbackPositions,
+    )) {
+      const detection = detections[position];
+      if (detection === undefined || (slot !== 0 && slot !== 1)) continue;
+      tracked[slot] = detection;
+      nextPrevious[slot] = detection;
+    }
+
+    this.previous = nextPrevious;
+    return tracked;
+  }
+}

--- a/apps/web/src/landmarks/workerSession.test.ts
+++ b/apps/web/src/landmarks/workerSession.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { LandmarkDetector } from "./mediapipeRuntime";
+import {
+  LANDMARK_WORKER_PROTOCOL_VERSION,
+  absentBodyAnchors,
+  type LandmarkWorkerOutputMessage,
+  type ProcessLandmarkFrame,
+} from "./protocol";
+import type { HandDetection } from "./tracking";
+import { LandmarkWorkerSession } from "./workerSession";
+
+function frame() {
+  const close = vi.fn();
+  return { image: { close } as unknown as ImageBitmap, close };
+}
+
+function hand(detectorIndex: number, x: number, side: "left" | "right"): HandDetection {
+  const points = Array.from({ length: 21 }, () => ({
+    x,
+    y: 0.5,
+    z: 0,
+    visibility: null,
+    presence: null,
+  }));
+  return {
+    detectorIndex,
+    imageLandmarks: points,
+    worldLandmarks: points,
+    reportedHandedness: side,
+    handednessConfidence: 0.9,
+  };
+}
+
+function processMessage(
+  image: ImageBitmap,
+  frameId: number,
+  taskTimestampMs: number,
+): ProcessLandmarkFrame {
+  return {
+    type: "process-frame",
+    protocolVersion: LANDMARK_WORKER_PROTOCOL_VERSION,
+    frameId,
+    relativeTimestampUs: 0,
+    taskTimestampMs,
+    frame: image,
+  };
+}
+
+describe("LandmarkWorkerSession", () => {
+  it("initializes once, preserves identity through a failed frame, and releases resources", async () => {
+    const outputs: LandmarkWorkerOutputMessage[] = [];
+    const first = frame();
+    const failed = frame();
+    const third = frame();
+    const infer = vi
+      .fn<LandmarkDetector["infer"]>()
+      .mockReturnValueOnce({
+        hands: [hand(0, 0.2, "left"), hand(1, 0.8, "right")],
+        bodyAnchors: absentBodyAnchors(),
+      })
+      .mockImplementationOnce(() => {
+        throw new Error("private runtime detail");
+      })
+      .mockReturnValueOnce({
+        hands: [hand(5, 0.78, "right")],
+        bodyAnchors: absentBodyAnchors(),
+      });
+    const detectorClose = vi.fn();
+    const detector: LandmarkDetector = { infer, close: detectorClose };
+    const factory = vi.fn(() => Promise.resolve(detector));
+    const session = new LandmarkWorkerSession(factory, (message) => outputs.push(message));
+
+    await session.handle({
+      type: "initialize",
+      protocolVersion: LANDMARK_WORKER_PROTOCOL_VERSION,
+      handModelBuffer: new ArrayBuffer(1),
+      poseModelBuffer: new ArrayBuffer(1),
+    });
+    await session.handle(processMessage(first.image, 0, 0));
+    await session.handle(processMessage(failed.image, 1, 1));
+    await session.handle(processMessage(third.image, 2, 2));
+    await session.handle({
+      type: "stop",
+      protocolVersion: LANDMARK_WORKER_PROTOCOL_VERSION,
+    });
+
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(outputs.map(({ type }) => type)).toEqual([
+      "ready",
+      "frame",
+      "frame",
+      "frame",
+      "stopped",
+    ]);
+    expect(outputs[2]).toMatchObject({
+      valid: false,
+      invalidReason: "task_inference_failed",
+      failureCode: "extraction.runtime.inference.failed",
+      failureCount: 1,
+    });
+    expect(outputs[3]).toMatchObject({
+      valid: true,
+      hands: [
+        { slotId: "hand_0", present: false },
+        { slotId: "hand_1", present: true, detectorIndex: 5 },
+      ],
+    });
+    expect(first.close).toHaveBeenCalledTimes(1);
+    expect(failed.close).toHaveBeenCalledTimes(1);
+    expect(third.close).toHaveBeenCalledTimes(1);
+    expect(detectorClose).toHaveBeenCalledTimes(1);
+    expect(JSON.stringify(outputs)).not.toContain("private runtime detail");
+  });
+
+  it("rejects a timestamp outside the exact recurrence and still closes the frame", async () => {
+    const outputs: LandmarkWorkerOutputMessage[] = [];
+    const image = frame();
+    const infer = vi.fn(() => ({ hands: [], bodyAnchors: absentBodyAnchors() }));
+    const detector: LandmarkDetector = {
+      infer,
+      close: vi.fn(),
+    };
+    const session = new LandmarkWorkerSession(
+      () => Promise.resolve(detector),
+      (message) => outputs.push(message),
+    );
+    await session.handle({
+      type: "initialize",
+      protocolVersion: LANDMARK_WORKER_PROTOCOL_VERSION,
+      handModelBuffer: new ArrayBuffer(1),
+      poseModelBuffer: new ArrayBuffer(1),
+    });
+
+    await session.handle(processMessage(image.image, 0, 7));
+
+    expect(outputs.at(-1)).toMatchObject({
+      type: "failure",
+      stage: "protocol",
+      code: "extraction.protocol.invalid",
+    });
+    expect(infer).not.toHaveBeenCalled();
+    expect(image.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/landmarks/workerSession.ts
+++ b/apps/web/src/landmarks/workerSession.ts
@@ -1,0 +1,203 @@
+import {
+  HAND_SLOT_IDS,
+  LANDMARK_WORKER_PROTOCOL_VERSION,
+  absentBodyAnchors,
+  absentHandSlots,
+  type HandSlot,
+  type HandSlots,
+  type LandmarkWorkerInputMessage,
+  type LandmarkWorkerOutputMessage,
+  type ProcessLandmarkFrame,
+} from "./protocol";
+import type { LandmarkDetector, LandmarkModelBuffers } from "./mediapipeRuntime";
+import { HandIdentityTracker, type HandDetection, type TrackedDetections } from "./tracking";
+
+export type LandmarkDetectorFactory = (models: LandmarkModelBuffers) => Promise<LandmarkDetector>;
+
+export type LandmarkWorkerPost = (message: LandmarkWorkerOutputMessage) => void;
+
+function now(): number {
+  return performance.now();
+}
+
+function presentHandSlot(
+  slotId: (typeof HAND_SLOT_IDS)[number],
+  detection: HandDetection,
+): HandSlot {
+  return {
+    slotId,
+    present: true,
+    detectorIndex: detection.detectorIndex,
+    trackingId: slotId,
+    handedness: detection.reportedHandedness,
+    handednessConfidence: detection.handednessConfidence,
+    imageLandmarks: detection.imageLandmarks,
+    worldLandmarks: detection.worldLandmarks,
+  };
+}
+
+function handSlots(detections: TrackedDetections): HandSlots {
+  return HAND_SLOT_IDS.map((slotId, index) => {
+    const detection = detections[index];
+    return detection === null || detection === undefined
+      ? absentHandSlots()[index]
+      : presentHandSlot(slotId, detection);
+  }) as unknown as HandSlots;
+}
+
+function isNonNegativeSafeInteger(value: number): boolean {
+  return Number.isSafeInteger(value) && value >= 0;
+}
+
+export class LandmarkWorkerSession {
+  private readonly tracker = new HandIdentityTracker();
+  private detector: LandmarkDetector | undefined;
+  private initializing = false;
+  private stopped = false;
+  private failureCount = 0;
+  private previousTaskTimestampMs = -1;
+
+  constructor(
+    private readonly createDetector: LandmarkDetectorFactory,
+    private readonly post: LandmarkWorkerPost,
+  ) {}
+
+  async handle(message: LandmarkWorkerInputMessage): Promise<void> {
+    if (message.protocolVersion !== LANDMARK_WORKER_PROTOCOL_VERSION) {
+      this.failProtocol();
+      if (message.type === "process-frame") message.frame.close();
+      return;
+    }
+    if (message.type === "initialize") {
+      await this.initialize(message.handModelBuffer, message.poseModelBuffer);
+      return;
+    }
+    if (message.type === "process-frame") {
+      this.processFrame(message);
+      return;
+    }
+    this.stop();
+  }
+
+  private async initialize(
+    handModelBuffer: ArrayBuffer,
+    poseModelBuffer: ArrayBuffer,
+  ): Promise<void> {
+    if (this.stopped || this.initializing || this.detector !== undefined) {
+      this.failProtocol();
+      return;
+    }
+    this.initializing = true;
+    const startedAt = now();
+    try {
+      const detector = await this.createDetector({ handModelBuffer, poseModelBuffer });
+      if (this.stopped) {
+        detector.close();
+        return;
+      }
+      this.detector = detector;
+      this.post({
+        type: "ready",
+        protocolVersion: LANDMARK_WORKER_PROTOCOL_VERSION,
+        startupMs: now() - startedAt,
+        failureCount: this.failureCount,
+      });
+    } catch {
+      this.failureCount += 1;
+      this.post({
+        type: "failure",
+        protocolVersion: LANDMARK_WORKER_PROTOCOL_VERSION,
+        stage: "initialization",
+        code: "extraction.runtime.initialization.failed",
+        failureCount: this.failureCount,
+      });
+    } finally {
+      this.initializing = false;
+    }
+  }
+
+  private processFrame(message: ProcessLandmarkFrame): void {
+    const startedAt = now();
+    try {
+      if (
+        this.stopped ||
+        this.detector === undefined ||
+        !isNonNegativeSafeInteger(message.frameId) ||
+        !isNonNegativeSafeInteger(message.relativeTimestampUs) ||
+        !isNonNegativeSafeInteger(message.taskTimestampMs) ||
+        message.taskTimestampMs !==
+          Math.max(
+            Math.floor(message.relativeTimestampUs / 1_000),
+            this.previousTaskTimestampMs + 1,
+          )
+      ) {
+        this.failProtocol();
+        return;
+      }
+      this.previousTaskTimestampMs = message.taskTimestampMs;
+      const detected = this.detector.infer(message.frame, message.taskTimestampMs);
+      const tracked = this.tracker.track(detected.hands);
+      this.post({
+        type: "frame",
+        protocolVersion: LANDMARK_WORKER_PROTOCOL_VERSION,
+        frameId: message.frameId,
+        relativeTimestampUs: message.relativeTimestampUs,
+        taskTimestampMs: message.taskTimestampMs,
+        valid: true,
+        invalidReason: null,
+        failureCode: null,
+        hands: handSlots(tracked),
+        bodyAnchors: detected.bodyAnchors,
+        processingMs: now() - startedAt,
+        failureCount: this.failureCount,
+      });
+    } catch {
+      this.failureCount += 1;
+      this.post({
+        type: "frame",
+        protocolVersion: LANDMARK_WORKER_PROTOCOL_VERSION,
+        frameId: message.frameId,
+        relativeTimestampUs: message.relativeTimestampUs,
+        taskTimestampMs: message.taskTimestampMs,
+        valid: false,
+        invalidReason: "task_inference_failed",
+        failureCode: "extraction.runtime.inference.failed",
+        hands: absentHandSlots(),
+        bodyAnchors: absentBodyAnchors(),
+        processingMs: now() - startedAt,
+        failureCount: this.failureCount,
+      });
+    } finally {
+      message.frame.close();
+    }
+  }
+
+  private failProtocol(): void {
+    this.failureCount += 1;
+    this.post({
+      type: "failure",
+      protocolVersion: LANDMARK_WORKER_PROTOCOL_VERSION,
+      stage: "protocol",
+      code: "extraction.protocol.invalid",
+      failureCount: this.failureCount,
+    });
+  }
+
+  private stop(): void {
+    if (this.stopped) return;
+    this.stopped = true;
+    try {
+      this.detector?.close();
+    } catch {
+      this.failureCount += 1;
+    } finally {
+      this.detector = undefined;
+      this.tracker.reset();
+      this.post({
+        type: "stopped",
+        protocolVersion: LANDMARK_WORKER_PROTOCOL_VERSION,
+        failureCount: this.failureCount,
+      });
+    }
+  }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -54,9 +54,13 @@ Static model-bundle files
   -> expose readiness or a clear failure to the route UI
 ```
 
-The immutable bundle, workers, MediaPipe Tasks, ONNX Runtime Web, cache policy, and
-Python/TypeScript parity fixtures are not part of the shell. No browser model is
-usable until those later gates are complete.
+The shell now contains a dormant `@mediapipe/tasks-vision@1.0.1` landmark worker.
+It initializes one hand/pose task pair from externally verified buffers, returns
+typed timestamps, two-hand slots, six body anchors, validity, and confidence, keeps
+only the newest waiting frame, emits sanitized timing/drop/failure measurements, and
+releases replaced or processed images and task resources. Bundle verification and
+loading, camera and replay producers, ONNX inference, event detection, and route
+lifecycle controls remain separate gates; no browser model is usable yet.
 
 The [licensed external-data boundary](external-datasets.md) is intentionally
 separate from participant ingest. It registers source, license, attribution,

--- a/docs/development.md
+++ b/docs/development.md
@@ -92,6 +92,10 @@ static host without rewrite rules. Story #38 provides the responsive, honest she
 only: it does not request camera access, load a model, process replay inputs, save
 feedback, or call a backend.
 
+The normal web checks also compile and test the dormant landmark worker. MediaPipe
+`.task` models remain external to Git, and neither task starts until a later boundary
+supplies verified model buffers and frames.
+
 ## Local experiment ledger
 
 Install the optional tracker and run its single end-to-end proof with:


### PR DESCRIPTION
Closes #46

## What changed

- pins `@mediapipe/tasks-vision@1.0.1` and initializes one hand/pose task pair inside a dedicated module worker
- adds a typed landmark protocol with exact timestamps, two stable hand slots, image/world landmarks, handedness confidence, validity, and six configured body anchors
- ports the offline two-hand identity rules without adding a second tracking policy
- adds one-in-flight plus one-newest-pending backpressure; replaced and processed `ImageBitmap` resources are closed
- reports startup, processing, dropped-frame, and sanitized failure measurements
- closes pending frames, MediaPipe tasks, listeners, and the worker on stop/failure
- keeps `/live` dormant and truthful; camera controls, bundle loading, ONNX inference, and gesture events remain follow-up stories

## Evidence

- `npm ci --no-audit --no-fund`
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm test` — 23 passed
- `npm run build` — emits the worker, MediaPipe loader, and WASM at root paths
- `npm run build:subpath` — emits the same assets under `/signlab/`
- `uv run --locked python scripts/check_repository_hygiene.py`
- deterministic 10,000-frame slow-worker stress test retains at most two frames, sends only the first and newest, and records exactly 9,998 displaced frames

## Scope boundary

This PR implements only the dormant landmark-worker boundary in #46. It does not request camera access, fetch or verify model bundles, run ONNX, detect gesture events, or add a worker framework.