### PR TITLE
Implement TypeScript candidate contracts

### DIFF
--- a/apps/web/src/inference/candidateDecision.test.ts
+++ b/apps/web/src/inference/candidateDecision.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import { decideCandidate } from "./candidateDecision";
+import policy from "../../../../docs/reports/popsign-constructed-calibration-policy-v1.json";
+
+describe("candidate decision contract", () => {
+  it("gives inactivity precedence over malformed policy and probability input", () => {
+    expect(decideCandidate(false, "not probabilities", null)).toEqual({ kind: "inactive" });
+  });
+
+  it("temperature-scales valid probabilities and chooses the first equal maximum", () => {
+    const probabilities = [0.4, 0.4, 0.05, 0.05, 0.05, 0.05];
+    const decision = decideCandidate(true, probabilities, policy);
+    const expected = 0.4 ** 20 / (2 * 0.4 ** 20 + 4 * 0.05 ** 20);
+
+    expect(decision).toMatchObject({ kind: "target", label: "hello" });
+    expect(decideCandidate(true, [1.000019, 0, 0, 0, 0, 0], policy)).toMatchObject({
+      kind: "target",
+    });
+    if (decision.kind !== "target") throw new Error("expected target decision");
+    expect(decision.confidence).toBeCloseTo(expected, 14);
+  });
+
+  it("keeps the selected other class distinct from target and abstain", () => {
+    expect(
+      decideCandidate(true, new Float32Array([0.01, 0.01, 0.01, 0.01, 0.01, 0.95]), policy),
+    ).toMatchObject({ kind: "other", label: "other" });
+  });
+
+  it("abstains on malformed active probability vectors", () => {
+    const malformed: unknown[] = [
+      "not probabilities",
+      [0.2, 0.2],
+      [0.2, 0.2, 0.2, 0.2, 0.2, Number.NaN],
+      [0.1, 0.1, 0.1, 0.1, 0.1, 0.1],
+    ];
+
+    expect(malformed.map((value) => decideCandidate(true, value, policy))).toEqual(
+      malformed.map(() => ({ kind: "abstain" })),
+    );
+  });
+
+  it("rejects policy variants instead of silently changing runtime behavior", () => {
+    const variants = [
+      { format: "signlab-decision-policy/2" },
+      { class_map: { ...policy.class_map, "0": "yes" } },
+      { identities: { ...policy.identities, model_sha256: "sha256:changed" } },
+      { unexpected: true },
+      { decision_precedence: new Array(4) },
+      {
+        temperature: {
+          method: "softmax_log_probability_scalar_temperature/1",
+          temperature_milli: 51,
+        },
+      },
+      {
+        abstention: {
+          inclusive: true,
+          objective: "maximize_target_coverage_zero_observed_accepted_errors/1",
+          threshold_percent: 1,
+        },
+      },
+    ].map((change) => ({ ...policy, ...change }));
+
+    expect(variants.map((variant) => decideCandidate(true, [1, 0, 0, 0, 0, 0], variant))).toEqual(
+      variants.map(() => ({ kind: "abstain" })),
+    );
+  });
+});

