### PR TITLE
Load browser model bundles safely

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@mediapipe/tasks-vision": "1.0.1",
+        "ajv": "8.20.0",
         "react": "19.2.8",
         "react-dom": "19.2.8",
         "react-router-dom": "7.18.3"
@@ -1683,16 +1684,15 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
-      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
-      "dev": true,
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -2163,6 +2163,30 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/espree": {
       "version": "11.2.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
@@ -2251,7 +2275,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -2267,6 +2290,22 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -2578,10 +2617,9 @@
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -3362,7 +3400,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@mediapipe/tasks-vision": "1.0.1",
+    "ajv": "8.20.0",
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "react-router-dom": "7.18.3"

--- a/apps/web/src/app/LivePage.test.tsx
+++ b/apps/web/src/app/LivePage.test.tsx
@@ -3,6 +3,11 @@ import { StrictMode } from "react";
 import { describe, expect, it, vi } from "vitest";
 
 import type { CameraEnvironment } from "../camera/useCameraSession";
+import {
+  type ModelBundleSession,
+  type ModelBundleStatus,
+  type VerifiedModelBundle,
+} from "../modelBundle/modelBundleSession";
 import { LivePage } from "./routes";
 
 class TestDocument extends EventTarget {
@@ -90,6 +95,9 @@ describe("consent-first camera preview", () => {
     expect(
       screen.getByText(/asks for permission only after you select Start camera/),
     ).toBeVisible();
+    expect(screen.getByRole("status", { name: "Model bundle status" })).toHaveTextContent(
+      "No model bundle is configured.",
+    );
 
     await startCamera();
 
@@ -98,7 +106,7 @@ describe("consent-first camera preview", () => {
       video: { facingMode: { ideal: "user" } },
     });
     const video = screen.getByLabelText("Local camera preview");
-    expect(video).toHaveProperty("srcObject", stream);
+    await waitFor(() => expect(video).toHaveProperty("srcObject", stream));
     expect(video).toHaveClass("is-mirrored");
 
     fireEvent.click(screen.getByRole("checkbox", { name: "Mirror preview" }));
@@ -305,5 +313,43 @@ describe("consent-first camera preview", () => {
 
     await waitFor(() => expect(late.track.stop).toHaveBeenCalledOnce());
     expect(screen.queryByLabelText("Local camera preview")).not.toBeInTheDocument();
+  });
+});
+
+describe("model bundle status", () => {
+  it.each([
+    [
+      {
+        phase: "ready",
+        active: { id: "candidate_bundle", version: "1.2.3" },
+      } satisfies ModelBundleStatus,
+      false,
+      "Verified model bundle candidate_bundle version 1.2.3 is ready.",
+    ],
+    [
+      {
+        phase: "error",
+        active: { id: "previous_bundle", version: "1.0.0" },
+        failureReason: "A model bundle file failed its integrity check.",
+      } satisfies ModelBundleStatus,
+      true,
+      "A model bundle file failed its integrity check. previous_bundle version 1.0.0 remains active.",
+    ],
+  ])("shows a concise %s state", async (result, rejects, message) => {
+    const load: ModelBundleSession["load"] = (_url, onStatus) => {
+      onStatus?.(result);
+      return rejects
+        ? Promise.reject(new Error("simulated load failure"))
+        : Promise.resolve({} as VerifiedModelBundle);
+    };
+    const loader: Pick<ModelBundleSession, "load" | "status"> = {
+      status: { phase: "idle", active: null },
+      load: vi.fn(load),
+    };
+
+    render(<LivePage modelBundleUrl="https://example.test/bundle/" modelBundleSession={loader} />);
+
+    expect(await screen.findByText(message)).toBeVisible();
+    expect(loader.load).toHaveBeenCalledOnce();
   });
 });

--- a/apps/web/src/app/routes.tsx
+++ b/apps/web/src/app/routes.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { Link } from "react-router-dom";
 
 import { livePageDefinition, type StaticPageDefinition } from "./routeDefinitions";
@@ -7,6 +7,7 @@ import {
   type CameraEnvironment,
   type CameraStatus,
 } from "../camera/useCameraSession";
+import { ModelBundleSession, type ModelBundleStatus } from "../modelBundle/modelBundleSession";
 
 function usePageHeading(title: string) {
   const headingRef = useRef<HTMLHeadingElement>(null);
@@ -19,9 +20,9 @@ function usePageHeading(title: string) {
   return headingRef;
 }
 
-function StatusBanner({ children }: { children: ReactNode }) {
+function StatusBanner({ children, label }: { children: ReactNode; label?: string }) {
   return (
-    <div className="status-banner" role="status">
+    <div className="status-banner" role="status" aria-label={label}>
       <span aria-hidden="true" />
       {children}
     </div>
@@ -36,12 +37,53 @@ const startableStatuses = new Set<CameraStatus>([
   "error",
 ]);
 
-export function LivePage({ cameraEnvironment }: { cameraEnvironment?: CameraEnvironment }) {
+type BundleLoader = Pick<ModelBundleSession, "load" | "status">;
+
+function bundleStatusMessage(status: ModelBundleStatus): string {
+  const active =
+    status.active === null ? null : `${status.active.id} version ${status.active.version}`;
+  if (status.phase === "idle") return "No model bundle is configured.";
+  if (status.phase === "loading") return "Loading the model bundle manifest and files.";
+  if (status.phase === "verifying") return "Verifying every model bundle file.";
+  if (status.phase === "ready") return `Verified model bundle ${active ?? ""} is ready.`;
+  const fallback = "The model bundle could not be activated.";
+  return `${status.failureReason ?? fallback}${active === null ? "" : ` ${active} remains active.`}`;
+}
+
+export function LivePage({
+  cameraEnvironment,
+  modelBundleUrl,
+  modelBundleSession,
+}: {
+  cameraEnvironment?: CameraEnvironment;
+  modelBundleUrl?: string;
+  modelBundleSession?: BundleLoader;
+}) {
   const headingRef = usePageHeading(livePageDefinition.label);
   const videoRef = useRef<HTMLVideoElement>(null);
   const [previewMirrored, setPreviewMirrored] = useState(true);
+  const bundleLoader = useMemo(
+    () => modelBundleSession ?? new ModelBundleSession(),
+    [modelBundleSession],
+  );
+  const [bundleStatus, setBundleStatus] = useState(bundleLoader.status);
   const { state, canRequest, start, pause, resume, stop, switchCamera } =
     useCameraSession(cameraEnvironment);
+
+  useEffect(() => {
+    const configuredUrl = modelBundleUrl ?? import.meta.env.VITE_SIGNLAB_MODEL_BUNDLE_URL;
+    if (configuredUrl?.trim() === "") return;
+    if (configuredUrl === undefined) return;
+    let mounted = true;
+    void bundleLoader
+      .load(configuredUrl, (status) => {
+        if (mounted) setBundleStatus(status);
+      })
+      .catch(() => undefined);
+    return () => {
+      mounted = false;
+    };
+  }, [bundleLoader, modelBundleUrl]);
 
   useEffect(() => {
     const video = videoRef.current;
@@ -71,9 +113,15 @@ export function LivePage({ cameraEnvironment }: { cameraEnvironment?: CameraEnvi
           </p>
         </div>
         <StatusBanner>{state.message}</StatusBanner>
+        <div className="model-bundle-status">
+          <p className="card-label">Model bundle</p>
+          <StatusBanner label="Model bundle status">
+            {bundleStatusMessage(bundleStatus)}
+          </StatusBanner>
+        </div>
         <p className="page-note">
-          The recognition model is not connected yet. Preview mirroring changes only what you see,
-          never the camera stream or future model coordinates.
+          Model execution and recognition are not connected yet. Preview mirroring changes only what
+          you see, never the camera stream or future model coordinates.
         </p>
       </div>
 

--- a/apps/web/src/modelBundle/modelBundleSession.test.ts
+++ b/apps/web/src/modelBundle/modelBundleSession.test.ts
@@ -1,0 +1,238 @@
+import { webcrypto } from "node:crypto";
+import { describe, expect, it, vi } from "vitest";
+
+import candidateDecisionPolicy from "../../../../docs/reports/popsign-constructed-calibration-policy-v1.json";
+import candidateEventConfig from "../../../../configs/evaluation/candidate-event-detector-v1.json";
+import candidateFeaturePlan from "../../../../src/signlab/resources/features/config/hand-local-64-1.default.json";
+import mediaPipeConfig from "../../../../src/signlab/resources/extraction/config/mediapipe-extraction-config-1.default.json";
+import manifestExample from "../../../../src/signlab/resources/model_bundles/examples/browser-model-bundle-manifest.example.json";
+import qualityPolicy from "../../../../src/signlab/resources/quality/config/landmark-quality-policy-1.default.json";
+import {
+  ModelBundleSession,
+  type ModelBundleAssetRole,
+  type ModelBundleEnvironment,
+  type ModelBundleStatus,
+} from "./modelBundleSession";
+
+const BASE_URL = "https://example.test/models/candidate/";
+const MANIFEST_URL = `${BASE_URL}manifest.json`;
+const encoder = new TextEncoder();
+
+function jsonBytes(value: unknown): Uint8Array {
+  return encoder.encode(JSON.stringify(value));
+}
+
+function arrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}
+
+async function sha256(bytes: Uint8Array): Promise<string> {
+  const digest = await webcrypto.subtle.digest("SHA-256", arrayBuffer(bytes));
+  return `sha256:${Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join("")}`;
+}
+
+async function fixture() {
+  const bytes: Record<ModelBundleAssetRole, Uint8Array> = {
+    decision_policy: jsonBytes(candidateDecisionPolicy),
+    feature_plan: jsonBytes(candidateFeaturePlan),
+    golden_smoke: jsonBytes({ format: "synthetic-golden-smoke/1" }),
+    landmarker: jsonBytes(mediaPipeConfig),
+    model: encoder.encode("tiny structural ONNX fixture"),
+    model_card: encoder.encode("# Synthetic model card\n"),
+    quality_policy: jsonBytes(qualityPolicy),
+    segmenter: jsonBytes(candidateEventConfig),
+  };
+  const manifest = structuredClone(manifestExample);
+  for (const asset of manifest.assets) {
+    const raw = bytes[asset.role as ModelBundleAssetRole];
+    asset.size_bytes = raw.byteLength;
+    asset.sha256 = await sha256(raw);
+  }
+  return { manifest, bytes };
+}
+
+function harness(
+  manifest: typeof manifestExample,
+  bytes: Record<ModelBundleAssetRole, Uint8Array>,
+  manifestBody: unknown = manifest,
+) {
+  const requests: string[] = [];
+  const responses = { ...bytes };
+  const failures = new Set<ModelBundleAssetRole>();
+  const fetch = vi.fn((input: URL): Promise<Response> => {
+    requests.push(input.href);
+    if (input.href === MANIFEST_URL) {
+      const body = typeof manifestBody === "string" ? manifestBody : JSON.stringify(manifestBody);
+      return Promise.resolve(new Response(body, { status: 200 }));
+    }
+    const asset = manifest.assets.find(
+      (candidate) => new URL(candidate.locator.path, MANIFEST_URL).href === input.href,
+    );
+    if (asset === undefined) return Promise.resolve(new Response(null, { status: 404 }));
+    const role = asset.role as ModelBundleAssetRole;
+    if (failures.has(role)) return Promise.reject(new TypeError("simulated network interruption"));
+    return Promise.resolve(new Response(arrayBuffer(responses[role]), { status: 200 }));
+  });
+  const environment: ModelBundleEnvironment = {
+    fetch,
+    subtle: webcrypto.subtle as SubtleCrypto,
+  };
+  return {
+    session: new ModelBundleSession(environment),
+    fetch,
+    requests,
+    responses,
+    failures,
+  };
+}
+
+describe("ModelBundleSession", () => {
+  it("loads the manifest first and atomically exposes immutable verified bytes", async () => {
+    const data = await fixture();
+    const test = harness(data.manifest, data.bytes);
+    const statuses: ModelBundleStatus[] = [];
+
+    const loaded = await test.session.load(BASE_URL, (status) => statuses.push(status));
+
+    expect(test.requests[0]).toBe(MANIFEST_URL);
+    expect(test.requests).toHaveLength(9);
+    expect(statuses.map((status) => status.phase)).toEqual(["loading", "verifying", "ready"]);
+    expect(loaded).toBe(test.session.active);
+    expect(loaded.id).toBe(data.manifest.bundle_id);
+    expect(loaded.version).toBe(data.manifest.version);
+    expect(Object.isFrozen(loaded)).toBe(true);
+    expect(Object.isFrozen(loaded.manifest)).toBe(true);
+    expect(Object.isFrozen(loaded.bytesByRole)).toBe(true);
+    expect(await loaded.bytesByRole.model.text()).toBe("tiny structural ONNX fixture");
+  });
+
+  it.each([
+    [
+      "unsupported version",
+      (value: typeof manifestExample) => (value.format = "browser-model-bundle/2"),
+      "bundle.manifest.unsupported",
+    ],
+    [
+      "missing role",
+      (value: typeof manifestExample) => value.assets.pop(),
+      "bundle.manifest.invalid",
+    ],
+    [
+      "duplicate role",
+      (value: typeof manifestExample) => (value.assets[1] = structuredClone(value.assets[0]!)),
+      "bundle.manifest.invalid",
+    ],
+    [
+      "wrong asset identity",
+      (value: typeof manifestExample) => (value.assets[0]!.artifact_id = "different_asset"),
+      "bundle.manifest.invalid",
+    ],
+    [
+      "unsafe path",
+      (value: typeof manifestExample) => (value.assets[4]!.locator.path = "../model.onnx"),
+      "bundle.manifest.invalid",
+    ],
+    [
+      "wrong label order",
+      (value: typeof manifestExample) => value.labels.reverse(),
+      "bundle.component.incompatible",
+    ],
+    [
+      "wrong ONNX shape",
+      (value: typeof manifestExample) => (value.onnx.input_shape[2] = 127),
+      "bundle.manifest.invalid",
+    ],
+    [
+      "wrong component identity",
+      (value: typeof manifestExample) =>
+        (value.components.landmarker_sha256 = `sha256:${"0".repeat(64)}`),
+      "bundle.component.incompatible",
+    ],
+  ])("rejects a %s before requesting assets", async (_name, mutate, code) => {
+    const data = await fixture();
+    mutate(data.manifest);
+    const test = harness(data.manifest, data.bytes);
+
+    await expect(test.session.load(BASE_URL)).rejects.toMatchObject({ code });
+    expect(test.requests).toEqual([MANIFEST_URL]);
+    expect(test.session.active).toBeNull();
+  });
+
+  it("rejects malformed manifest JSON before requesting assets", async () => {
+    const data = await fixture();
+    const test = harness(data.manifest, data.bytes, "{broken");
+
+    await expect(test.session.load(BASE_URL)).rejects.toMatchObject({
+      code: "bundle.manifest.invalid",
+    });
+    expect(test.requests).toEqual([MANIFEST_URL]);
+  });
+
+  it("fails before asset downloads when Web Crypto is unavailable", async () => {
+    const data = await fixture();
+    const test = harness(data.manifest, data.bytes);
+    const session = new ModelBundleSession({ fetch: test.fetch });
+
+    await expect(session.load(BASE_URL)).rejects.toMatchObject({
+      code: "bundle.environment.unsupported",
+    });
+    expect(test.requests).toEqual([MANIFEST_URL]);
+  });
+
+  it.each([
+    ["size", "bundle.asset.size_mismatch"],
+    ["digest", "bundle.asset.digest_mismatch"],
+    ["network", "bundle.asset.unavailable"],
+  ])("rejects an asset %s failure", async (failure, code) => {
+    const data = await fixture();
+    const test = harness(data.manifest, data.bytes);
+    if (failure === "size") test.responses.model = encoder.encode("short");
+    if (failure === "digest") {
+      const altered = data.bytes.model.slice();
+      altered[0] = altered[0]! ^ 1;
+      test.responses.model = altered;
+    }
+    if (failure === "network") test.failures.add("model");
+
+    await expect(test.session.load(BASE_URL)).rejects.toMatchObject({ code });
+    expect(test.session.active).toBeNull();
+    expect(test.session.status).toMatchObject({ phase: "error", active: null });
+  });
+
+  it("rejects an altered pinned component after its raw-byte checks pass", async () => {
+    const data = await fixture();
+    const altered = { ...candidateEventConfig, start_motion_q: 250001 };
+    data.bytes.segmenter = jsonBytes(altered);
+    const segmenter = data.manifest.assets.find((asset) => asset.role === "segmenter")!;
+    segmenter.size_bytes = data.bytes.segmenter.byteLength;
+    segmenter.sha256 = await sha256(data.bytes.segmenter);
+    const test = harness(data.manifest, data.bytes);
+
+    await expect(test.session.load(BASE_URL)).rejects.toMatchObject({
+      code: "bundle.component.incompatible",
+    });
+    expect(test.session.active).toBeNull();
+  });
+
+  it("preserves the previous active bundle when a replacement fails", async () => {
+    const data = await fixture();
+    const test = harness(data.manifest, data.bytes);
+    const first = await test.session.load(BASE_URL);
+    const altered = test.responses.model.slice();
+    altered[0] = altered[0]! ^ 1;
+    test.responses.model = altered;
+
+    await expect(test.session.load(BASE_URL)).rejects.toMatchObject({
+      code: "bundle.asset.digest_mismatch",
+    });
+
+    expect(test.session.active).toBe(first);
+    expect(test.session.status).toEqual({
+      phase: "error",
+      active: { id: first.id, version: first.version },
+      failureReason: "A model bundle file failed its integrity check.",
+    });
+  });
+});

--- a/apps/web/src/modelBundle/modelBundleSession.ts
+++ b/apps/web/src/modelBundle/modelBundleSession.ts
@@ -1,0 +1,387 @@
+import Ajv2020 from "ajv/dist/2020.js";
+
+import candidateDecisionPolicy from "../../../../docs/reports/popsign-constructed-calibration-policy-v1.json";
+import candidateEventConfig from "../../../../configs/evaluation/candidate-event-detector-v1.json";
+import candidateFeaturePlan from "../../../../src/signlab/resources/features/config/hand-local-64-1.default.json";
+import mediaPipeConfig from "../../../../src/signlab/resources/extraction/config/mediapipe-extraction-config-1.default.json";
+import manifestSchema from "../../../../src/signlab/resources/model_bundles/schemas/browser-model-bundle-manifest-1.schema.json";
+import qualityPolicy from "../../../../src/signlab/resources/quality/config/landmark-quality-policy-1.default.json";
+
+const LABELS = ["hello", "no", "please", "thank_you", "yes", "other"] as const;
+const ASSETS = [
+  ["decision_policy", "decision-policy.json", "application/json"],
+  ["feature_plan", "feature-plan.json", "application/json"],
+  ["golden_smoke", "golden/smoke.json", "application/json"],
+  ["landmarker", "landmarker.json", "application/json"],
+  ["model", "model.onnx", "application/onnx"],
+  ["model_card", "model-card.md", "text/markdown"],
+  ["quality_policy", "quality-policy.json", "application/json"],
+  ["segmenter", "segmenter.json", "application/json"],
+] as const;
+const COMPONENTS = {
+  landmarker_sha256: "sha256:7343cd8bb724313b4063a3ebd5d7f7470a78b00f2eeda275a15e5f9b2e66e94c",
+  quality_policy_sha256: "sha256:680b0904e1cc5d8e03119032e92920a3a0185917a600c4293323b7925da9a545",
+  feature_plan_sha256: "sha256:1c62d2738ce0609168967b675fa0dcd1797f8fbe881cd9b5c775d4e2a83e4a3e",
+  segmenter_sha256: "sha256:0443badf68d34347a00096682cf049b6f49b5253c12e47bf61b068a597aa162d",
+  decision_policy_sha256: "sha256:6eb700443dbb50de5094868d564e8a72aff6af0182c8394ab8c6a28844572e41",
+} as const;
+const TAXONOMY_SHA256 = "sha256:c0f6cbddfe43e3a6eb3de01dbbbbc1ceebcb83d50cc197999776f58e3d9ce20d";
+const ONNX = {
+  format: "onnx",
+  opset: 18,
+  input_name: "input",
+  input_shape: [1, 64, 126],
+  input_dtype: "float32",
+  input_semantics: "hand_local_feature_sequence",
+  output_name: "probabilities",
+  output_shape: [1, 6],
+  output_dtype: "float32",
+  output_semantics: "uncalibrated_class_probabilities",
+} as const;
+const LICENSES = [
+  { scope: "mediapipe", spdx: "Apache-2.0", distribution: "redistributable" },
+  {
+    scope: "popsign_source_data",
+    spdx: "CC-BY-4.0",
+    distribution: "redistributable_with_attribution",
+  },
+  { scope: "signlab_code", spdx: "MIT", distribution: "redistributable" },
+  { scope: "trained_model", spdx: "NOASSERTION", distribution: "local_evaluation_only" },
+] as const;
+const PINNED_COMPONENTS = {
+  decision_policy: candidateDecisionPolicy,
+  feature_plan: candidateFeaturePlan,
+  landmarker: mediaPipeConfig,
+  quality_policy: qualityPolicy,
+  segmenter: candidateEventConfig,
+} as const;
+
+export type ModelBundleAssetRole = (typeof ASSETS)[number][0];
+export type ModelBundlePhase = "idle" | "loading" | "verifying" | "ready" | "error";
+export type ModelBundleFailureCode =
+  | "bundle.environment.unsupported"
+  | "bundle.load.superseded"
+  | "bundle.manifest.unavailable"
+  | "bundle.manifest.invalid"
+  | "bundle.manifest.unsupported"
+  | "bundle.asset.unavailable"
+  | "bundle.asset.size_mismatch"
+  | "bundle.asset.digest_mismatch"
+  | "bundle.component.incompatible";
+
+interface ManifestAsset {
+  readonly artifact_id: string;
+  readonly role: ModelBundleAssetRole;
+  readonly media_type: string;
+  readonly sha256: string;
+  readonly size_bytes: number;
+  readonly locator: { readonly kind: "workspace_relative"; readonly path: string };
+}
+
+export interface ModelBundleManifest {
+  readonly format: "browser-model-bundle/1";
+  readonly bundle_id: string;
+  readonly version: string;
+  readonly candidate: Readonly<Record<string, string>>;
+  readonly components: typeof COMPONENTS;
+  readonly onnx: typeof ONNX;
+  readonly labels: readonly string[];
+  readonly licenses: readonly unknown[];
+  readonly assets: readonly ManifestAsset[];
+}
+
+export interface VerifiedModelBundle {
+  readonly id: string;
+  readonly version: string;
+  readonly manifest: ModelBundleManifest;
+  readonly bytesByRole: Readonly<Record<ModelBundleAssetRole, Blob>>;
+}
+
+export interface ModelBundleStatus {
+  readonly phase: ModelBundlePhase;
+  readonly active: { readonly id: string; readonly version: string } | null;
+  readonly failureReason?: string;
+}
+
+export interface ModelBundleEnvironment {
+  readonly fetch: (input: URL) => Promise<Response>;
+  readonly subtle?: SubtleCrypto;
+  readonly documentBaseUrl?: string;
+}
+
+const FAILURE_MESSAGES: Record<ModelBundleFailureCode, string> = {
+  "bundle.environment.unsupported": "This browser cannot verify model files.",
+  "bundle.load.superseded": "A newer model bundle load replaced this request.",
+  "bundle.manifest.unavailable": "The model bundle manifest could not be loaded.",
+  "bundle.manifest.invalid": "The model bundle manifest is incomplete or invalid.",
+  "bundle.manifest.unsupported": "This model bundle version is not supported.",
+  "bundle.asset.unavailable": "A required model bundle file could not be loaded.",
+  "bundle.asset.size_mismatch": "A model bundle file has the wrong size.",
+  "bundle.asset.digest_mismatch": "A model bundle file failed its integrity check.",
+  "bundle.component.incompatible": "The model bundle is incompatible with this demo.",
+};
+
+export class ModelBundleLoadError extends Error {
+  constructor(readonly code: ModelBundleFailureCode) {
+    super(FAILURE_MESSAGES[code]);
+    this.name = "ModelBundleLoadError";
+  }
+}
+
+const schemaValidator = new Ajv2020({ allErrors: false });
+// Pydantic emits this annotation; the surrounding oneOf still performs the validation.
+schemaValidator.addKeyword({ keyword: "discriminator", schemaType: "object", valid: true });
+const validateSchema = schemaValidator.compile(manifestSchema);
+
+function equalJson(value: unknown, expected: unknown): boolean {
+  if (Array.isArray(expected)) {
+    return (
+      Array.isArray(value) &&
+      value.length === expected.length &&
+      expected.every((item, index) => equalJson(value[index], item))
+    );
+  }
+  if (typeof expected === "object" && expected !== null) {
+    if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+    const actual = value as Record<string, unknown>;
+    const entries = Object.entries(expected);
+    return (
+      Object.keys(actual).length === entries.length &&
+      entries.every(([key, item]) => equalJson(actual[key], item))
+    );
+  }
+  return value === expected;
+}
+
+function deepFreeze<T>(value: T): Readonly<T> {
+  if (typeof value === "object" && value !== null && !Object.isFrozen(value)) {
+    Object.values(value).forEach((nested) => deepFreeze(nested));
+    Object.freeze(value);
+  }
+  return value;
+}
+
+function fail(code: ModelBundleFailureCode): never {
+  throw new ModelBundleLoadError(code);
+}
+
+function validateManifest(value: unknown): ModelBundleManifest {
+  if (typeof value === "object" && value !== null && "format" in value) {
+    if ((value as { format?: unknown }).format !== "browser-model-bundle/1") {
+      fail("bundle.manifest.unsupported");
+    }
+  }
+  if (!validateSchema(value)) fail("bundle.manifest.invalid");
+  const manifest = value as unknown as ModelBundleManifest;
+  if (
+    !equalJson(manifest.labels, LABELS) ||
+    !equalJson(manifest.components, COMPONENTS) ||
+    !equalJson(manifest.onnx, ONNX) ||
+    !equalJson(manifest.licenses, LICENSES) ||
+    manifest.candidate.input_feature_plan_sha256 !== COMPONENTS.feature_plan_sha256 ||
+    manifest.candidate.taxonomy_sha256 !== TAXONOMY_SHA256 ||
+    manifest.assets.length !== ASSETS.length
+  ) {
+    fail("bundle.component.incompatible");
+  }
+  manifest.assets.forEach((asset, index) => {
+    const expected = ASSETS[index];
+    if (
+      expected === undefined ||
+      asset.role !== expected[0] ||
+      asset.artifact_id !== expected[0] ||
+      asset.locator.kind !== "workspace_relative" ||
+      asset.locator.path !== expected[1] ||
+      asset.media_type !== expected[2] ||
+      asset.size_bytes <= 0
+    ) {
+      fail("bundle.manifest.invalid");
+    }
+  });
+  return deepFreeze(manifest);
+}
+
+function bundleManifestUrl(base: string, fallbackBase?: string): URL {
+  try {
+    const url = new URL(base, fallbackBase);
+    if (
+      !["http:", "https:"].includes(url.protocol) ||
+      url.username !== "" ||
+      url.password !== "" ||
+      url.search !== "" ||
+      url.hash !== ""
+    ) {
+      fail("bundle.manifest.invalid");
+    }
+    if (!url.pathname.endsWith("/")) url.pathname += "/";
+    return new URL("manifest.json", url);
+  } catch (error) {
+    if (error instanceof ModelBundleLoadError) throw error;
+    return fail("bundle.manifest.invalid");
+  }
+}
+
+function assetUrl(manifestUrl: URL, path: string): URL {
+  const base = new URL(".", manifestUrl);
+  const url = new URL(path, base);
+  if (url.origin !== base.origin || !url.pathname.startsWith(base.pathname)) {
+    fail("bundle.manifest.invalid");
+  }
+  return url;
+}
+
+function parseJson(buffer: ArrayBuffer, code: ModelBundleFailureCode): unknown {
+  try {
+    return JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(buffer)) as unknown;
+  } catch {
+    return fail(code);
+  }
+}
+
+function verifyComponents(
+  manifest: ModelBundleManifest,
+  buffers: Readonly<Record<ModelBundleAssetRole, ArrayBuffer>>,
+): void {
+  for (const [role, expected] of Object.entries(PINNED_COMPONENTS)) {
+    const parsed = parseJson(
+      buffers[role as ModelBundleAssetRole],
+      "bundle.component.incompatible",
+    );
+    if (!equalJson(parsed, expected)) fail("bundle.component.incompatible");
+  }
+  const identities = candidateDecisionPolicy.identities;
+  const candidate = manifest.candidate;
+  if (
+    candidate.research_checkpoint_sha256 !== identities.model_sha256 ||
+    candidate.configuration_sha256 !== identities.configuration_sha256 ||
+    candidate.corpus_sha256 !== identities.corpus_sha256 ||
+    candidate.derivative_set_sha256 !== identities.derivative_set_sha256 ||
+    candidate.split_sha256 !== identities.split_sha256 ||
+    candidate.input_feature_plan_sha256 !== identities.input_feature_plan_sha256 ||
+    candidate.source_feature_plan_sha256 !== identities.source_feature_plan_sha256 ||
+    candidate.taxonomy_sha256 !== identities.taxonomy_sha256
+  ) {
+    fail("bundle.component.incompatible");
+  }
+}
+
+function statusFor(
+  phase: ModelBundlePhase,
+  active: VerifiedModelBundle | null,
+  failureReason?: string,
+): ModelBundleStatus {
+  return Object.freeze({
+    phase,
+    active: active === null ? null : Object.freeze({ id: active.id, version: active.version }),
+    ...(failureReason === undefined ? {} : { failureReason }),
+  });
+}
+
+export class ModelBundleSession {
+  private activeValue: VerifiedModelBundle | null = null;
+  private statusValue = statusFor("idle", null);
+  private attempt = 0;
+
+  constructor(
+    private readonly environment: ModelBundleEnvironment = {
+      fetch: (input) => globalThis.fetch(input),
+      subtle: globalThis.crypto?.subtle,
+      documentBaseUrl: globalThis.document?.baseURI,
+    },
+  ) {}
+
+  get active(): VerifiedModelBundle | null {
+    return this.activeValue;
+  }
+
+  get status(): ModelBundleStatus {
+    return this.statusValue;
+  }
+
+  async load(
+    baseUrl: string,
+    onStatus: (status: ModelBundleStatus) => void = () => undefined,
+  ): Promise<VerifiedModelBundle> {
+    const attempt = ++this.attempt;
+    const update = (phase: ModelBundlePhase, reason?: string) => {
+      if (attempt !== this.attempt) fail("bundle.load.superseded");
+      this.statusValue = statusFor(phase, this.activeValue, reason);
+      onStatus(this.statusValue);
+    };
+
+    try {
+      update("loading");
+      const manifestUrl = bundleManifestUrl(baseUrl, this.environment.documentBaseUrl);
+      const manifestBuffer = await this.fetchBytes(manifestUrl, "bundle.manifest.unavailable");
+      if (attempt !== this.attempt) fail("bundle.load.superseded");
+      const manifest = validateManifest(parseJson(manifestBuffer, "bundle.manifest.invalid"));
+      const subtle = this.environment.subtle;
+      if (subtle === undefined) fail("bundle.environment.unsupported");
+      const downloads = await Promise.all(
+        manifest.assets.map(async (asset) => ({
+          asset,
+          buffer: await this.fetchBytes(
+            assetUrl(manifestUrl, asset.locator.path),
+            "bundle.asset.unavailable",
+          ),
+        })),
+      );
+      update("verifying");
+      const buffers = {} as Record<ModelBundleAssetRole, ArrayBuffer>;
+      for (const { asset, buffer } of downloads) {
+        if (buffer.byteLength !== asset.size_bytes) fail("bundle.asset.size_mismatch");
+        let digest: ArrayBuffer;
+        try {
+          digest = await subtle.digest("SHA-256", new Uint8Array(buffer));
+        } catch {
+          fail("bundle.environment.unsupported");
+        }
+        const actual = `sha256:${Array.from(new Uint8Array(digest), (byte) =>
+          byte.toString(16).padStart(2, "0"),
+        ).join("")}`;
+        if (actual !== asset.sha256) fail("bundle.asset.digest_mismatch");
+        buffers[asset.role] = buffer;
+      }
+      verifyComponents(manifest, buffers);
+      if (attempt !== this.attempt) fail("bundle.load.superseded");
+      const bytesByRole = Object.freeze(
+        Object.fromEntries(
+          manifest.assets.map((asset) => [
+            asset.role,
+            new Blob([buffers[asset.role]], { type: asset.media_type }),
+          ]),
+        ) as Record<ModelBundleAssetRole, Blob>,
+      );
+      const verified = Object.freeze({
+        id: manifest.bundle_id,
+        version: manifest.version,
+        manifest,
+        bytesByRole,
+      });
+      this.activeValue = verified;
+      update("ready");
+      return verified;
+    } catch (error) {
+      const failure =
+        error instanceof ModelBundleLoadError
+          ? error
+          : new ModelBundleLoadError("bundle.asset.unavailable");
+      if (attempt === this.attempt) {
+        this.statusValue = statusFor("error", this.activeValue, failure.message);
+        onStatus(this.statusValue);
+      }
+      throw failure;
+    }
+  }
+
+  private async fetchBytes(url: URL, code: ModelBundleFailureCode): Promise<ArrayBuffer> {
+    try {
+      const response = await this.environment.fetch(url);
+      if (!response.ok) fail(code);
+      return await response.arrayBuffer();
+    } catch (error) {
+      if (error instanceof ModelBundleLoadError) throw error;
+      return fail(code);
+    }
+  }
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -352,6 +352,14 @@ h1 {
   color: #415a58;
 }
 
+.model-bundle-status {
+  margin-top: 1.25rem;
+}
+
+.model-bundle-status .card-label {
+  margin-bottom: 0.5rem;
+}
+
 .camera-card {
   padding: clamp(1rem, 2.5vw, 1.5rem);
   border-radius: 1.5rem;

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_SIGNLAB_MODEL_BUNDLE_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
Closes #40

## Outcome

Adds the bounded browser session loader required before inference:

- validates the existing `browser-model-bundle/1` JSON Schema before requesting assets
- rejects unsupported labels, inventory, paths, component identities, licenses, and ONNX contracts
- verifies every asset's byte length and SHA-256 through Web Crypto
- exposes frozen manifest metadata and immutable bytes-by-role blobs
- activates only after complete verification and preserves the prior active bundle on failure
- reports idle/loading/verifying/ready/error plus active bundle identity on the live page

Persistent caching, service workers, ONNX session creation, inference, and rollback remain outside this story.

## Scope check

- one loader module
- one focused loader test module
- small live-page integration
- approximately 417 nonblank production TypeScript lines, below the 450-line target

## Verification

- `npm ci --no-audit --no-fund`
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm test` — 67 passed
- `npm run build`
- `npm run build:subpath`
- repository hygiene check passed

SHA checks detect corruption/inconsistency with the fetched manifest; they are not an authenticity claim.