### PR TITLE
Add consent-first camera controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,9 +180,11 @@ masked training-only statistics, and content-addressed cache objects. Licensed
 PopSign execution now produces one deterministic, leakage-checked 80-sample public
 smoke split from the verified retained landmark inventory without rerunning MediaPipe.
 A responsive React/Vite shell now exposes the planned public routes without a backend
-and includes a dormant MediaPipe landmark-worker boundary; camera access, model-bundle
-delivery, replay, feedback storage, and gesture inference remain explicitly
-unconnected. A minimal local MLflow ledger can now log, query, and byte-verify one
+and includes a dormant MediaPipe landmark-worker boundary. Its live route now provides
+an explicit, consent-first local camera preview with pause, stop, device switching,
+and lifecycle cleanup; it neither saves nor uploads video, and it does not send frames
+to the worker. Model-bundle delivery, replay, feedback storage, and gesture inference
+remain explicitly unconnected. A minimal local MLflow ledger can now log, query, and byte-verify one
 portable baseline result without a server or custom dashboard. The first frozen
 signer-disjoint benchmark now compares majority, seeded stratified-random, and
 train-only multinomial-logistic references from one checked-in configuration. The

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -2,13 +2,14 @@ import { Route, Routes } from "react-router-dom";
 
 import { AppShell } from "./AppShell";
 import { staticPages } from "./routeDefinitions";