--- a/apps/web/src/inference/candidateDecision.ts
+++ b/apps/web/src/inference/candidateDecision.ts
@@ -1,0 +1,89 @@
+import candidateDecisionPolicy from "../../../../docs/reports/popsign-constructed-calibration-policy-v1.json";
+
+export const CANDIDATE_LABELS = ["hello", "no", "please", "thank_you", "yes", "other"] as const;
+
+export type CandidateLabel = (typeof CANDIDATE_LABELS)[number];
+export type CandidateDecision =
+  | { readonly kind: "inactive" | "abstain" }
+  | {
+      readonly kind: "target";
+      readonly label: Exclude<CandidateLabel, "other">;
+      readonly confidence: number;
+    }
+  | { readonly kind: "other"; readonly label: "other"; readonly confidence: number };
+
+const TEMPERATURE = candidateDecisionPolicy.temperature.temperature_milli / 1_000;
+const THRESHOLD = candidateDecisionPolicy.abstention.threshold_percent / 100;
+const PROBABILITY_SUM_TOLERANCE = 1e-5 + 1e-5;
+const LOG_FLOOR = 1e-7;
+
+function exactPolicy(value: unknown, expected: unknown = candidateDecisionPolicy): boolean {
+  if (Array.isArray(expected)) {
+    return (
+      Array.isArray(value) &&
+      value.length === expected.length &&
+      expected.every((item, index) => exactPolicy(value[index], item))
+    );
+  }
+  if (typeof expected === "object" && expected !== null) {
+    if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+    const actual = value as Record<string, unknown>;
+    const entries = Object.entries(expected);
+    return (
+      Object.keys(actual).length === entries.length &&
+      entries.every(([key, item]) => exactPolicy(actual[key], item))
+    );
+  }
+  return value === expected;
+}
+
+function validProbabilities(value: unknown): number[] | null {
+  if (!Array.isArray(value) && !(value instanceof Float32Array)) return null;
+  const values: readonly unknown[] = value instanceof Float32Array ? Array.from(value) : value;
+  if (values.length !== CANDIDATE_LABELS.length) return null;
+
+  const probabilities: number[] = [];
+  for (const entry of values) {
+    if (typeof entry !== "number" || !Number.isFinite(entry) || entry < 0) return null;
+    probabilities.push(entry);
+  }
+  const sum = probabilities.reduce((total, entry) => total + entry, 0);
+  return Math.abs(sum - 1) <= PROBABILITY_SUM_TOLERANCE ? probabilities : null;
+}
+
+function calibratedProbabilities(probabilities: readonly number[]): number[] {
+  const logits = probabilities.map(
+    (probability) => Math.log(Math.min(1, Math.max(LOG_FLOOR, probability))) / TEMPERATURE,
+  );
+  const maximum = Math.max(...logits);
+  const exponentials = logits.map((logit) => Math.exp(logit - maximum));
+  const total = exponentials.reduce((sum, value) => sum + value, 0);
+  return exponentials.map((value) => value / total);
+}
+
+/** Apply the one supported candidate policy without guessing on invalid runtime input. */
+export function decideCandidate(
+  candidateActive: boolean,
+  probabilities: unknown,
+  policy: unknown,
+): CandidateDecision {
+  if (!candidateActive) return { kind: "inactive" };
+
+  const checkedProbabilities = validProbabilities(probabilities);
+  if (!exactPolicy(policy) || checkedProbabilities === null) {
+    return { kind: "abstain" };
+  }
+
+  const calibrated = calibratedProbabilities(checkedProbabilities);
+  let selectedIndex = 0;
+  for (let index = 1; index < calibrated.length; index += 1) {
+    if (calibrated[index]! > calibrated[selectedIndex]!) selectedIndex = index;
+  }
+  const confidence = calibrated[selectedIndex]!;
+  const label = CANDIDATE_LABELS[selectedIndex]!;
+
+  if (confidence < THRESHOLD) return { kind: "abstain" };
+  return label === "other"
+    ? { kind: "other", label, confidence }
+    : { kind: "target", label, confidence };
+}

