### PR TITLE
Run candidate inference in a browser worker

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@mediapipe/tasks-vision": "1.0.1",
         "ajv": "8.20.0",
+        "onnxruntime-web": "1.29.0",
         "react": "19.2.8",
         "react-dom": "19.2.8",
         "react-router-dom": "7.18.3"
@@ -27,7 +28,6 @@
         "eslint-plugin-react-refresh": "0.5.5",
         "globals": "17.11.0",
         "jsdom": "29.1.1",
-        "onnxruntime-web": "1.29.0",
         "prettier": "3.9.6",
         "typescript": "6.0.3",
         "typescript-eslint": "8.68.0",
@@ -781,35 +781,30 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
       "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
       "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
       "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
       "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
       "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1"
@@ -819,28 +814,24 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
       "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
       "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
       "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@rolldown/binding-android-arm-eabi": {
@@ -1248,7 +1239,6 @@
       "version": "24.13.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
       "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
@@ -2373,7 +2363,6 @@
       "version": "25.9.23",
       "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
       "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/flatted": {
@@ -2438,7 +2427,6 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
       "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/hermes-estree": {
@@ -2947,7 +2935,6 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/lru-cache": {
@@ -3075,14 +3062,12 @@
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.29.0.tgz",
       "integrity": "sha512-/F63/e2VJoaVXGGNu6S5QH7jivBThGO95OzAVXXQ8hTta/b1QxI8udHa6cI3+3mAb5WWIIaMMwfZw01oivjJ1g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/onnxruntime-web": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.29.0.tgz",
       "integrity": "sha512-LuQlpX6MFLJZu756erwUeb1mNfoJGbs1kzDwJGNlf5RvfYMdqhcY3vNpDPK40CUV2HoWTkIj+uS0o36GFHjeYw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flatbuffers": "^25.1.24",
@@ -3207,7 +3192,6 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
       "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/postcss": {
@@ -3285,7 +3269,6 @@
       "version": "7.6.6",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.6.tgz",
       "integrity": "sha512-dYDWdjSl5RNb7SgPxGQcRU+GtvP7s2fpkrY0r432PcOIaZ0/rBcxEZnQN67iJhFuQiVw754JDoPruPCNdGsbjg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -3716,7 +3699,6 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@mediapipe/tasks-vision": "1.0.1",
     "ajv": "8.20.0",
+    "onnxruntime-web": "1.29.0",
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "react-router-dom": "7.18.3"
@@ -38,7 +39,6 @@
     "eslint-plugin-react-refresh": "0.5.5",
     "globals": "17.11.0",
     "jsdom": "29.1.1",
-    "onnxruntime-web": "1.29.0",
     "prettier": "3.9.6",
     "typescript": "6.0.3",
     "typescript-eslint": "8.68.0",

--- a/apps/web/src/inference/CandidateInferenceWorkerClient.test.ts
+++ b/apps/web/src/inference/CandidateInferenceWorkerClient.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { VerifiedModelBundle } from "../modelBundle/modelBundleSession";
+import {
+  CandidateInferenceWorkerClient,
+  type CandidateInferenceClientEvent,
+  type CandidateInferenceWorkerPort,
+} from "./CandidateInferenceWorkerClient";
+import {
+  CANDIDATE_INFERENCE_PROTOCOL_VERSION,
+  type CandidateInferenceInput,
+  type CandidateInferenceWorkerInput,
+  type CandidateInferenceWorkerOutput,
+} from "./candidateInferenceProtocol";
+
+class ManualWorkerPort implements CandidateInferenceWorkerPort {
+  readonly posts: Array<{
+    message: CandidateInferenceWorkerInput;
+    transfer: readonly Transferable[];
+  }> = [];
+  readonly terminate = vi.fn();
+  failNextPost = false;
+  private messageListener: ((message: CandidateInferenceWorkerOutput) => void) | undefined;
+  private errorListener: (() => void) | undefined;
+
+  post(message: CandidateInferenceWorkerInput, transfer: readonly Transferable[] = []): void {
+    if (this.failNextPost) {
+      this.failNextPost = false;
+      throw new Error("worker post failed");
+    }
+    this.posts.push({ message, transfer });
+  }
+
+  onMessage(listener: (message: CandidateInferenceWorkerOutput) => void): () => void {
+    this.messageListener = listener;
+    return () => {
+      this.messageListener = undefined;
+    };
+  }
+
+  onError(listener: () => void): () => void {
+    this.errorListener = listener;
+    return () => {
+      this.errorListener = undefined;
+    };
+  }
+
+  emit(message: CandidateInferenceWorkerOutput): void {
+    this.messageListener?.(message);
+  }
+
+  fail(): void {
+    this.errorListener?.();
+  }
+}
+
+const bundle = (): VerifiedModelBundle =>
+  ({
+    id: "candidate-browser-model",
+    version: "1.0.0",
+    manifest: {},
+    bytesByRole: {
+      model: new Blob([new Uint8Array([1])]),
+      feature_plan: new Blob([new Uint8Array([2, 3])]),
+      decision_policy: new Blob([new Uint8Array([4, 5, 6])]),
+    },
+  }) as unknown as VerifiedModelBundle;
+
+const input = {
+  frames: [],
+  sourceMirrorState: "not_mirrored",
+  quality: {},
+} as unknown as CandidateInferenceInput;
+
+const ready = (): CandidateInferenceWorkerOutput => ({
+  type: "ready",
+  protocolVersion: CANDIDATE_INFERENCE_PROTOCOL_VERSION,
+  bundle: { id: "candidate-browser-model", version: "1.0.0" },
+  backend: "wasm",
+  startupMs: 5,
+});
+
+const result = (requestId: number): CandidateInferenceWorkerOutput => ({
+  type: "result",
+  protocolVersion: CANDIDATE_INFERENCE_PROTOCOL_VERSION,
+  requestId,
+  decision: { kind: "target", label: "hello", confidence: 0.9 },
+  reason: "accepted_target",
+  rankedScores: [
+    { label: "hello", confidence: 0.9 },
+    { label: "no", confidence: 0.02 },
+    { label: "please", confidence: 0.02 },
+    { label: "thank_you", confidence: 0.02 },
+    { label: "yes", confidence: 0.02 },
+    { label: "other", confidence: 0.02 },
+  ],
+  bundle: { id: "candidate-browser-model", version: "1.0.0" },
+  backend: "wasm",
+  timings: { preprocessingMs: 1, inferenceMs: 2, decisionMs: 1, totalMs: 4 },
+});
+
+describe("CandidateInferenceWorkerClient", () => {
+  it("transfers the verified runtime assets and permits exactly one request at a time", async () => {
+    const port = new ManualWorkerPort();
+    const events: CandidateInferenceClientEvent[] = [];
+    const client = new CandidateInferenceWorkerClient(port, (event) => events.push(event));
+
+    expect(() => client.classify(0, input)).toThrow("candidate.inference.client.not_ready");
+    await client.initialize(bundle());
+    const initialization = port.posts[0]?.message;
+    expect(initialization).toMatchObject({
+      type: "initialize",
+      bundle: { id: "candidate-browser-model", version: "1.0.0" },
+    });
+    if (initialization?.type !== "initialize") throw new Error("expected initialization");
+    expect([
+      initialization.modelBuffer.byteLength,
+      initialization.featurePlanBuffer.byteLength,
+      initialization.decisionPolicyBuffer.byteLength,
+    ]).toEqual([1, 2, 3]);
+    expect(port.posts[0]?.transfer.map((buffer) => (buffer as ArrayBuffer).byteLength)).toEqual([
+      1, 2, 3,
+    ]);
+
+    port.emit(ready());
+    client.classify(7, input);
+    expect(port.posts.at(-1)?.message).toMatchObject({ type: "classify", requestId: 7, input });
+    expect(() => client.classify(8, input)).toThrow("candidate.inference.client.busy");
+
+    port.emit(result(7));
+    client.classify(8, input);
+    port.emit({
+      type: "failure",
+      protocolVersion: CANDIDATE_INFERENCE_PROTOCOL_VERSION,
+      code: "candidate.inference.input.invalid",
+      requestId: 8,
+      fatal: false,
+    });
+    client.classify(9, input);
+    expect(events.map(({ type }) => type)).toEqual(["ready", "result", "failure"]);
+
+    client.close();
+    expect(port.posts.at(-1)?.message.type).toBe("stop");
+    port.emit({ type: "stopped", protocolVersion: CANDIDATE_INFERENCE_PROTOCOL_VERSION });
+    expect(port.terminate).toHaveBeenCalledOnce();
+  });
+
+  it("fails closed on an uncorrelated response or worker transport error", async () => {
+    const port = new ManualWorkerPort();
+    const events: CandidateInferenceClientEvent[] = [];
+    const client = new CandidateInferenceWorkerClient(port, (event) => events.push(event));
+    await client.initialize(bundle());
+    port.emit(ready());
+    client.classify(1, input);
+
+    port.emit(result(2));
+
+    expect(events.at(-1)).toEqual({
+      type: "worker-transport-failure",
+      code: "candidate.inference.transport.failed",
+    });
+    expect(port.terminate).toHaveBeenCalledOnce();
+    port.fail();
+    expect(events.filter(({ type }) => type === "worker-transport-failure")).toHaveLength(1);
+    expect(() => client.classify(3, input)).toThrow("candidate.inference.client.not_ready");
+  });
+
+  it("reports a sanitized transport failure when stop cannot be posted", () => {
+    const port = new ManualWorkerPort();
+    const events: CandidateInferenceClientEvent[] = [];
+    const client = new CandidateInferenceWorkerClient(port, (event) => events.push(event));
+    port.failNextPost = true;
+
+    client.close();
+
+    expect(events).toEqual([
+      {
+        type: "worker-transport-failure",
+        code: "candidate.inference.transport.failed",
+      },
+    ]);
+    expect(port.terminate).toHaveBeenCalledOnce();
+  });
+
+  it.each(["transport", "stopped"] as const)(
+    "releases the worker before a throwing consumer callback on %s",
+    (terminal) => {
+      const port = new ManualWorkerPort();
+      new CandidateInferenceWorkerClient(port, () => {
+        throw new Error("consumer callback failed");
+      });
+      const trigger = () => {
+        if (terminal === "transport") port.fail();
+        else
+          port.emit({
+            type: "stopped",
+            protocolVersion: CANDIDATE_INFERENCE_PROTOCOL_VERSION,
+          });
+      };
+
+      expect(trigger).toThrow("consumer callback failed");
+      expect(port.terminate).toHaveBeenCalledOnce();
+      expect(trigger).not.toThrow();
+    },
+  );
+});

--- a/apps/web/src/inference/CandidateInferenceWorkerClient.ts
+++ b/apps/web/src/inference/CandidateInferenceWorkerClient.ts
@@ -1,0 +1,156 @@
+import type { VerifiedModelBundle } from "../modelBundle/modelBundleSession";
+import {
+  CANDIDATE_INFERENCE_PROTOCOL_VERSION,
+  type CandidateInferenceInput,
+  type CandidateInferenceWorkerInput,
+  type CandidateInferenceWorkerOutput,
+} from "./candidateInferenceProtocol";
+
+export interface CandidateInferenceWorkerPort {
+  post(message: CandidateInferenceWorkerInput, transfer?: readonly Transferable[]): void;
+  onMessage(listener: (message: CandidateInferenceWorkerOutput) => void): () => void;
+  onError(listener: () => void): () => void;
+  terminate(): void;
+}
+
+export type CandidateInferenceClientEvent =
+  | CandidateInferenceWorkerOutput
+  | {
+      readonly type: "worker-transport-failure";
+      readonly code: "candidate.inference.transport.failed";
+    };
+
+class BrowserCandidateInferenceWorkerPort implements CandidateInferenceWorkerPort {
+  private readonly worker = new Worker(new URL("./candidateInference.worker.ts", import.meta.url), {
+    name: "signlab-candidate-inference",
+    type: "module",
+  });
+
+  post(message: CandidateInferenceWorkerInput, transfer: readonly Transferable[] = []): void {
+    this.worker.postMessage(message, [...transfer]);
+  }
+
+  onMessage(listener: (message: CandidateInferenceWorkerOutput) => void): () => void {
+    const handler = (event: MessageEvent<CandidateInferenceWorkerOutput>) => listener(event.data);
+    this.worker.addEventListener("message", handler);
+    return () => this.worker.removeEventListener("message", handler);
+  }
+
+  onError(listener: () => void): () => void {
+    this.worker.addEventListener("error", listener);
+    return () => this.worker.removeEventListener("error", listener);
+  }
+
+  terminate(): void {
+    this.worker.terminate();
+  }
+}
+
+export function createCandidateInferenceWorkerClient(
+  onEvent: (event: CandidateInferenceClientEvent) => void,
+): CandidateInferenceWorkerClient {
+  return new CandidateInferenceWorkerClient(new BrowserCandidateInferenceWorkerPort(), onEvent);
+}
+
+export class CandidateInferenceWorkerClient {
+  private initialized = false;
+  private ready = false;
+  private closed = false;
+  private inFlightRequestId: number | null = null;
+  private readonly removeMessageListener: () => void;
+  private readonly removeErrorListener: () => void;
+
+  constructor(
+    private readonly port: CandidateInferenceWorkerPort,
+    private readonly onEvent: (event: CandidateInferenceClientEvent) => void,
+  ) {
+    this.removeMessageListener = port.onMessage((message) => this.handle(message));
+    this.removeErrorListener = port.onError(() => this.failTransport());
+  }
+
+  async initialize(bundle: VerifiedModelBundle): Promise<void> {
+    if (this.initialized || this.closed) throw new Error("candidate.inference.client.closed");
+    this.initialized = true;
+    try {
+      const [modelBuffer, featurePlanBuffer, decisionPolicyBuffer] = await Promise.all([
+        bundle.bytesByRole.model.arrayBuffer(),
+        bundle.bytesByRole.feature_plan.arrayBuffer(),
+        bundle.bytesByRole.decision_policy.arrayBuffer(),
+      ]);
+      if (this.closed) return;
+      this.port.post(
+        {
+          type: "initialize",
+          protocolVersion: CANDIDATE_INFERENCE_PROTOCOL_VERSION,
+          bundle: { id: bundle.id, version: bundle.version },
+          modelBuffer,
+          featurePlanBuffer,
+          decisionPolicyBuffer,
+        },
+        [modelBuffer, featurePlanBuffer, decisionPolicyBuffer],
+      );
+    } catch {
+      this.failTransport();
+    }
+  }
+
+  classify(requestId: number, input: CandidateInferenceInput): void {
+    if (!this.ready || this.closed) throw new Error("candidate.inference.client.not_ready");
+    if (this.inFlightRequestId !== null) throw new Error("candidate.inference.client.busy");
+    this.inFlightRequestId = requestId;
+    try {
+      this.port.post({
+        type: "classify",
+        protocolVersion: CANDIDATE_INFERENCE_PROTOCOL_VERSION,
+        requestId,
+        input,
+      });
+    } catch {
+      this.failTransport();
+    }
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.ready = false;
+    try {
+      this.port.post({ type: "stop", protocolVersion: CANDIDATE_INFERENCE_PROTOCOL_VERSION });
+    } catch {
+      this.failTransport();
+    }
+  }
+
+  private handle(message: CandidateInferenceWorkerOutput): void {
+    if (message.protocolVersion !== CANDIDATE_INFERENCE_PROTOCOL_VERSION) {
+      this.failTransport();
+      return;
+    }
+    if (message.type === "ready") this.ready = true;
+    else if (message.type === "result" || (message.type === "failure" && !message.fatal)) {
+      if (message.requestId !== this.inFlightRequestId) return this.failTransport();
+      this.inFlightRequestId = null;
+    }
+    if ((message.type === "failure" && message.fatal) || message.type === "stopped")
+      this.finalize();
+    this.onEvent(message);
+  }
+
+  private failTransport(): void {
+    if (this.closed) return;
+    this.finalize();
+    this.onEvent({
+      type: "worker-transport-failure",
+      code: "candidate.inference.transport.failed",
+    });
+  }
+
+  private finalize(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.ready = false;
+    this.inFlightRequestId = null;
+    this.removeMessageListener();
+    this.removeErrorListener();
+    this.port.terminate();
+  }
+}

--- a/apps/web/src/inference/candidateDecision.test.ts
+++ b/apps/web/src/inference/candidateDecision.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { decideCandidate } from "./candidateDecision";
+import { decideCandidate, scoreCandidate } from "./candidateDecision";
 import policy from "../../../../docs/reports/popsign-constructed-calibration-policy-v1.json";
 
 describe("candidate decision contract", () => {
@@ -10,21 +10,41 @@ describe("candidate decision contract", () => {
 
   it("temperature-scales valid probabilities and chooses the first equal maximum", () => {
     const probabilities = [0.4, 0.4, 0.05, 0.05, 0.05, 0.05];
-    const decision = decideCandidate(true, probabilities, policy);
-    const expected = 0.4 ** 20 / (2 * 0.4 ** 20 + 4 * 0.05 ** 20);
+    const scored = scoreCandidate(probabilities, policy);
+    const denominator = 2 * 0.4 ** 20 + 4 * 0.05 ** 20;
+    const expected = [0.4 ** 20 / denominator, 0.05 ** 20 / denominator];
 
-    expect(decision).toMatchObject({ kind: "target", label: "hello" });
+    expect(scored).toMatchObject({
+      decision: { kind: "target", label: "hello" },
+      reason: "accepted_target",
+    });
+    if (scored === null) throw new Error("expected scored decision");
+    expect(scored.rankedScores.map(({ label }) => label)).toEqual([
+      "hello",
+      "no",
+      "please",
+      "thank_you",
+      "yes",
+      "other",
+    ]);
+    scored.rankedScores.forEach(({ confidence }, index) => {
+      expect(confidence / expected[index < 2 ? 0 : 1]!).toBeCloseTo(1, 12);
+    });
+    expect(decideCandidate(true, probabilities, policy)).toEqual(scored.decision);
     expect(decideCandidate(true, [1.000019, 0, 0, 0, 0, 0], policy)).toMatchObject({
       kind: "target",
     });
-    if (decision.kind !== "target") throw new Error("expected target decision");
-    expect(decision.confidence).toBeCloseTo(expected, 14);
   });
 
   it("keeps the selected other class distinct from target and abstain", () => {
-    expect(
-      decideCandidate(true, new Float32Array([0.01, 0.01, 0.01, 0.01, 0.01, 0.95]), policy),
-    ).toMatchObject({ kind: "other", label: "other" });
+    const probabilities = new Float32Array([0.01, 0.01, 0.01, 0.01, 0.01, 0.95]);
+    const scored = scoreCandidate(probabilities, policy);
+
+    expect(scored).toMatchObject({
+      decision: { kind: "other", label: "other" },
+      reason: "accepted_other",
+    });
+    expect(decideCandidate(true, probabilities, policy)).toEqual(scored?.decision);
   });
 
   it("abstains on malformed active probability vectors", () => {
@@ -35,6 +55,9 @@ describe("candidate decision contract", () => {
       [0.1, 0.1, 0.1, 0.1, 0.1, 0.1],
     ];
 
+    expect(malformed.map((value) => scoreCandidate(value, policy))).toEqual(
+      malformed.map(() => null),
+    );
     expect(malformed.map((value) => decideCandidate(true, value, policy))).toEqual(
       malformed.map(() => ({ kind: "abstain" })),
     );

--- a/apps/web/src/inference/candidateDecision.ts
+++ b/apps/web/src/inference/candidateDecision.ts
@@ -11,18 +11,26 @@ export type CandidateDecision =
       readonly confidence: number;
     }
   | { readonly kind: "other"; readonly label: "other"; readonly confidence: number };
+export interface ScoredCandidateDecision {
+  readonly decision: Exclude<CandidateDecision, { readonly kind: "inactive" }>;
+  readonly reason: "accepted_target" | "accepted_other" | "below_threshold";
+  readonly rankedScores: readonly {
+    readonly label: CandidateLabel;
+    readonly confidence: number;
+  }[];
+}
 
 const TEMPERATURE = candidateDecisionPolicy.temperature.temperature_milli / 1_000;
 const THRESHOLD = candidateDecisionPolicy.abstention.threshold_percent / 100;
 const PROBABILITY_SUM_TOLERANCE = 1e-5 + 1e-5;
 const LOG_FLOOR = 1e-7;
 
-function exactPolicy(value: unknown, expected: unknown = candidateDecisionPolicy): boolean {
+export function exactJson(value: unknown, expected: unknown = candidateDecisionPolicy): boolean {
   if (Array.isArray(expected)) {
     return (
       Array.isArray(value) &&
       value.length === expected.length &&
-      expected.every((item, index) => exactPolicy(value[index], item))
+      expected.every((item, index) => exactJson(value[index], item))
     );
   }
   if (typeof expected === "object" && expected !== null) {
@@ -31,7 +39,7 @@ function exactPolicy(value: unknown, expected: unknown = candidateDecisionPolicy
     const entries = Object.entries(expected);
     return (
       Object.keys(actual).length === entries.length &&
-      entries.every(([key, item]) => exactPolicy(actual[key], item))
+      entries.every(([key, item]) => exactJson(actual[key], item))
     );
   }
   return value === expected;
@@ -61,6 +69,30 @@ function calibratedProbabilities(probabilities: readonly number[]): number[] {
   return exponentials.map((value) => value / total);
 }
 
+export function scoreCandidate(
+  probabilities: unknown,
+  policy: unknown,
+): ScoredCandidateDecision | null {
+  const checked = validProbabilities(probabilities);
+  if (!exactJson(policy) || checked === null) return null;
+  const rankedScores = calibratedProbabilities(checked)
+    .map((confidence, index) => ({ label: CANDIDATE_LABELS[index]!, confidence }))
+    .sort((left, right) => right.confidence - left.confidence);
+  const selected = rankedScores[0]!;
+  if (selected.confidence < THRESHOLD) {
+    return { decision: { kind: "abstain" }, reason: "below_threshold", rankedScores };
+  }
+  const decision =
+    selected.label === "other"
+      ? ({ kind: "other", label: "other", confidence: selected.confidence } as const)
+      : ({ kind: "target", label: selected.label, confidence: selected.confidence } as const);
+  return {
+    decision,
+    reason: decision.kind === "other" ? "accepted_other" : "accepted_target",
+    rankedScores,
+  };
+}
+
 /** Apply the one supported candidate policy without guessing on invalid runtime input. */
 export function decideCandidate(
   candidateActive: boolean,
@@ -68,22 +100,5 @@ export function decideCandidate(
   policy: unknown,
 ): CandidateDecision {
   if (!candidateActive) return { kind: "inactive" };
-
-  const checkedProbabilities = validProbabilities(probabilities);
-  if (!exactPolicy(policy) || checkedProbabilities === null) {
-    return { kind: "abstain" };
-  }
-
-  const calibrated = calibratedProbabilities(checkedProbabilities);
-  let selectedIndex = 0;
-  for (let index = 1; index < calibrated.length; index += 1) {
-    if (calibrated[index]! > calibrated[selectedIndex]!) selectedIndex = index;
-  }
-  const confidence = calibrated[selectedIndex]!;
-  const label = CANDIDATE_LABELS[selectedIndex]!;
-
-  if (confidence < THRESHOLD) return { kind: "abstain" };
-  return label === "other"
-    ? { kind: "other", label, confidence }
-    : { kind: "target", label, confidence };
+  return scoreCandidate(probabilities, policy)?.decision ?? { kind: "abstain" };
 }

--- a/apps/web/src/inference/candidateInference.worker.ts
+++ b/apps/web/src/inference/candidateInference.worker.ts
@@ -1,0 +1,26 @@
+import type {
+  CandidateInferenceWorkerInput,
+  CandidateInferenceWorkerOutput,
+} from "./candidateInferenceProtocol";
+import {
+  CandidateInferenceSession,
+  createCandidateInferenceEngine,
+} from "./candidateInferenceSession";
+
+interface CandidateInferenceWorkerScope {
+  onmessage: ((event: MessageEvent<CandidateInferenceWorkerInput>) => void) | null;
+  postMessage(message: CandidateInferenceWorkerOutput): void;
+  close(): void;
+}
+
+const workerScope = self as unknown as CandidateInferenceWorkerScope;
+const session = new CandidateInferenceSession(createCandidateInferenceEngine, (message) => {
+  workerScope.postMessage(message);
+});
+
+workerScope.onmessage = (event) => {
+  const stopAfterHandling = event.data.type === "stop";
+  void session.handle(event.data).finally(() => {
+    if (stopAfterHandling) workerScope.close();
+  });
+};

--- a/apps/web/src/inference/candidateInferenceProtocol.ts
+++ b/apps/web/src/inference/candidateInferenceProtocol.ts
@@ -1,0 +1,89 @@
+import type { ScoredCandidateDecision } from "./candidateDecision";
+import type {
+  CandidateFrame,
+  CandidateQualityEvidence,
+  SourceMirrorState,
+} from "./candidatePreprocessing";
+
+export const CANDIDATE_INFERENCE_PROTOCOL_VERSION = "signlab-candidate-inference-worker/1" as const;
+
+export interface CandidateInferenceInput {
+  readonly frames: readonly CandidateFrame[];
+  readonly sourceMirrorState: SourceMirrorState;
+  readonly quality: CandidateQualityEvidence;
+}
+
+export interface InitializeCandidateInference {
+  readonly type: "initialize";
+  readonly protocolVersion: typeof CANDIDATE_INFERENCE_PROTOCOL_VERSION;
+  readonly bundle: { readonly id: string; readonly version: string };
+  readonly modelBuffer: ArrayBuffer;
+  readonly featurePlanBuffer: ArrayBuffer;
+  readonly decisionPolicyBuffer: ArrayBuffer;
+}
+
+export interface ClassifyCandidate {
+  readonly type: "classify";
+  readonly protocolVersion: typeof CANDIDATE_INFERENCE_PROTOCOL_VERSION;
+  readonly requestId: number;
+  readonly input: CandidateInferenceInput;
+}
+
+export interface StopCandidateInference {
+  readonly type: "stop";
+  readonly protocolVersion: typeof CANDIDATE_INFERENCE_PROTOCOL_VERSION;
+}
+
+export type CandidateInferenceWorkerInput =
+  InitializeCandidateInference | ClassifyCandidate | StopCandidateInference;
+
+interface CandidateInferenceOutputBase {
+  readonly protocolVersion: typeof CANDIDATE_INFERENCE_PROTOCOL_VERSION;
+}
+
+export interface CandidateInferenceReady extends CandidateInferenceOutputBase {
+  readonly type: "ready";
+  readonly bundle: { readonly id: string; readonly version: string };
+  readonly backend: "wasm";
+  readonly startupMs: number;
+}
+
+export interface CandidateInferenceTimings {
+  readonly preprocessingMs: number;
+  readonly inferenceMs: number;
+  readonly decisionMs: number;
+  readonly totalMs: number;
+}
+
+export interface CandidateInferenceResult
+  extends CandidateInferenceOutputBase, ScoredCandidateDecision {
+  readonly type: "result";
+  readonly requestId: number;
+  readonly bundle: { readonly id: string; readonly version: string };
+  readonly backend: "wasm";
+  readonly timings: CandidateInferenceTimings;
+}
+
+export type CandidateInferenceFailureCode =
+  | "candidate.inference.initialization.failed"
+  | "candidate.inference.input.invalid"
+  | "candidate.inference.runtime.failed"
+  | "candidate.inference.output.invalid"
+  | "candidate.inference.protocol.invalid";
+
+export interface CandidateInferenceFailure extends CandidateInferenceOutputBase {
+  readonly type: "failure";
+  readonly code: CandidateInferenceFailureCode;
+  readonly requestId: number | null;
+  readonly fatal: boolean;
+}
+
+export interface CandidateInferenceStopped extends CandidateInferenceOutputBase {
+  readonly type: "stopped";
+}
+
+export type CandidateInferenceWorkerOutput =
+  | CandidateInferenceReady
+  | CandidateInferenceResult
+  | CandidateInferenceFailure
+  | CandidateInferenceStopped;

--- a/apps/web/src/inference/candidateInferenceSession.test.ts
+++ b/apps/web/src/inference/candidateInferenceSession.test.ts
@@ -1,0 +1,279 @@
+/// <reference types="node" />
+// @vitest-environment node
+
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+import decisionPolicy from "../../../../docs/reports/popsign-constructed-calibration-policy-v1.json";
+import featurePlan from "../../../../src/signlab/resources/features/config/hand-local-64-1.default.json";
+import fixture from "../../../../tests/fixtures/public/parity/candidate-runtime-goldens-v1.json";
+import {
+  CANDIDATE_INFERENCE_PROTOCOL_VERSION,
+  type CandidateInferenceFailure,
+  type CandidateInferenceInput,
+  type CandidateInferenceResult,
+  type CandidateInferenceWorkerInput,
+  type CandidateInferenceWorkerOutput,
+  type InitializeCandidateInference,
+} from "./candidateInferenceProtocol";
+import {
+  CandidateInferenceSession,
+  createCandidateInferenceEngine,
+  type CandidateInferenceEngine,
+} from "./candidateInferenceSession";
+
+const repositoryRoot = resolve(process.cwd(), "../..");
+const bundle = { id: "candidate-fixture", version: "1" } as const;
+const source = fixture.preprocessingCases.find(({ id }) => id === "gap_unmirrored");
+const runtime = fixture.onnx.cases.find(
+  ({ preprocessingCaseId }) => preprocessingCaseId === "gap_unmirrored",
+);
+if (source === undefined || runtime === undefined) throw new Error("missing candidate golden");
+
+const input = {
+  frames: source.frames,
+  sourceMirrorState: source.sourceMirrorState,
+  quality: source.quality,
+} as unknown as CandidateInferenceInput;
+
+const encode = (value: unknown): ArrayBuffer =>
+  new TextEncoder().encode(JSON.stringify(value)).buffer;
+const initialize = (
+  modelBuffer = new Uint8Array([1, 2, 3]).buffer,
+): InitializeCandidateInference => ({
+  type: "initialize",
+  protocolVersion: CANDIDATE_INFERENCE_PROTOCOL_VERSION,
+  bundle,
+  modelBuffer,
+  featurePlanBuffer: encode(featurePlan),
+  decisionPolicyBuffer: encode(Object.fromEntries(Object.entries(decisionPolicy).reverse())),
+});
+const classify = (requestId: number, candidateInput = input) => ({
+  type: "classify" as const,
+  protocolVersion: CANDIDATE_INFERENCE_PROTOCOL_VERSION,
+  requestId,
+  input: candidateInput,
+});
+const expectedTensorQ = () => {
+  const expected = source.expected as unknown as {
+    readonly nonPaddingFrameCount: number;
+    readonly valuesQ: readonly (readonly number[])[];
+  };
+  return expected.valuesQ.flat().concat(Array((64 - expected.nonPaddingFrameCount) * 126).fill(0));
+};
+
+describe("candidate inference session", () => {
+  it("reports an unknown message as a typed protocol failure", async () => {
+    const messages: CandidateInferenceWorkerOutput[] = [];
+    const session = new CandidateInferenceSession(vi.fn(), (message) => messages.push(message));
+
+    await session.handle({
+      type: "unknown",
+      protocolVersion: CANDIDATE_INFERENCE_PROTOCOL_VERSION,
+    } as unknown as CandidateInferenceWorkerInput);
+
+    expect(messages).toEqual([
+      {
+        type: "failure",
+        protocolVersion: CANDIDATE_INFERENCE_PROTOCOL_VERSION,
+        code: "candidate.inference.protocol.invalid",
+        requestId: null,
+        fatal: true,
+      },
+    ]);
+  });
+
+  it("initializes exact configs, reuses one engine, scores golden inputs, and stops cleanly", async () => {
+    const messages: CandidateInferenceWorkerOutput[] = [];
+    const close = vi.fn();
+    const tensors: Float32Array[] = [];
+    const createEngine = vi.fn(async (modelBuffer: ArrayBuffer) => {
+      const engine = await createCandidateInferenceEngine(modelBuffer);
+      return {
+        run: async (values: Float32Array) => {
+          tensors.push(values);
+          return engine.run(values);
+        },
+        close: async () => {
+          close();
+          await engine.close();
+        },
+      };
+    });
+    let clock = 0;
+    const session = new CandidateInferenceSession(
+      createEngine,
+      (message) => messages.push(message),
+      () => ++clock,
+    );
+
+    const model = Uint8Array.from(
+      await readFile(resolve(repositoryRoot, fixture.resources.testModel.path)),
+    ).buffer;
+    await session.handle(initialize(model));
+    await session.handle(classify(7));
+    await session.handle(classify(8));
+    await session.handle({
+      type: "stop",
+      protocolVersion: CANDIDATE_INFERENCE_PROTOCOL_VERSION,
+    });
+
+    expect(messages[0]).toEqual({
+      type: "ready",
+      protocolVersion: CANDIDATE_INFERENCE_PROTOCOL_VERSION,
+      bundle,
+      backend: "wasm",
+      startupMs: 1,
+    });
+    const results = messages.filter(
+      (message): message is CandidateInferenceResult => message.type === "result",
+    );
+    expect(results).toHaveLength(2);
+    expect(results.map(({ requestId }) => requestId)).toEqual([7, 8]);
+    expect(results[0]).toMatchObject({
+      decision: { kind: "target", label: "hello" },
+      reason: "accepted_target",
+      bundle,
+      backend: "wasm",
+      timings: { preprocessingMs: 1, inferenceMs: 1, decisionMs: 1, totalMs: 3 },
+    });
+    expect(results[0]!.rankedScores.map(({ label }) => label)).toEqual([
+      "hello",
+      "yes",
+      "please",
+      "thank_you",
+      "no",
+      "other",
+    ]);
+    expect(Array.from(tensors[0]!, (value) => Math.round(value * 1_000_000))).toEqual(
+      expectedTensorQ(),
+    );
+    expect(createEngine).toHaveBeenCalledTimes(1);
+    expect(tensors).toHaveLength(2);
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(messages.at(-1)).toEqual({
+      type: "stopped",
+      protocolVersion: CANDIDATE_INFERENCE_PROTOCOL_VERSION,
+    });
+  });
+
+  it("rejects changed configs before engine creation and sanitizes engine startup failures", async () => {
+    for (const key of ["featurePlanBuffer", "decisionPolicyBuffer"] as const) {
+      const messages: CandidateInferenceWorkerOutput[] = [];
+      const engine: CandidateInferenceEngine = { run: vi.fn(), close: vi.fn() };
+      const createEngine = vi.fn(() => Promise.resolve(engine));
+      const session = new CandidateInferenceSession(createEngine, (message) =>
+        messages.push(message),
+      );
+
+      await session.handle({ ...initialize(), [key]: encode({ changed: true }) });
+
+      expect(createEngine).not.toHaveBeenCalled();
+      expect(messages).toEqual([
+        {
+          type: "failure",
+          protocolVersion: CANDIDATE_INFERENCE_PROTOCOL_VERSION,
+          code: "candidate.inference.initialization.failed",
+          requestId: null,
+          fatal: true,
+        },
+      ]);
+    }
+
+    const messages: CandidateInferenceWorkerOutput[] = [];
+    const session = new CandidateInferenceSession(
+      () => Promise.reject(new Error("secret model loader details")),
+      (message) => messages.push(message),
+    );
+    await session.handle(initialize());
+    expect(messages).toEqual([
+      {
+        type: "failure",
+        protocolVersion: CANDIDATE_INFERENCE_PROTOCOL_VERSION,
+        code: "candidate.inference.initialization.failed",
+        requestId: null,
+        fatal: true,
+      },
+    ]);
+    expect(JSON.stringify(messages)).not.toContain("secret");
+  });
+
+  it("reports sanitized input, runtime, and output failures", async () => {
+    const cases: readonly {
+      readonly requestId: number;
+      readonly candidateInput: CandidateInferenceInput;
+      readonly run: (values: Float32Array) => Promise<unknown>;
+      readonly code: CandidateInferenceFailure["code"];
+    }[] = [
+      {
+        requestId: 11,
+        candidateInput: { ...input, frames: [] },
+        run: () => Promise.resolve(new Float32Array(runtime.probabilities)),
+        code: "candidate.inference.input.invalid",
+      },
+      {
+        requestId: 12,
+        candidateInput: input,
+        run: () => Promise.reject(new Error("secret filesystem path and runtime details")),
+        code: "candidate.inference.runtime.failed",
+      },
+      {
+        requestId: 13,
+        candidateInput: input,
+        run: () => Promise.resolve(new Float32Array([0.2, 0.2, 0.2, 0.2, 0.2, 0.2])),
+        code: "candidate.inference.output.invalid",
+      },
+    ];
+
+    for (const failureCase of cases) {
+      const messages: CandidateInferenceWorkerOutput[] = [];
+      const session = new CandidateInferenceSession(
+        () => Promise.resolve({ run: failureCase.run, close: vi.fn() }),
+        (message) => messages.push(message),
+      );
+      await session.handle(initialize());
+      messages.length = 0;
+
+      await session.handle(classify(failureCase.requestId, failureCase.candidateInput));
+
+      expect(messages).toEqual([
+        {
+          type: "failure",
+          protocolVersion: CANDIDATE_INFERENCE_PROTOCOL_VERSION,
+          code: failureCase.code,
+          requestId: failureCase.requestId,
+          fatal: false,
+        },
+      ]);
+      expect(JSON.stringify(messages)).not.toContain("secret");
+    }
+  });
+
+  it("defensively rejects an overlapping classification without interrupting the first", async () => {
+    const messages: CandidateInferenceWorkerOutput[] = [];
+    let resolveRun: ((probabilities: Float32Array) => void) | undefined;
+    const pending = new Promise<Float32Array>((resolve) => {
+      resolveRun = resolve;
+    });
+    const session = new CandidateInferenceSession(
+      () => Promise.resolve({ run: () => pending, close: vi.fn() }),
+      (message) => messages.push(message),
+    );
+    await session.handle(initialize());
+
+    const first = session.handle(classify(21));
+    await session.handle(classify(22));
+    expect(messages.at(-1)).toMatchObject({
+      type: "failure",
+      code: "candidate.inference.protocol.invalid",
+      requestId: 22,
+      fatal: false,
+    });
+
+    resolveRun?.(new Float32Array(runtime.probabilities));
+    await first;
+    expect(messages.at(-1)).toMatchObject({ type: "result", requestId: 21 });
+  });
+});

--- a/apps/web/src/inference/candidateInferenceSession.ts
+++ b/apps/web/src/inference/candidateInferenceSession.ts
@@ -1,0 +1,237 @@
+import * as ort from "onnxruntime-web/wasm";
+
+import decisionPolicy from "../../../../docs/reports/popsign-constructed-calibration-policy-v1.json";
+import featurePlan from "../../../../src/signlab/resources/features/config/hand-local-64-1.default.json";
+import { exactJson, scoreCandidate } from "./candidateDecision";
+import {
+  CANDIDATE_INFERENCE_PROTOCOL_VERSION,
+  type CandidateInferenceFailureCode,
+  type CandidateInferenceWorkerInput,
+  type CandidateInferenceWorkerOutput,
+  type ClassifyCandidate,
+  type InitializeCandidateInference,
+} from "./candidateInferenceProtocol";
+import { preprocessCandidate } from "./candidatePreprocessing";
+
+export interface CandidateInferenceEngine {
+  run(values: Float32Array): Promise<unknown>;
+  close(): Promise<void> | void;
+}
+
+type EngineFactory = (model: ArrayBuffer) => Promise<CandidateInferenceEngine>;
+
+export async function createCandidateInferenceEngine(
+  modelBuffer: ArrayBuffer,
+): Promise<CandidateInferenceEngine> {
+  ort.env.wasm.numThreads = 1;
+  ort.env.wasm.proxy = false;
+  const session = await ort.InferenceSession.create(new Uint8Array(modelBuffer), {
+    executionProviders: ["wasm"],
+    executionMode: "sequential",
+  });
+  const input = session.inputMetadata.length === 1 ? session.inputMetadata[0] : undefined;
+  const output = session.outputMetadata.length === 1 ? session.outputMetadata[0] : undefined;
+  if (
+    !input?.isTensor ||
+    input.name !== "input" ||
+    input.type !== "float32" ||
+    input.shape.length !== 3 ||
+    input.shape[0] !== 1 ||
+    input.shape[1] !== 64 ||
+    input.shape[2] !== 126 ||
+    !output?.isTensor ||
+    output.name !== "probabilities" ||
+    output.type !== "float32" ||
+    output.shape.length !== 2 ||
+    output.shape[0] !== 1 ||
+    output.shape[1] !== 6
+  ) {
+    await session.release();
+    throw new Error("candidate.inference.model_contract.invalid");
+  }
+  return {
+    async run(values) {
+      if (values.length !== 64 * 126) {
+        throw new Error("candidate.inference.tensor.invalid");
+      }
+      const results = await session.run({
+        input: new ort.Tensor("float32", values, [1, 64, 126]),
+      });
+      const output = results.probabilities;
+      if (
+        output?.type !== "float32" ||
+        output.dims.join() !== "1,6" ||
+        !(output.data instanceof Float32Array) ||
+        output.data.length !== 6
+      ) {
+        throw new Error("candidate.inference.output_contract.invalid");
+      }
+      return new Float32Array(output.data);
+    },
+    close: () => session.release(),
+  };
+}
+
+function requireExactJson(buffer: ArrayBuffer, expected: unknown): void {
+  try {
+    const value = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(buffer)) as unknown;
+    if (!exactJson(value, expected)) throw new Error();
+  } catch {
+    throw new Error("candidate.inference.config.invalid");
+  }
+}
+
+const safeId = (value: number) => Number.isSafeInteger(value) && value >= 0;
+const elapsed = (start: number, end: number) => Math.max(0, end - start);
+
+export class CandidateInferenceSession {
+  private engine: CandidateInferenceEngine | null = null;
+  private bundle: { readonly id: string; readonly version: string } | null = null;
+  private initializing = false;
+  private busy = false;
+  private stopped = false;
+
+  constructor(
+    private readonly createEngine: EngineFactory,
+    private readonly post: (message: CandidateInferenceWorkerOutput) => void,
+    private readonly now: () => number = () => performance.now(),
+  ) {}
+
+  async handle(message: CandidateInferenceWorkerInput): Promise<void> {
+    if (message.protocolVersion !== CANDIDATE_INFERENCE_PROTOCOL_VERSION) {
+      this.fail("candidate.inference.protocol.invalid", null, true);
+    } else if (message.type === "initialize") await this.initialize(message);
+    else if (message.type === "classify") await this.classify(message);
+    else if (message.type === "stop") await this.stop();
+    else this.fail("candidate.inference.protocol.invalid", null, true);
+  }
+
+  private async initialize(message: InitializeCandidateInference): Promise<void> {
+    if (
+      this.stopped ||
+      this.initializing ||
+      this.engine !== null ||
+      message.bundle.id.length === 0 ||
+      message.bundle.version.length === 0
+    ) {
+      this.fail("candidate.inference.protocol.invalid", null, true);
+      return;
+    }
+    this.initializing = true;
+    const started = this.now();
+    try {
+      requireExactJson(message.featurePlanBuffer, featurePlan);
+      requireExactJson(message.decisionPolicyBuffer, decisionPolicy);
+      const engine = await this.createEngine(message.modelBuffer);
+      if (this.stopped) {
+        await engine.close();
+        return;
+      }
+      this.engine = engine;
+      this.bundle = Object.freeze({ ...message.bundle });
+      this.post({
+        type: "ready",
+        protocolVersion: CANDIDATE_INFERENCE_PROTOCOL_VERSION,
+        bundle: this.bundle,
+        backend: "wasm",
+        startupMs: elapsed(started, this.now()),
+      });
+    } catch {
+      this.fail("candidate.inference.initialization.failed", null, true);
+    } finally {
+      this.initializing = false;
+    }
+  }
+
+  private async classify(message: ClassifyCandidate): Promise<void> {
+    if (!safeId(message.requestId) || !this.engine || !this.bundle || this.stopped) {
+      this.fail("candidate.inference.protocol.invalid", message.requestId, true);
+      return;
+    }
+    if (this.busy) {
+      this.fail("candidate.inference.protocol.invalid", message.requestId, false);
+      return;
+    }
+    this.busy = true;
+    const started = this.now();
+    try {
+      let tensor: Float32Array;
+      try {
+        const { frames, sourceMirrorState, quality } = message.input;
+        tensor = preprocessCandidate(frames, sourceMirrorState, quality, featurePlan).values;
+      } catch {
+        this.fail("candidate.inference.input.invalid", message.requestId, false);
+        return;
+      }
+      const preprocessed = this.now();
+      let probabilities: unknown;
+      try {
+        probabilities = await this.engine.run(tensor);
+      } catch (error) {
+        if (!this.stopped) {
+          const invalidOutput =
+            error instanceof Error &&
+            error.message === "candidate.inference.output_contract.invalid";
+          this.fail(
+            invalidOutput
+              ? "candidate.inference.output.invalid"
+              : "candidate.inference.runtime.failed",
+            message.requestId,
+            false,
+          );
+        }
+        return;
+      }
+      const inferred = this.now();
+      const scored = scoreCandidate(probabilities, decisionPolicy);
+      if (scored === null) {
+        this.fail("candidate.inference.output.invalid", message.requestId, false);
+        return;
+      }
+      const decided = this.now();
+      if (this.stopped) return;
+      this.post({
+        type: "result",
+        protocolVersion: CANDIDATE_INFERENCE_PROTOCOL_VERSION,
+        requestId: message.requestId,
+        ...scored,
+        bundle: this.bundle,
+        backend: "wasm",
+        timings: {
+          preprocessingMs: elapsed(started, preprocessed),
+          inferenceMs: elapsed(preprocessed, inferred),
+          decisionMs: elapsed(inferred, decided),
+          totalMs: elapsed(started, decided),
+        },
+      });
+    } finally {
+      this.busy = false;
+    }
+  }
+
+  private async stop(): Promise<void> {
+    if (this.stopped) return;
+    this.stopped = true;
+    const engine = this.engine;
+    this.engine = null;
+    await Promise.resolve(engine?.close()).catch(() => undefined);
+    this.post({
+      type: "stopped",
+      protocolVersion: CANDIDATE_INFERENCE_PROTOCOL_VERSION,
+    });
+  }
+
+  private fail(
+    code: CandidateInferenceFailureCode,
+    requestId: number | null,
+    fatal: boolean,
+  ): void {
+    this.post({
+      type: "failure",
+      protocolVersion: CANDIDATE_INFERENCE_PROTOCOL_VERSION,
+      code,
+      requestId: safeId(requestId ?? -1) ? requestId : null,
+      fatal,
+    });
+  }
+}

--- a/apps/web/src/inference/candidateParity.test.ts
+++ b/apps/web/src/inference/candidateParity.test.ts
@@ -5,13 +5,13 @@ import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 
-import * as ort from "onnxruntime-web";
 import { describe, expect, it } from "vitest";
 
 import policy from "../../../../docs/reports/popsign-constructed-calibration-policy-v1.json";
 import plan from "../../../../src/signlab/resources/features/config/hand-local-64-1.default.json";
 import fixture from "../../../../tests/fixtures/public/parity/candidate-runtime-goldens-v1.json";
 import { CANDIDATE_LABELS, decideCandidate } from "./candidateDecision";
+import { createCandidateInferenceEngine } from "./candidateInferenceSession";
 import { preprocessCandidate } from "./candidatePreprocessing";
 
 type ExpectedRows = {
@@ -142,31 +142,18 @@ describe("candidate runtime golden parity", () => {
   });
 
   it("proves the single-threaded WASM engine contract, not worker/browser integration", async () => {
-    ort.env.wasm.numThreads = 1;
     const model = await readFile(resolve(repositoryRoot, fixture.resources.testModel.path));
-    const session = await ort.InferenceSession.create(new Uint8Array(model), {
-      executionProviders: ["wasm"],
-      intraOpNumThreads: 1,
-      interOpNumThreads: 1,
-    });
+    const engine = await createCandidateInferenceEngine(Uint8Array.from(model).buffer);
     try {
-      expect(session.inputNames).toEqual([fixture.onnx.input.name]);
-      expect(session.outputNames).toEqual([fixture.onnx.output.name]);
       for (const runtimeCase of fixture.onnx.cases) {
         const source = fixture.preprocessingCases.find(
           (candidateCase) => candidateCase.id === runtimeCase.preprocessingCaseId,
         );
         if (source === undefined) throw new Error("missing preprocessing golden");
         const values = expectedTensor(source.expected);
-        const input = new ort.Tensor("float32", values, fixture.onnx.input.shape);
-        const output = (await session.run({ [fixture.onnx.input.name]: input }))[
-          fixture.onnx.output.name
-        ];
-        if (output === undefined || !(output.data instanceof Float32Array)) {
-          throw new Error("invalid ONNX output");
-        }
-        expect(output.dims).toEqual(fixture.onnx.output.shape);
-        output.data.forEach((value, index) => {
+        const probabilities = await engine.run(values);
+        if (!(probabilities instanceof Float32Array)) throw new Error("invalid ONNX output");
+        probabilities.forEach((value, index) => {
           const expected = runtimeCase.probabilities[index]!;
           const tolerance =
             fixture.onnx.tolerances.absolute +
@@ -175,7 +162,7 @@ describe("candidate runtime golden parity", () => {
         });
       }
     } finally {
-      await session.release();
+      await engine.close();
     }
   });
 });


### PR DESCRIPTION
Closes #44

## What this delivers

- Initializes one reusable, single-threaded ONNX Runtime Web WASM session from the verified model bundle assets.
- Validates exact model names, numeric tensor shapes, and float32 types before classification.
- Runs the existing candidate preprocessing, real ONNX model, temperature calibration, learned `other`, and abstention logic off the main thread.
- Enforces one classification in flight with no queue and returns ranked scores, decision reason, bundle identity, backend, and phase timings.
- Fails closed with typed, sanitized initialization, input, runtime, output, protocol, and transport errors.
- Cleans up the session, worker, and listeners, including when consumer callbacks throw.
- Moves the already-pinned `onnxruntime-web@1.29.0` package from development to runtime dependencies.

## Scope check

- WASM only; no WebGPU or provider selection.
- No replay, event slicing, camera/React wiring, retry, persistence, or worker pool.
- 498 nonblank added production TypeScript lines, below the 500-line hard stop.

## Verification

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm test` — 83 passed
- `npm run build`
- `npm run build:subpath`
- Direct Vite worker-entry builds at `/` and `/signlab/`; both emitted the candidate worker and correctly based ORT WASM asset.
- Repository hygiene check
- Candidate-runtime golden regeneration check
- Two independent final reviews found no remaining blockers.

Story #47 intentionally retains ownership of making this worker reachable from the live page.