-import { NotFoundPage, OverviewPage, StaticPage } from "./routes";
+import { LivePage, NotFoundPage, OverviewPage, StaticPage } from "./routes";
 
 export function App() {
   return (
     <AppShell>
       <Routes>
         <Route path="/" element={<OverviewPage />} />
+        <Route path="/live" element={<LivePage />} />
         {staticPages.map((page) => (
           <Route key={page.path} path={page.path} element={<StaticPage page={page} />} />
         ))}

--- a/apps/web/src/app/LivePage.test.tsx
+++ b/apps/web/src/app/LivePage.test.tsx
@@ -1,0 +1,309 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { StrictMode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { CameraEnvironment } from "../camera/useCameraSession";
+import { LivePage } from "./routes";
+
+class TestDocument extends EventTarget {
+  hidden = false;
+}
+
+class TestMediaDevices extends EventTarget {
+  getUserMedia = vi.fn<(constraints: MediaStreamConstraints) => Promise<MediaStream>>();
+  enumerateDevices = vi.fn<() => Promise<MediaDeviceInfo[]>>();
+}
+
+interface TestTrack extends EventTarget {
+  enabled: boolean;
+  getSettings: () => MediaTrackSettings;
+  stop: ReturnType<typeof vi.fn>;
+}
+
+function cameraDevice(deviceId: string, label: string): MediaDeviceInfo {
+  return {
+    deviceId,
+    groupId: "group",
+    kind: "videoinput",
+    label,
+    toJSON: () => ({}),
+  };
+}
+
+function cameraStream(deviceId: string) {
+  const track = new EventTarget() as TestTrack;
+  track.enabled = true;
+  track.getSettings = () => ({ deviceId });
+  track.stop = vi.fn();
+  const mediaTrack = track as unknown as MediaStreamTrack;
+  const stream = {
+    getTracks: () => [mediaTrack],
+    getVideoTracks: () => [mediaTrack],
+  } as unknown as MediaStream;
+  return { stream, track };
+}
+
+function cameraEnvironment(mediaDevices?: TestMediaDevices, secure = true) {
+  const pageDocument = new TestDocument();
+  const environment: CameraEnvironment = {
+    document: pageDocument,
+    isSecureContext: secure,
+    mediaDevices,
+  };
+  return { environment, pageDocument };
+}
+
+async function startCamera() {
+  fireEvent.click(screen.getByRole("button", { name: "Start camera" }));
+  await screen.findByText(
+    "Camera is on. Raw video stays on this page and is not saved or uploaded.",
+  );
+}
+
+describe("consent-first camera preview", () => {
+  it("waits for explicit consent and keeps the preview out of transport and storage APIs", async () => {
+    const devices = new TestMediaDevices();
+    const { stream, track } = cameraStream("front");
+    devices.getUserMedia.mockResolvedValue(stream);
+    devices.enumerateDevices.mockResolvedValue([cameraDevice("front", "Front camera")]);
+    const { environment } = cameraEnvironment(devices);
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const xhrSpy = vi.spyOn(XMLHttpRequest.prototype, "send");
+    const storageSpy = vi.spyOn(Storage.prototype, "setItem");
+    const webSocketSpy = vi.fn();
+    const sendBeaconSpy = vi.fn();
+    vi.stubGlobal("WebSocket", webSocketSpy);
+    vi.stubGlobal(
+      "navigator",
+      Object.create(navigator, {
+        sendBeacon: { value: sendBeaconSpy },
+      }) as Navigator,
+    );
+
+    render(
+      <StrictMode>
+        <LivePage cameraEnvironment={environment} />
+      </StrictMode>,
+    );
+
+    expect(devices.getUserMedia).not.toHaveBeenCalled();
+    expect(
+      screen.getByText(/asks for permission only after you select Start camera/),
+    ).toBeVisible();
+
+    await startCamera();
+
+    expect(devices.getUserMedia).toHaveBeenCalledWith({
+      audio: false,
+      video: { facingMode: { ideal: "user" } },
+    });
+    const video = screen.getByLabelText("Local camera preview");
+    expect(video).toHaveProperty("srcObject", stream);
+    expect(video).toHaveClass("is-mirrored");
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "Mirror preview" }));
+    expect(video).not.toHaveClass("is-mirrored");
+
+    fireEvent.click(screen.getByRole("button", { name: "Pause preview" }));
+    expect(track.enabled).toBe(false);
+    expect(screen.getByText(/Stop the camera to release it completely/)).toBeVisible();
+
+    fireEvent.click(screen.getByRole("button", { name: "Resume preview" }));
+    expect(track.enabled).toBe(true);
+
+    fireEvent.click(screen.getByRole("button", { name: "Stop camera" }));
+    expect(track.stop).toHaveBeenCalledOnce();
+    expect(screen.queryByLabelText("Local camera preview")).not.toBeInTheDocument();
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(xhrSpy).not.toHaveBeenCalled();
+    expect(webSocketSpy).not.toHaveBeenCalled();
+    expect(sendBeaconSpy).not.toHaveBeenCalled();
+    expect(storageSpy).not.toHaveBeenCalled();
+  });
+
+  it("acquires a replacement before releasing the selected camera", async () => {
+    const devices = new TestMediaDevices();
+    const first = cameraStream("front");
+    const second = cameraStream("back");
+    let resolveReplacement!: (stream: MediaStream) => void;
+    const replacement = new Promise<MediaStream>((resolve) => {
+      resolveReplacement = resolve;
+    });
+    devices.getUserMedia.mockResolvedValueOnce(first.stream).mockReturnValueOnce(replacement);
+    devices.enumerateDevices.mockResolvedValue([
+      cameraDevice("front", "Front camera"),
+      cameraDevice("back", "Back camera"),
+    ]);
+    const { environment } = cameraEnvironment(devices);
+
+    render(<LivePage cameraEnvironment={environment} />);
+    await startCamera();
+    const selector = await screen.findByRole("combobox", { name: "Camera" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Pause preview" }));
+    expect(selector).toBeDisabled();
+    fireEvent.click(screen.getByRole("button", { name: "Resume preview" }));
+    expect(selector).toBeEnabled();
+
+    fireEvent.change(selector, { target: { value: "back" } });
+    expect(devices.getUserMedia).toHaveBeenLastCalledWith({
+      audio: false,
+      video: { deviceId: { exact: "back" } },
+    });
+    expect(first.track.stop).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveReplacement(second.stream);
+      await replacement;
+    });
+
+    expect(first.track.stop).toHaveBeenCalledOnce();
+    expect(screen.getByLabelText("Local camera preview")).toHaveProperty(
+      "srcObject",
+      second.stream,
+    );
+  });
+
+  it("keeps the current camera when a replacement cannot start", async () => {
+    const devices = new TestMediaDevices();
+    const current = cameraStream("front");
+    const failure = new Error("busy");
+    failure.name = "NotReadableError";
+    devices.getUserMedia.mockResolvedValueOnce(current.stream).mockRejectedValueOnce(failure);
+    devices.enumerateDevices.mockResolvedValue([
+      cameraDevice("front", "Front camera"),
+      cameraDevice("back", "Back camera"),
+    ]);
+    const { environment } = cameraEnvironment(devices);
+
+    render(<LivePage cameraEnvironment={environment} />);
+    await startCamera();
+    const selector = await screen.findByRole("combobox", { name: "Camera" });
+    fireEvent.change(selector, { target: { value: "back" } });
+
+    expect(await screen.findByText(/previous camera is still active/)).toBeVisible();
+    expect(current.track.stop).not.toHaveBeenCalled();
+    expect(screen.getByLabelText("Local camera preview")).toHaveProperty(
+      "srcObject",
+      current.stream,
+    );
+    expect(selector).toHaveValue("front");
+  });
+
+  it("releases the camera when the page is hidden or unmounted", async () => {
+    const devices = new TestMediaDevices();
+    const first = cameraStream("front");
+    devices.getUserMedia.mockResolvedValue(first.stream);
+    devices.enumerateDevices.mockResolvedValue([]);
+    const { environment, pageDocument } = cameraEnvironment(devices);
+    const view = render(<LivePage cameraEnvironment={environment} />);
+    await startCamera();
+
+    pageDocument.hidden = true;
+    act(() => {
+      pageDocument.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(first.track.stop).toHaveBeenCalledOnce();
+    expect(screen.getByText(/page was hidden/)).toBeVisible();
+
+    pageDocument.hidden = false;
+    const second = cameraStream("front");
+    devices.getUserMedia.mockResolvedValue(second.stream);
+    await startCamera();
+    view.unmount();
+    expect(second.track.stop).toHaveBeenCalledOnce();
+  });
+
+  it("reports external interruption and actionable access failures", async () => {
+    const devices = new TestMediaDevices();
+    const active = cameraStream("front");
+    devices.getUserMedia.mockResolvedValue(active.stream);
+    devices.enumerateDevices.mockResolvedValue([]);
+    const { environment } = cameraEnvironment(devices);
+    const view = render(<LivePage cameraEnvironment={environment} />);
+    await startCamera();
+
+    act(() => {
+      active.track.dispatchEvent(new Event("ended"));
+    });
+    expect(screen.getByText(/camera stopped unexpectedly/)).toBeVisible();
+    expect(screen.getByRole("button", { name: "Start camera" })).toBeVisible();
+    expect(active.track.stop).toHaveBeenCalledOnce();
+
+    view.unmount();
+    const deniedDevices = new TestMediaDevices();
+    const denied = new Error("denied");
+    denied.name = "NotAllowedError";
+    deniedDevices.getUserMedia.mockRejectedValue(denied);
+    deniedDevices.enumerateDevices.mockResolvedValue([]);
+    render(<LivePage cameraEnvironment={cameraEnvironment(deniedDevices).environment} />);
+    fireEvent.click(screen.getByRole("button", { name: "Start camera" }));
+    expect(await screen.findByText(/permission was denied/)).toBeVisible();
+  });
+
+  it("explains insecure and unavailable environments without requesting access", () => {
+    const insecureDevices = new TestMediaDevices();
+    const insecure = cameraEnvironment(insecureDevices, false).environment;
+    const view = render(<LivePage cameraEnvironment={insecure} />);
+
+    expect(screen.getByText(/requires HTTPS or a local development address/)).toBeVisible();
+    expect(screen.queryByRole("button", { name: "Start camera" })).not.toBeInTheDocument();
+    expect(insecureDevices.getUserMedia).not.toHaveBeenCalled();
+
+    view.unmount();
+    render(<LivePage cameraEnvironment={cameraEnvironment().environment} />);
+    expect(screen.getByText(/browser does not provide camera access/)).toBeVisible();
+    expect(screen.queryByRole("button", { name: "Start camera" })).not.toBeInTheDocument();
+  });
+
+  it("releases a stream that arrives after unmount", async () => {
+    const devices = new TestMediaDevices();
+    const late = cameraStream("front");
+    let resolvePermission!: (stream: MediaStream) => void;
+    const permission = new Promise<MediaStream>((resolve) => {
+      resolvePermission = resolve;
+    });
+    devices.getUserMedia.mockReturnValue(permission);
+    devices.enumerateDevices.mockResolvedValue([]);
+    const { environment } = cameraEnvironment(devices);
+    const view = render(<LivePage cameraEnvironment={environment} />);
+    fireEvent.click(screen.getByRole("button", { name: "Start camera" }));
+
+    view.unmount();
+    await act(async () => {
+      resolvePermission(late.stream);
+      await permission;
+    });
+
+    await waitFor(() => expect(late.track.stop).toHaveBeenCalledOnce());
+  });
+
+  it("releases a pending stream if the page becomes hidden", async () => {
+    const devices = new TestMediaDevices();
+    const late = cameraStream("front");
+    let resolvePermission!: (stream: MediaStream) => void;
+    const permission = new Promise<MediaStream>((resolve) => {
+      resolvePermission = resolve;
+    });
+    devices.getUserMedia.mockReturnValue(permission);
+    devices.enumerateDevices.mockResolvedValue([]);
+    const { environment, pageDocument } = cameraEnvironment(devices);
+    render(<LivePage cameraEnvironment={environment} />);
+    fireEvent.click(screen.getByRole("button", { name: "Start camera" }));
+
+    pageDocument.hidden = true;
+    act(() => {
+      pageDocument.dispatchEvent(new Event("visibilitychange"));
+    });
+    expect(screen.getByText(/page was hidden/)).toBeVisible();
+
+    await act(async () => {
+      resolvePermission(late.stream);
+      await permission;
+    });
+
+    await waitFor(() => expect(late.track.stop).toHaveBeenCalledOnce());
+    expect(screen.queryByLabelText("Local camera preview")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/routeDefinitions.ts
+++ b/apps/web/src/app/routeDefinitions.ts
@@ -1,5 +1,3 @@
-import { supportsLandmarkWorkerRuntime } from "../landmarks/LandmarkWorkerClient";
-
 export interface StaticPageDefinition {
   path: string;
   label: string;
@@ -12,30 +10,19 @@ export interface StaticPageDefinition {
   note?: string;
 }
 
-const landmarkRuntimeSupport = supportsLandmarkWorkerRuntime()
-  ? "This browser exposes the Worker, ImageBitmap, OffscreenCanvas, WebAssembly, and SIMD capabilities needed by the later demo."
-  : "This browser does not expose every Worker, ImageBitmap, OffscreenCanvas, WebAssembly, and SIMD capability needed by the later demo.";
+export const livePageDefinition = {
+  path: "/live",
+  label: "Live demo",
+  eyebrow: "Local camera preview",
+  heading: "Live recognition",
+  summary: "Start a private camera preview when you are ready. Recognition is not connected yet.",
+  status: "Camera is off. Nothing is being captured.",
+  detailsTitle: "Camera privacy",
+  details: [],
+  note: "These English labels are project prompts, not a validated claim about ASL vocabulary.",
+} as const satisfies StaticPageDefinition;
 
 export const staticPages = [
-  {
-    path: "/live",
-    label: "Live demo",
-    eyebrow: "Browser demo",
-    heading: "Live recognition",
-    summary:
-      "This page will eventually recognize one completed gesture event at a time from five project prompts: Hello, No, Please, Thank you, and Yes.",
-    status:
-      "Landmark extraction is implemented off the UI thread but is not active on this page yet. No camera permission is requested, no frame is captured, and no model bundle is loaded.",
-    detailsTitle: "Current worker boundary",
-    details: [
-      "Once supplied with already-verified model bytes, MediaPipe initializes once inside a worker.",
-      "The worker returns typed hand and body landmarks and keeps only the newest waiting frame.",
-      "Processed or replaced frames are released, and image data is not logged.",
-      landmarkRuntimeSupport,
-      "Camera controls and gesture recognition remain separate follow-up work.",
-    ],
-    note: "These English labels are project prompts, not a validated claim about ASL vocabulary.",
-  },
   {
     path: "/replay",
     label: "Replay",
@@ -109,12 +96,12 @@ export const staticPages = [
     summary:
       "The completed browser demo is intended to process camera frames on the user’s device. Raw video will not be uploaded or stored by default.",
     status:
-      "This scaffold does not request camera access, store feedback, run inference, or include analytics.",
+      "The live route requests camera access only after an explicit start action. The app does not store feedback, run inference, or include analytics.",
     detailsTitle: "Current privacy facts",
     details: [
       "This page loads only static application files.",
       "There is no application server or user account.",
-      "Future camera and storage behavior must pass separate review gates.",
+      "The live preview remains on-device and releases its camera when stopped or interrupted.",
     ],
   },
   {
@@ -139,5 +126,6 @@ export const staticPages = [
 
 export const navigationItems = [
   { path: "/", label: "Overview" },
+  { path: livePageDefinition.path, label: livePageDefinition.label },
   ...staticPages.map(({ path, label }) => ({ path, label })),
 ] as const;

--- a/apps/web/src/app/routes.tsx
+++ b/apps/web/src/app/routes.tsx
@@ -168,7 +168,8 @@ export function OverviewPage() {
             movement or uncertainty for a result.
           </p>
           <StatusBanner>
-            Browser interface scaffold: camera and model inference are not connected yet.
+            Browser interface in progress: local camera preview is available; model inference is not
+            connected yet.
           </StatusBanner>
         </div>
 

--- a/apps/web/src/app/routes.tsx
+++ b/apps/web/src/app/routes.tsx
@@ -1,7 +1,12 @@
-import { useEffect, useRef, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import { Link } from "react-router-dom";
 
-import type { StaticPageDefinition } from "./routeDefinitions";
+import { livePageDefinition, type StaticPageDefinition } from "./routeDefinitions";
+import {
+  useCameraSession,
+  type CameraEnvironment,
+  type CameraStatus,
+} from "../camera/useCameraSession";
 
 function usePageHeading(title: string) {
   const headingRef = useRef<HTMLHeadingElement>(null);
@@ -20,6 +25,129 @@ function StatusBanner({ children }: { children: ReactNode }) {
       <span aria-hidden="true" />
       {children}
     </div>
+  );
+}
+
+const startableStatuses = new Set<CameraStatus>([
+  "idle",
+  "denied",
+  "unavailable",
+  "interrupted",
+  "error",
+]);
+
+export function LivePage({ cameraEnvironment }: { cameraEnvironment?: CameraEnvironment }) {
+  const headingRef = usePageHeading(livePageDefinition.label);
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const [previewMirrored, setPreviewMirrored] = useState(true);
+  const { state, canRequest, start, pause, resume, stop, switchCamera } =
+    useCameraSession(cameraEnvironment);
+
+  useEffect(() => {
+    const video = videoRef.current;
+    if (video === null) return;
+    video.srcObject = state.stream;
+    return () => {
+      video.srcObject = null;
+    };
+  }, [state.stream]);
+
+  const hasStream = state.stream !== null;
+  const canStart = canRequest && startableStatuses.has(state.status);
+
+  return (
+    <section className="live-page" aria-labelledby="live-heading">
+      <div className="live-intro">
+        <p className="eyebrow">{livePageDefinition.eyebrow}</p>
+        <h1 id="live-heading" ref={headingRef} tabIndex={-1}>
+          {livePageDefinition.heading}
+        </h1>
+        <p className="page-summary">{livePageDefinition.summary}</p>
+        <div className="privacy-notice">
+          <strong>Your camera stays under your control.</strong>
+          <p>
+            SignLab asks for permission only after you select Start camera. This preview stays on
+            this device; the page does not upload, save, or record raw video.
+          </p>
+        </div>
+        <StatusBanner>{state.message}</StatusBanner>
+        <p className="page-note">
+          The recognition model is not connected yet. Preview mirroring changes only what you see,
+          never the camera stream or future model coordinates.
+        </p>
+      </div>
+
+      <div className="camera-card">
+        <div className="camera-preview">
+          {hasStream ? (
+            <video
+              ref={videoRef}
+              className={previewMirrored ? "is-mirrored" : undefined}
+              aria-label="Local camera preview"
+              autoPlay
+              muted
+              playsInline
+            />
+          ) : (
+            <div className="camera-placeholder" aria-hidden="true">
+              <span>Camera off</span>
+            </div>
+          )}
+        </div>
+
+        <div className="camera-controls" aria-label="Camera controls">
+          {canStart ? (
+            <button className="primary-action" type="button" onClick={() => void start()}>
+              Start camera
+            </button>
+          ) : null}
+          {state.status === "active" ? (
+            <button type="button" onClick={pause}>
+              Pause preview
+            </button>
+          ) : null}
+          {state.status === "paused" ? (
+            <button type="button" onClick={resume}>
+              Resume preview
+            </button>
+          ) : null}
+          {hasStream ? (
+            <button type="button" onClick={() => stop()}>
+              Stop camera
+            </button>
+          ) : null}
+        </div>
+
+        {hasStream ? (
+          <div className="camera-options">
+            {state.devices.length > 1 ? (
+              <label>
+                Camera
+                <select
+                  value={state.selectedDeviceId ?? ""}
+                  disabled={state.status !== "active"}
+                  onChange={(event) => void switchCamera(event.target.value)}
+                >
+                  {state.devices.map((device) => (
+                    <option key={device.deviceId} value={device.deviceId}>
+                      {device.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            ) : null}
+            <label className="mirror-option">
+              <input
+                type="checkbox"
+                checked={previewMirrored}
+                onChange={(event) => setPreviewMirrored(event.target.checked)}
+              />
+              Mirror preview
+            </label>
+          </div>
+        ) : null}
+      </div>
+    </section>
   );
 }
 

--- a/apps/web/src/camera/useCameraSession.ts
+++ b/apps/web/src/camera/useCameraSession.ts
@@ -1,0 +1,339 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export type CameraStatus =
+  | "idle"
+  | "requesting"
+  | "active"
+  | "paused"
+  | "switching"
+  | "denied"
+  | "unavailable"
+  | "insecure"
+  | "interrupted"
+  | "error";
+
+export interface CameraDevice {
+  readonly deviceId: string;
+  readonly label: string;
+}
+
+export interface CameraEnvironment {
+  readonly document: Pick<Document, "hidden" | "addEventListener" | "removeEventListener">;
+  readonly isSecureContext: boolean;
+  readonly mediaDevices: Pick<MediaDevices, "getUserMedia" | "enumerateDevices"> | undefined;
+}
+
+export interface CameraSessionState {
+  readonly status: CameraStatus;
+  readonly message: string;
+  readonly stream: MediaStream | null;
+  readonly devices: readonly CameraDevice[];
+  readonly selectedDeviceId: string | null;
+}
+
+function browserCameraEnvironment(): CameraEnvironment {
+  return {
+    document,
+    isSecureContext: globalThis.isSecureContext === true,
+    mediaDevices: navigator.mediaDevices,
+  };
+}
+
+function initialState(environment: CameraEnvironment): CameraSessionState {
+  if (!environment.isSecureContext) {
+    return {
+      status: "insecure",
+      message: "Camera access requires HTTPS or a local development address.",
+      stream: null,
+      devices: [],
+      selectedDeviceId: null,
+    };
+  }
+  if (environment.mediaDevices?.getUserMedia === undefined) {
+    return {
+      status: "unavailable",
+      message: "This browser does not provide camera access.",
+      stream: null,
+      devices: [],
+      selectedDeviceId: null,
+    };
+  }
+  return {
+    status: "idle",
+    message: "Camera is off. Nothing is being captured.",
+    stream: null,
+    devices: [],
+    selectedDeviceId: null,
+  };
+}
+
+function cameraError(error: unknown): Pick<CameraSessionState, "status" | "message"> {
+  const name =
+    typeof error === "object" && error !== null && "name" in error
+      ? String(error.name)
+      : "UnknownError";
+  if (name === "NotAllowedError" || name === "SecurityError") {
+    return {
+      status: "denied",
+      message:
+        "Camera permission was denied. Allow camera access in site settings, then try again.",
+    };
+  }
+  if (name === "NotFoundError" || name === "OverconstrainedError") {
+    return {
+      status: "unavailable",
+      message: "No usable camera was found. Connect or select another camera, then try again.",
+    };
+  }
+  if (name === "NotReadableError" || name === "AbortError") {
+    return {
+      status: "error",
+      message: "The camera could not start. Close other camera apps and try again.",
+    };
+  }
+  return {
+    status: "error",
+    message: "The camera could not start. Check the device and try again.",
+  };
+}
+
+function videoConstraints(deviceId?: string): MediaStreamConstraints {
+  return {
+    audio: false,
+    video:
+      deviceId === undefined
+        ? { facingMode: { ideal: "user" } }
+        : { deviceId: { exact: deviceId } },
+  };
+}
+
+export function useCameraSession(environment?: CameraEnvironment) {
+  const [cameraEnvironment] = useState(() => environment ?? browserCameraEnvironment());
+  const [state, setState] = useState(() => initialState(cameraEnvironment));
+  const streamRef = useRef<MediaStream | null>(null);
+  const operationRef = useRef(0);
+  const mountedRef = useRef(true);
+  const trackEndHandlersRef = useRef(new Map<MediaStreamTrack, EventListener>());
+
+  const releaseStream = useCallback((stream: MediaStream) => {
+    for (const track of stream.getTracks()) {
+      const handler = trackEndHandlersRef.current.get(track);
+      if (handler !== undefined) track.removeEventListener("ended", handler);
+      trackEndHandlersRef.current.delete(track);
+      track.stop();
+    }
+  }, []);
+
+  const refreshDevices = useCallback(async () => {
+    const mediaDevices = cameraEnvironment.mediaDevices;
+    if (mediaDevices === undefined) return;
+    try {
+      const devices = (await mediaDevices.enumerateDevices())
+        .filter(({ kind }) => kind === "videoinput")
+        .map(({ deviceId, label }, index) => ({
+          deviceId,
+          label: label || `Camera ${index + 1}`,
+        }));
+      if (mountedRef.current) setState((current) => ({ ...current, devices }));
+    } catch {
+      // Device labels are helpful but not required to keep an active stream usable.
+    }
+  }, [cameraEnvironment]);
+
+  const commitStream = useCallback(
+    (stream: MediaStream, requestedDeviceId: string | undefined, operation: number) => {
+      if (!mountedRef.current || operation !== operationRef.current) {
+        releaseStream(stream);
+        return;
+      }
+      const videoTrack = stream.getVideoTracks()[0];
+      if (videoTrack === undefined) {
+        releaseStream(stream);
+        const previous = streamRef.current;
+        streamRef.current = null;
+        if (previous !== null) releaseStream(previous);
+        setState((current) => ({
+          ...current,
+          status: "unavailable",
+          message: "The selected device did not provide a video track.",
+          stream: null,
+          selectedDeviceId: null,
+        }));
+        return;
+      }
+
+      const ended = () => {
+        if (streamRef.current !== stream) return;
+        streamRef.current = null;
+        releaseStream(stream);
+        if (mountedRef.current) {
+          setState((current) => ({
+            ...current,
+            status: "interrupted",
+            message: "The camera stopped unexpectedly. Reconnect it or start the camera again.",
+            stream: null,
+          }));
+        }
+      };
+      for (const track of stream.getTracks()) {
+        trackEndHandlersRef.current.set(track, ended);
+        track.addEventListener("ended", ended, { once: true });
+      }
+
+      const previous = streamRef.current;
+      streamRef.current = stream;
+      if (previous !== null && previous !== stream) releaseStream(previous);
+      const selectedDeviceId = videoTrack.getSettings().deviceId ?? requestedDeviceId ?? null;
+      setState((current) => ({
+        ...current,
+        status: "active",
+        message: "Camera is on. Raw video stays on this page and is not saved or uploaded.",
+        stream,
+        selectedDeviceId,
+      }));
+      void refreshDevices();
+    },
+    [refreshDevices, releaseStream],
+  );
+
+  const requestStream = useCallback(
+    async (deviceId?: string, switching = false) => {
+      const current = cameraEnvironment;
+      if (!current.isSecureContext) {
+        setState((value) => ({
+          ...value,
+          status: "insecure",
+          message: "Camera access requires HTTPS or a local development address.",
+        }));
+        return;
+      }
+      if (current.mediaDevices?.getUserMedia === undefined) {
+        setState((value) => ({
+          ...value,
+          status: "unavailable",
+          message: "This browser does not provide camera access.",
+        }));
+        return;
+      }
+
+      const operation = operationRef.current + 1;
+      operationRef.current = operation;
+      setState((value) => ({
+        ...value,
+        status: switching ? "switching" : "requesting",
+        message: switching
+          ? "Switching cameras…"
+          : "Waiting for you to choose whether to allow camera access…",
+      }));
+      try {
+        const stream = await current.mediaDevices.getUserMedia(videoConstraints(deviceId));
+        commitStream(stream, deviceId, operation);
+      } catch (error) {
+        if (!mountedRef.current || operation !== operationRef.current) return;
+        const failure = cameraError(error);
+        if (switching && streamRef.current !== null) {
+          setState((value) => ({
+            ...value,
+            status: "active",
+            message: `${failure.message} The previous camera is still active.`,
+          }));
+        } else {
+          setState((value) => ({ ...value, ...failure, stream: null }));
+        }
+      }
+    },
+    [cameraEnvironment, commitStream],
+  );
+
+  const start = useCallback(() => requestStream(), [requestStream]);
+
+  const switchCamera = useCallback(
+    (deviceId: string) => {
+      if (state.status !== "active" || deviceId === state.selectedDeviceId) {
+        return Promise.resolve();
+      }
+      return requestStream(deviceId, streamRef.current !== null);
+    },
+    [requestStream, state.selectedDeviceId, state.status],
+  );
+
+  const pause = useCallback(() => {
+    const stream = streamRef.current;
+    if (stream === null || state.status !== "active") return;
+    for (const track of stream.getVideoTracks()) track.enabled = false;
+    setState((current) => ({
+      ...current,
+      status: "paused",
+      message: "Preview is paused. Stop the camera to release it completely.",
+    }));
+  }, [state.status]);
+
+  const resume = useCallback(() => {
+    const stream = streamRef.current;
+    if (stream === null || state.status !== "paused") return;
+    for (const track of stream.getVideoTracks()) track.enabled = true;
+    setState((current) => ({
+      ...current,
+      status: "active",
+      message: "Camera is on. Raw video stays on this page and is not saved or uploaded.",
+    }));
+  }, [state.status]);
+
+  const stop = useCallback(
+    (message = "Camera is off. Nothing is being captured.") => {
+      operationRef.current += 1;
+      const stream = streamRef.current;
+      streamRef.current = null;
+      if (stream !== null) releaseStream(stream);
+      if (mountedRef.current) {
+        setState((current) => ({
+          ...current,
+          status: "idle",
+          message,
+          stream: null,
+          selectedDeviceId: null,
+        }));
+      }
+    },
+    [releaseStream],
+  );
+
+  useEffect(() => {
+    mountedRef.current = true;
+    const current = cameraEnvironment;
+    const handleVisibility = () => {
+      if (!current.document.hidden) return;
+      operationRef.current += 1;
+      const stream = streamRef.current;
+      streamRef.current = null;
+      if (stream !== null) releaseStream(stream);
+      setState((cameraState) => {
+        const wasStarting =
+          cameraState.status === "requesting" || cameraState.status === "switching";
+        if (stream === null && !wasStarting) return cameraState;
+        return {
+          ...cameraState,
+          status: "idle",
+          message:
+            "Camera stopped because this page was hidden. Start it again when you are ready.",
+          stream: null,
+          selectedDeviceId: null,
+        };
+      });
+    };
+    current.document.addEventListener("visibilitychange", handleVisibility);
+    return () => {
+      mountedRef.current = false;
+      operationRef.current += 1;
+      current.document.removeEventListener("visibilitychange", handleVisibility);
+      const stream = streamRef.current;
+      streamRef.current = null;
+      if (stream !== null) releaseStream(stream);
+    };
+  }, [cameraEnvironment, releaseStream]);
+
+  const canRequest =
+    cameraEnvironment.isSecureContext && cameraEnvironment.mediaDevices?.getUserMedia !== undefined;
+
+  return { state, canRequest, start, pause, resume, stop, switchCamera } as const;
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -322,6 +322,147 @@ h1 {
   padding: clamp(5rem, 10vw, 9rem) 0;
 }
 
+.live-page {
+  display: grid;
+  grid-template-columns: minmax(0, 0.85fr) minmax(24rem, 1.15fr);
+  gap: clamp(3rem, 7vw, 8rem);
+  align-items: center;
+  width: min(100% - 3rem, 82rem);
+  min-height: calc(100vh - 15rem);
+  margin: 0 auto;
+  padding: clamp(4rem, 8vw, 7rem) 0;
+}
+
+.live-page h1 {
+  max-width: 10ch;
+  font-size: clamp(3.2rem, 7vw, 6.5rem);
+}
+
+.privacy-notice {
+  max-width: 42rem;
+  padding: 1rem 1.1rem;
+  margin-bottom: 1.25rem;
+  border-left: 0.25rem solid #e8623c;
+  background: rgb(255 255 255 / 50%);
+  line-height: 1.55;
+}
+
+.privacy-notice p {
+  margin: 0.35rem 0 0;
+  color: #415a58;
+}
+
+.camera-card {
+  padding: clamp(1rem, 2.5vw, 1.5rem);
+  border-radius: 1.5rem;
+  color: #f2f1e9;
+  background: #15302f;
+  box-shadow: 0 1.5rem 4rem rgb(21 48 47 / 18%);
+}
+
+.camera-preview {
+  overflow: hidden;
+  aspect-ratio: 4 / 3;
+  border-radius: 1rem;
+  background: #091b1a;
+}
+
+.camera-preview video,
+.camera-placeholder {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.camera-preview video {
+  object-fit: cover;
+}
+
+.camera-preview video.is-mirrored {
+  transform: scaleX(-1);
+}
+
+.camera-placeholder {
+  display: grid;
+  place-items: center;
+  background: radial-gradient(circle at center, rgb(245 165 139 / 12%), transparent 42%), #091b1a;
+}
+
+.camera-placeholder span {
+  color: #adc0bd;
+  font-size: 0.8rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.camera-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  margin-top: 1rem;
+}
+
+.camera-controls button {
+  padding: 0.7rem 0.95rem;
+  border: 1px solid rgb(242 241 233 / 28%);
+  border-radius: 999px;
+  color: #f2f1e9;
+  background: transparent;
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 750;
+  cursor: pointer;
+}
+
+.camera-controls .primary-action {
+  border-color: #e8623c;
+  background: #e8623c;
+}
+
+.camera-controls button:hover {
+  border-color: #f5a58b;
+}
+
+.camera-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem 1.5rem;
+  align-items: end;
+  padding-top: 1rem;
+}
+
+.camera-options label {
+  display: grid;
+  gap: 0.4rem;
+  color: #adc0bd;
+  font-size: 0.78rem;
+  font-weight: 750;
+}
+
+.camera-options select {
+  min-width: 12rem;
+  padding: 0.55rem 2rem 0.55rem 0.65rem;
+  border: 1px solid rgb(242 241 233 / 28%);
+  border-radius: 0.55rem;
+  color: #15302f;
+  background: #f2f1e9;
+  font: inherit;
+}
+
+.camera-options .mirror-option {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  min-height: 2.35rem;
+}
+
+.mirror-option input {
+  width: 1rem;
+  height: 1rem;
+  accent-color: #e8623c;
+}
+
 .content-page h1 {
   max-width: 13ch;
   font-size: clamp(3.2rem, 7vw, 6.5rem);
@@ -492,6 +633,11 @@ h1 {
     min-height: auto;
   }
 
+  .live-page {
+    grid-template-columns: 1fr;
+    min-height: auto;
+  }
+
   .detail-card {
     max-width: 38rem;
   }
@@ -512,6 +658,7 @@ h1 {
 @media (max-width: 540px) {
   .site-header,
   .hero,
+  .live-page,
   .site-footer {
     width: min(100% - 2rem, 86rem);
   }

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -6,4 +6,5 @@ import { afterEach, vi } from "vitest";
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -40,9 +40,12 @@ development API. Hash-based navigation works on a root domain and on an arbitrar
 configured subpath without server-side route rewrites.
 
 The feature routes describe their intended behavior but deliberately do not imitate
-unfinished features. This shell requests no camera permission, makes no runtime data
-request, loads no model, reads no replay input, and stores no feedback. Those
-capabilities belong to later stories and retain their own evidence gates.
+unfinished features. The live route requests camera permission only after an explicit
+user action and can show a local preview. It stops camera tracks on stop, navigation,
+page hiding, or device interruption; it does not upload, record, persist, or submit
+frames to the worker. The shell makes no runtime data request, loads no model, reads
+no replay input, and stores no feedback. Those capabilities retain separate evidence
+gates.
 
 The intended bundle-loading flow is manifest-first:
 
@@ -58,9 +61,9 @@ The shell now contains a dormant `@mediapipe/tasks-vision@1.0.1` landmark worker
 It initializes one hand/pose task pair from externally verified buffers, returns
 typed timestamps, two-hand slots, six body anchors, validity, and confidence, keeps
 only the newest waiting frame, emits sanitized timing/drop/failure measurements, and
-releases replaced or processed images and task resources. Bundle verification and
-loading, camera and replay producers, ONNX inference, event detection, and route
-lifecycle controls remain separate gates; no browser model is usable yet.
+releases replaced or processed images and task resources. The camera preview remains
+disconnected from that worker. Bundle verification and loading, replay input, ONNX
+inference, and event detection remain separate gates; no browser model is usable yet.
 
 The [licensed external-data boundary](external-datasets.md) is intentionally
 separate from participant ingest. It registers source, license, attribution,

--- a/docs/development.md
+++ b/docs/development.md
@@ -88,9 +88,10 @@ npm run build:subpath
 
 The two builds prove the static files can be published at a root domain or a
 configured `/signlab/` subpath. Hash-based routes keep every page usable on a plain
-static host without rewrite rules. Story #38 provides the responsive, honest shell
-only: it does not request camera access, load a model, process replay inputs, save
-feedback, or call a backend.
+static host without rewrite rules. The live route requests camera access only after
+the user selects **Start camera**, keeps its preview local, and releases tracks during
+its documented lifecycle transitions. It does not send frames to the dormant worker,
+load a model, process replay inputs, save feedback, or call a backend.
 
 The normal web checks also compile and test the dormant landmark worker. MediaPipe
 `.task` models remain external to Git, and neither task starts until a later boundary


### PR DESCRIPTION
Closes #42.

## What changed
- replace the static Live route with an explicit, consent-first local camera preview
- add start, pause/resume, stop, and camera switching controls with CSS-only preview mirroring
- release streams on stop, route unmount, page hiding, external track interruption, and late permission resolution
- show actionable insecure-context, unavailable-device, denied-permission, busy-camera, and interruption states
- keep camera support independent from the dormant landmark worker; no frame loop, model loading, recording, persistence, analytics, or upload path is added
- update public documentation and privacy copy to match the implemented boundary

## Evidence
- 31 web tests, including explicit-permission gating, StrictMode, switching/fallback, visibility/unmount races, interruption, transport/storage API spies, and mirroring
- web formatting, lint, typecheck, root/subpath builds: pass
- 1,357 Python tests pass; 13 environment-specific skips
- repository hygiene: pass
- desktop and narrow browser layout checks: pass with no console errors