--- a/apps/web/src/inference/candidatePreprocessing.test.ts
+++ b/apps/web/src/inference/candidatePreprocessing.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+
+import plan from "../../../../src/signlab/resources/features/config/hand-local-64-1.default.json";
+import {
+  absentBodyAnchors,
+  absentHandSlots,
+  type HandSlot,
+  type HandSlotId,
+  type LandmarkPoint,
+} from "../landmarks/protocol";
+import {
+  preprocessCandidate,
+  type CandidateFrame,
+  type CandidateGapEvidence,
+} from "./candidatePreprocessing";
+
+const point = (x: number, y: number, z: number): LandmarkPoint => ({
+  x,
+  y,
+  z,
+  visibility: null,
+  presence: null,
+});
+
+function hand(
+  slotId: HandSlotId,
+  handedness: "left" | "right",
+  mirrored = false,
+  zeroScale = false,
+  invalid = false,
+  landmarkOneY = 0.05,
+): HandSlot {
+  const landmarks = Array.from({ length: 21 }, (_, index) => {
+    const [x, y, z] = zeroScale
+      ? [0, 0, 0]
+      : index === 9
+        ? [1, 0, 0]
+        : [index / 10, index === 1 ? landmarkOneY : index / 20, -index / 40];
+    return point(
+      invalid && index === 1 ? Number.NaN : mirrored ? -(3 + 2 * x) : 3 + 2 * x,
+      4 + 2 * y,
+      2 * z,
+    );
+  });
+  return {
+    slotId,
+    present: true,
+    detectorIndex: slotId === "hand_0" ? 0 : 1,
+    trackingId: slotId,
+    handedness,
+    handednessConfidence: 0.9,
+    imageLandmarks: landmarks,
+    worldLandmarks: landmarks,
+  };
+}
+
+function frame(
+  timestamp: number,
+  first: HandSlot | null,
+  second: HandSlot | null = null,
+): CandidateFrame {
+  const absent = absentHandSlots();
+  return {
+    relativeTimestampUs: timestamp,
+    valid: true,
+    hands: [first ?? absent[0], second ?? absent[1]],
+    bodyAnchors: absentBodyAnchors(),
+  };
+}
+
+const quality = (gaps: readonly CandidateGapEvidence[] = [], discontinuities = 0) => ({
+  timestampDiscontinuityCount: discontinuities,
+  gaps,
+});
+const count = (values: Uint8Array, start: number, length: number) =>
+  values.slice(start, start + length).reduce((sum, value) => sum + value, 0);
+
+describe("candidate preprocessing contract", () => {
+  it("normalizes fixed hand slots, mirror state, elapsed time, quantization, and padding", () => {
+    const unmirroredHands = [hand("hand_0", "left"), hand("hand_1", "right")] as const;
+    const mirroredHands = [hand("hand_0", "right", true), hand("hand_1", "left", true)] as const;
+    const run = (hands: readonly [HandSlot, HandSlot], mirror: "mirrored" | "not_mirrored") =>
+      preprocessCandidate([frame(0, ...hands), frame(50_000, ...hands)], mirror, quality(), plan);
+    const result = run(unmirroredHands, "not_mirrored");
+    const mirrored = run(mirroredHands, "mirrored");
+    const halfStep = preprocessCandidate(
+      [
+        frame(
+          0,
+          hand("hand_0", "left", false, false, false, 0.0000005),
+          hand("hand_1", "right", false, false, false, -0.0000005),
+        ),
+      ],
+      "not_mirrored",
+      quality(),
+      plan,
+    );
+
+    expect(result.shape).toEqual([1, 64, 126]);
+    expect(result.values).toHaveLength(8_064);
+    expect(Array.from(result.values.slice(0, 126))).toEqual(
+      Array.from(mirrored.values.slice(0, 126)),
+    );
+    expect(result.values[3]).toBe(Math.fround(0.1));
+    expect(result.values[66]).toBe(Math.fround(-0.1));
+    expect(halfStep.values[4]).toBe(Math.fround(0.000001));
+    expect(halfStep.values[67]).toBe(Math.fround(-0.000001));
+    expect(result.timestampsUs.slice(0, 4)).toEqual([0, 33_333, 50_000, 83_333]);
+    expect(count(result.interpolatedMask, 126, 126)).toBe(126);
+    expect(count(result.validMask, 0, 126)).toBe(126);
+    expect(result.bodyAvailableMask[0]).toBe(0);
+    expect(Array.from(result.paddingMask.slice(0, 4))).toEqual([0, 0, 0, 1]);
+  });
+
+  it("bridges only an approved gap and masks missing or zero-scale hands", () => {
+    const rows = [
+      frame(0, hand("hand_0", "left", false, false, false, 0)),
+      frame(33_333, null),
+      frame(66_666, hand("hand_0", "left", false, false, false, 0.2)),
+    ];
+    const gap: CandidateGapEvidence = {
+      signal: "hand_0",
+      decision: "interpolate_linear",
+      leftObservedFrameIndex: 0,
+      leftObservedTimestampUs: 0,
+      rightObservedFrameIndex: 2,
+      rightObservedTimestampUs: 66_666,
+    };
+    const blocked = preprocessCandidate(rows, "not_mirrored", quality(), plan);
+    const approved = preprocessCandidate(rows, "not_mirrored", quality([gap]), plan);
+    const invalidScale = preprocessCandidate(
+      [frame(0, hand("hand_0", "left"), hand("hand_1", "right", false, true))],
+      "not_mirrored",
+      quality(),
+      plan,
+    );
+
+    expect(count(blocked.validMask, 126, 63)).toBe(0);
+    expect(count(approved.interpolatedMask, 126, 63)).toBe(63);
+    expect(approved.values[130]).toBe(Math.fround(0.1));
+    expect(approved.handPresentMask[2]).toBe(1);
+    expect(invalidScale.handPresentMask[1]).toBe(1);
+    expect(count(invalidScale.validMask, 63, 63)).toBe(0);
+  });
+
+  it("preserves long-grid endpoints and rejects unsafe inputs or contract variants", () => {
+    const timestamp = (index: number) => Math.floor((2 * index * 1_000_000 + 30) / 60);
+    const rows = Array.from({ length: 66 }, (_, index) =>
+      frame(timestamp(index), hand("hand_0", "left")),
+    );
+    const result = preprocessCandidate(rows, "not_mirrored", quality(), plan);
+    const changedPlan = structuredClone(plan);
+    changedPlan.feature_order.reverse();
+    const sparsePlan = { ...plan, feature_order: new Array(126) };
+    const rejects =
+      (
+        candidateFrames: readonly CandidateFrame[],
+        candidateQuality = quality(),
+        candidatePlan: unknown = plan,
+      ) =>
+      () =>
+        preprocessCandidate(candidateFrames, "not_mirrored", candidateQuality, candidatePlan);
+
+    expect([result.timestampsUs[0], result.timestampsUs[63]]).toEqual([0, timestamp(65)]);
+    expect(count(result.paddingMask, 0, 64)).toBe(0);
+    [
+      rejects([]),
+      rejects([frame(0, null), frame(0, null)]),
+      rejects([frame(0, hand("hand_0", "left", false, false, true))]),
+      rejects([frame(0, null)], quality([], 1)),
+      rejects([frame(0, null)], quality(), changedPlan),
+      rejects([frame(0, null)], quality(), sparsePlan),
+    ].forEach((invoke) => expect(invoke).toThrow());
+  });
+});

--- a/apps/web/src/inference/candidatePreprocessing.ts
+++ b/apps/web/src/inference/candidatePreprocessing.ts
@@ -1,0 +1,364 @@
+import {
+  BODY_ANCHOR_NAMES,
+  HAND_SLOT_IDS,
+  type LandmarkFrameMessage,
+  type LandmarkPoint,
+  type ReportedHandedness,
+} from "../landmarks/protocol";
+import candidateFeaturePlan from "../../../../src/signlab/resources/features/config/hand-local-64-1.default.json";
+
+const FRAME_COUNT = 64;
+const HAND_WIDTH = 63;
+const FEATURE_WIDTH = 126;
+const SCALE = 1_000_000;
+const SHAPE = [1, FRAME_COUNT, FEATURE_WIDTH] as const;
+const GAP_SIGNALS = [...HAND_SLOT_IDS, "left_shoulder", "right_shoulder"] as const;
+
+export type SourceMirrorState = "mirrored" | "not_mirrored";
+export type CandidateGapSignal = (typeof GAP_SIGNALS)[number];
+export type CandidateFrame = Pick<
+  LandmarkFrameMessage,
+  "relativeTimestampUs" | "valid" | "hands" | "bodyAnchors"
+>;
+
+export interface CandidateGapEvidence {
+  readonly signal: CandidateGapSignal;
+  readonly decision: "interpolate_linear";
+  readonly leftObservedFrameIndex: number;
+  readonly leftObservedTimestampUs: number;
+  readonly rightObservedFrameIndex: number;
+  readonly rightObservedTimestampUs: number;
+}
+
+export interface CandidateQualityEvidence {
+  readonly timestampDiscontinuityCount: number;
+  readonly gaps: readonly CandidateGapEvidence[];
+}
+
+type Point = readonly [number, number, number];
+type HandValue = { readonly world: readonly Point[]; readonly handedness: ReportedHandedness };
+type Sample<T> = { readonly value: T; readonly evidence: "observed" | "interpolated" };
+
+function deepEqual(value: unknown, expected: unknown): boolean {
+  if (Array.isArray(expected)) {
+    return (
+      Array.isArray(value) &&
+      value.length === expected.length &&
+      expected.every((item, index) => deepEqual(value[index], item))
+    );
+  }
+  if (typeof expected === "object" && expected !== null) {
+    if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+    const actual = value as Record<string, unknown>;
+    const entries = Object.entries(expected);
+    return (
+      Object.keys(actual).length === entries.length &&
+      entries.every(([key, item]) => deepEqual(actual[key], item))
+    );
+  }
+  return value === expected;
+}
+
+function requireCandidatePlan(plan: unknown): void {
+  if (!deepEqual(plan, candidateFeaturePlan)) {
+    throw new Error("candidate.preprocessing.unsupported_feature_plan");
+  }
+}
+
+const safeTimestamp = (value: number) => Number.isSafeInteger(value) && value >= 0;
+
+function xyz(point: LandmarkPoint | null): Point {
+  if (point === null || ![point.x, point.y, point.z].every(Number.isFinite)) {
+    throw new Error("candidate.preprocessing.invalid_landmarks");
+  }
+  return [point.x, point.y, point.z];
+}
+
+function handAt(frame: CandidateFrame, slotIndex: number): HandValue | null {
+  const slot = HAND_SLOT_IDS[slotIndex];
+  const hand = frame.hands[slotIndex];
+  if (slot === undefined || hand?.slotId !== slot) {
+    throw new Error("candidate.preprocessing.invalid_hand_slots");
+  }
+  if (!frame.valid || !hand.present) return null;
+  if (
+    (hand.handedness !== "left" && hand.handedness !== "right") ||
+    hand.handednessConfidence === null ||
+    !Number.isFinite(hand.handednessConfidence) ||
+    hand.handednessConfidence < 0 ||
+    hand.handednessConfidence > 1 ||
+    hand.worldLandmarks?.length !== 21
+  ) {
+    throw new Error("candidate.preprocessing.invalid_hand");
+  }
+  return { world: hand.worldLandmarks.map(xyz), handedness: hand.handedness };
+}
+
+function anchorAt(frame: CandidateFrame, name: "left_shoulder" | "right_shoulder"): Point | null {
+  const index = BODY_ANCHOR_NAMES.indexOf(name);
+  const anchor = frame.bodyAnchors[index];
+  if (anchor?.name !== name) throw new Error("candidate.preprocessing.invalid_body_anchors");
+  return !frame.valid || !anchor.present ? null : xyz(anchor.imagePoint);
+}
+
+function signalAt(frame: CandidateFrame, signal: CandidateGapSignal): HandValue | Point | null {
+  if (signal === "hand_0") return handAt(frame, 0);
+  if (signal === "hand_1") return handAt(frame, 1);
+  return anchorAt(frame, signal);
+}
+
+function validateInputs(
+  frames: readonly CandidateFrame[],
+  quality: CandidateQualityEvidence,
+): void {
+  if (
+    frames.length === 0 ||
+    frames[0]?.relativeTimestampUs !== 0 ||
+    quality.timestampDiscontinuityCount !== 0
+  ) {
+    throw new Error("candidate.preprocessing.invalid_timeline");
+  }
+  frames.forEach((frame, index) => {
+    if (
+      !safeTimestamp(frame.relativeTimestampUs) ||
+      (index > 0 &&
+        (frames[index - 1]?.relativeTimestampUs ?? Infinity) >= frame.relativeTimestampUs) ||
+      !HAND_SLOT_IDS.every((slot, slotIndex) => frame.hands[slotIndex]?.slotId === slot) ||
+      !BODY_ANCHOR_NAMES.every((name, anchorIndex) => frame.bodyAnchors[anchorIndex]?.name === name)
+    ) {
+      throw new Error("candidate.preprocessing.invalid_timeline");
+    }
+    HAND_SLOT_IDS.forEach((_, slotIndex) => void handAt(frame, slotIndex));
+  });
+  quality.gaps.forEach((gap) => {
+    const interior = frames.slice(gap.leftObservedFrameIndex + 1, gap.rightObservedFrameIndex);
+    if (
+      !GAP_SIGNALS.includes(gap.signal) ||
+      gap.decision !== "interpolate_linear" ||
+      ![
+        gap.leftObservedFrameIndex,
+        gap.rightObservedFrameIndex,
+        gap.leftObservedTimestampUs,
+        gap.rightObservedTimestampUs,
+      ].every(safeTimestamp) ||
+      gap.rightObservedFrameIndex <= gap.leftObservedFrameIndex + 1 ||
+      frames[gap.leftObservedFrameIndex]?.relativeTimestampUs !== gap.leftObservedTimestampUs ||
+      frames[gap.rightObservedFrameIndex]?.relativeTimestampUs !== gap.rightObservedTimestampUs ||
+      signalAt(frames[gap.leftObservedFrameIndex]!, gap.signal) === null ||
+      signalAt(frames[gap.rightObservedFrameIndex]!, gap.signal) === null ||
+      interior.some((frame) => signalAt(frame, gap.signal) !== null)
+    ) {
+      throw new Error("candidate.preprocessing.invalid_gap_evidence");
+    }
+  });
+}
+
+function roundHalfUp(numerator: number, denominator: number): number {
+  return Math.floor((2 * numerator + denominator) / (2 * denominator));
+}
+
+function elapsedGrid(finalUs: number): number[] {
+  const maximumSpan = roundHalfUp((1_000_000 - 1) * SCALE, 30);
+  if (finalUs > maximumSpan) throw new Error("candidate.preprocessing.timeline_too_long");
+  const output: number[] = [];
+  for (let index = 0; ; index += 1) {
+    const timestamp = roundHalfUp(index * SCALE, 30);
+    if (timestamp > finalUs) break;
+    output.push(timestamp);
+  }
+  if (output.at(-1) !== finalUs) output.push(finalUs);
+  return output;
+}
+
+function lowerBound(frames: readonly CandidateFrame[], targetUs: number): number {
+  let low = 0;
+  let high = frames.length;
+  while (low < high) {
+    const middle = Math.floor((low + high) / 2);
+    if ((frames[middle]?.relativeTimestampUs ?? Infinity) < targetUs) low = middle + 1;
+    else high = middle;
+  }
+  return low;
+}
+
+function sample<T>(
+  frames: readonly CandidateFrame[],
+  quality: CandidateQualityEvidence,
+  signal: CandidateGapSignal,
+  targetUs: number,
+  read: (frame: CandidateFrame) => T | null,
+  blend: (left: T, right: T, ratio: number) => T | null,
+): Sample<T> | null {
+  const position = lowerBound(frames, targetUs);
+  const exact = frames[position];
+  if (exact?.relativeTimestampUs === targetUs) {
+    const value = read(exact);
+    if (value !== null) return { value, evidence: "observed" };
+  }
+  const gap = quality.gaps.find((item) => {
+    return (
+      item.signal === signal &&
+      item.leftObservedTimestampUs <= targetUs &&
+      targetUs <= item.rightObservedTimestampUs
+    );
+  });
+  const leftIndex = gap?.leftObservedFrameIndex ?? position - 1;
+  const rightIndex = gap?.rightObservedFrameIndex ?? position;
+  const leftFrame = frames[leftIndex];
+  const rightFrame = frames[rightIndex];
+  if (leftFrame === undefined || rightFrame === undefined) return null;
+  const left = read(leftFrame);
+  const right = read(rightFrame);
+  const elapsed = rightFrame.relativeTimestampUs - leftFrame.relativeTimestampUs;
+  if (
+    left === null ||
+    right === null ||
+    elapsed <= 0 ||
+    targetUs < leftFrame.relativeTimestampUs ||
+    targetUs > rightFrame.relativeTimestampUs
+  )
+    return null;
+  const value = blend(left, right, (targetUs - leftFrame.relativeTimestampUs) / elapsed);
+  return value === null ? null : { value, evidence: "interpolated" };
+}
+
+function interpolatePoint(left: Point, right: Point, ratio: number): Point {
+  return [0, 1, 2].map(
+    (axis) => left[axis]! + (right[axis]! - left[axis]!) * ratio,
+  ) as unknown as Point;
+}
+
+function sampleHand(
+  frames: readonly CandidateFrame[],
+  quality: CandidateQualityEvidence,
+  slotIndex: number,
+  targetUs: number,
+): Sample<HandValue> | null {
+  return sample(
+    frames,
+    quality,
+    HAND_SLOT_IDS[slotIndex] ?? "hand_0",
+    targetUs,
+    (frame) => handAt(frame, slotIndex),
+    (left, right, ratio) =>
+      left.handedness !== right.handedness
+        ? null
+        : {
+            handedness: left.handedness,
+            world: left.world.map((point, index) =>
+              interpolatePoint(point, right.world[index]!, ratio),
+            ),
+          },
+  );
+}
+
+function localPoints(hand: HandValue, mirrored: boolean): readonly Point[] | null {
+  const points = hand.world.map(([x, y, z]) => [mirrored ? -x : x, y, z] as const);
+  const wrist = points[0];
+  const middleMcp = points[9];
+  if (wrist === undefined || middleMcp === undefined) return null;
+  const scale = Math.hypot(
+    middleMcp[0] - wrist[0],
+    middleMcp[1] - wrist[1],
+    middleMcp[2] - wrist[2],
+  );
+  if (!Number.isFinite(scale) || scale <= 0) return null;
+  const corrected = mirrored ? hand.handedness : hand.handedness === "left" ? "right" : "left";
+  const sign = corrected === "left" ? -1 : 1;
+  return points.map(([x, y, z]) => [
+    (sign * (x - wrist[0])) / scale,
+    (y - wrist[1]) / scale,
+    (z - wrist[2]) / scale,
+  ]);
+}
+
+function modelValue(value: number): number {
+  const scaled = Math.abs(value) * SCALE;
+  if (!Number.isFinite(scaled) || scaled > Number.MAX_SAFE_INTEGER) {
+    throw new Error("candidate.preprocessing.invalid_feature_value");
+  }
+  const integer = Math.floor(scaled + 0.5) * (value < 0 ? -1 : 1);
+  return Math.fround(integer === 0 ? 0 : integer / SCALE);
+}
+
+function selectionIndices(count: number): number[] {
+  if (count <= FRAME_COUNT) return Array.from({ length: count }, (_, index) => index);
+  return Array.from({ length: FRAME_COUNT }, (_, index) =>
+    Math.floor((2 * index * (count - 1) + FRAME_COUNT - 1) / (2 * (FRAME_COUNT - 1))),
+  );
+}
+
+export function preprocessCandidate(
+  frames: readonly CandidateFrame[],
+  sourceMirrorState: SourceMirrorState,
+  quality: CandidateQualityEvidence,
+  featurePlan: unknown,
+) {
+  requireCandidatePlan(featurePlan);
+  if (sourceMirrorState !== "mirrored" && sourceMirrorState !== "not_mirrored") {
+    throw new Error("candidate.preprocessing.invalid_mirror_state");
+  }
+  validateInputs(frames, quality);
+  const sourceGrid = elapsedGrid(frames.at(-1)!.relativeTimestampUs);
+  const selected = selectionIndices(sourceGrid.length);
+  const values = new Float32Array(FRAME_COUNT * FEATURE_WIDTH);
+  const validMask = new Uint8Array(values.length);
+  const observedMask = new Uint8Array(values.length);
+  const interpolatedMask = new Uint8Array(values.length);
+  const handPresentMask = new Uint8Array(FRAME_COUNT * 2);
+  const bodyAvailableMask = new Uint8Array(FRAME_COUNT);
+  const paddingMask = new Uint8Array(FRAME_COUNT);
+  const timestampsUs = selected.map((index) => sourceGrid[index]!);
+  const mirrored = sourceMirrorState === "mirrored";
+
+  selected.forEach((sourceIndex, outputIndex) => {
+    const targetUs = sourceGrid[sourceIndex]!;
+    HAND_SLOT_IDS.forEach((_, slotIndex) => {
+      const sampled = sampleHand(frames, quality, slotIndex, targetUs);
+      if (sampled === null) return;
+      handPresentMask[outputIndex * 2 + slotIndex] = 1;
+      localPoints(sampled.value, mirrored)?.forEach((coordinates, landmarkIndex) =>
+        coordinates.forEach((value, axisIndex) => {
+          const index =
+            outputIndex * FEATURE_WIDTH + slotIndex * HAND_WIDTH + landmarkIndex * 3 + axisIndex;
+          values[index] = modelValue(value);
+          validMask[index] = 1;
+          if (sampled.evidence === "observed") observedMask[index] = 1;
+          else interpolatedMask[index] = 1;
+        }),
+      );
+    });
+    const shoulder = (name: "left_shoulder" | "right_shoulder") =>
+      sample(frames, quality, name, targetUs, (frame) => anchorAt(frame, name), interpolatePoint)
+        ?.value;
+    const left = shoulder("left_shoulder");
+    const right = shoulder("right_shoulder");
+    if (left !== undefined && right !== undefined) {
+      const leftX = mirrored ? 1 - left[0] : left[0];
+      const rightX = mirrored ? 1 - right[0] : right[0];
+      const bodyScale = Math.hypot(rightX - leftX, right[1] - left[1]);
+      if (Number.isFinite(bodyScale) && bodyScale > 0) {
+        bodyAvailableMask[outputIndex] = 1;
+      }
+    }
+  });
+
+  const lastSelectedTimestamp = timestampsUs.at(-1)!;
+  for (let index = selected.length; index < FRAME_COUNT; index += 1) {
+    paddingMask[index] = 1;
+    const offset = index - selected.length + 1;
+    timestampsUs.push(lastSelectedTimestamp + roundHalfUp(offset * SCALE, 30));
+  }
+  if (!values.every(Number.isFinite)) throw new Error("candidate.preprocessing.invalid_tensor");
+  return {
+    values,
+    shape: SHAPE,
+    validMask,
+    observedMask,
+    interpolatedMask,
+    handPresentMask,
+    bodyAvailableMask,
+    paddingMask,
+    timestampsUs,
+  };
+}


### PR DESCRIPTION
Closes #36

## What changed

- add the exact candidate hand-local preprocessing contract in pure TypeScript
- produce a finite `1 × 64 × 126` Float32 tensor with validity, evidence, hand, body, and padding masks
- preserve the Python candidate's elapsed-time grid, approved-gap behavior, mirror/handedness normalization, quantization, endpoint selection, and right padding
- add the exact candidate decision contract for target, `other`, `abstain`, and `inactive`
- reject altered plan/policy contracts, malformed timelines, discontinuities, unsafe numeric input, and malformed active probabilities

## Scope

- 641/650 nonblank TypeScript production/test lines
- no React, worker integration, bundle loading, ONNX Web, event detection, or cross-runtime parity work
- cross-runtime goldens and parity remain deferred to #39

## Verification

- `npm test -- --run` — 39 passed
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm run build:subpath`
- independent correctness review: PASS
- independent scope review: PASS