### PR TITLE
Connect live camera events to on-device predictions

### DIFF
--- a/apps/web/src/app/LivePage.test.tsx
+++ b/apps/web/src/app/LivePage.test.tsx
@@ -1,8 +1,13 @@
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { StrictMode } from "react";
 import { describe, expect, it, vi } from "vitest";
 
 import type { CameraEnvironment } from "../camera/useCameraSession";
+import {
+  CANDIDATE_INFERENCE_PROTOCOL_VERSION,
+  type CandidateInferenceResult,
+} from "../inference/candidateInferenceProtocol";
+import type { LiveRecognitionSnapshot } from "../live/liveRecognitionSession";
 import {
   type ModelBundleSession,
   type ModelBundleStatus,
@@ -351,5 +356,230 @@ describe("model bundle status", () => {
 
     expect(await screen.findByText(message)).toBeVisible();
     expect(loader.load).toHaveBeenCalledOnce();
+  });
+});
+
+const resultCases = [
+  {
+    title: "Hello",
+    decision: { kind: "target", label: "hello", confidence: 0.82 } as const,
+    reason: "accepted_target" as const,
+  },
+  {
+    title: "Other movement",
+    decision: { kind: "other", label: "other", confidence: 0.74 } as const,
+    reason: "accepted_other" as const,
+  },
+  {
+    title: "No confident match",
+    decision: { kind: "abstain" } as const,
+    reason: "below_threshold" as const,
+  },
+];
+type TestLiveRuntime = NonNullable<Parameters<typeof LivePage>[0]["liveRuntime"]>;
+type TestLiveSessionFactory = TestLiveRuntime["createSession"];
+
+function inferenceResult(
+  decision: (typeof resultCases)[number]["decision"],
+  reason: (typeof resultCases)[number]["reason"],
+): CandidateInferenceResult {
+  return {
+    type: "result",
+    protocolVersion: CANDIDATE_INFERENCE_PROTOCOL_VERSION,
+    requestId: 0,
+    bundle: { id: "browser-candidate", version: "1.0.0" },
+    backend: "wasm",
+    decision,
+    reason,
+    rankedScores: [
+      { label: "hello", confidence: 0.82 },
+      { label: "other", confidence: 0.12 },
+      { label: "yes", confidence: 0.06 },
+    ],
+    timings: { preprocessingMs: 2, inferenceMs: 5, decisionMs: 1, totalMs: 8 },
+  };
+}
+
+describe("live on-device result", () => {
+  it.each(resultCases)(
+    "keeps a $title event result stable",
+    async ({ title, decision, reason }) => {
+      const devices = new TestMediaDevices();
+      const active = cameraStream("front");
+      devices.getUserMedia.mockResolvedValue(active.stream);
+      devices.enumerateDevices.mockResolvedValue([]);
+      const bundle = { id: "browser-candidate", version: "1.0.0" } as VerifiedModelBundle;
+      const load: ModelBundleSession["load"] = (_url, onStatus) => {
+        onStatus?.({ phase: "ready", active: { id: bundle.id, version: bundle.version } });
+        return Promise.resolve(bundle);
+      };
+      const loader: Pick<ModelBundleSession, "load" | "status"> = {
+        status: { phase: "idle", active: null },
+        load: vi.fn(load),
+      };
+      let emit: (snapshot: LiveRecognitionSnapshot) => void = () => undefined;
+      const close = vi.fn(() => Promise.resolve());
+      const frameSource = {
+        request: vi.fn(() => 7),
+        cancel: vi.fn(),
+        capture: vi.fn(() => Promise.resolve({ close: vi.fn() } as unknown as ImageBitmap)),
+      };
+      const liveRuntime: TestLiveRuntime = {
+        loadAssets: () =>
+          Promise.resolve({
+            handModelBuffer: new ArrayBuffer(1),
+            poseModelBuffer: new ArrayBuffer(1),
+          }),
+        createSession: (_bundle, _buffers, onState) => {
+          emit = onState;
+          return {
+            initialize: () => {
+              onState({ phase: "ready", stableResult: null, failureCode: null });
+              return Promise.resolve();
+            },
+            submitFrame: vi.fn(),
+            close,
+          };
+        },
+        ...frameSource,
+      };
+
+      render(
+        <LivePage
+          cameraEnvironment={cameraEnvironment(devices).environment}
+          modelBundleUrl="https://example.test/bundle/"
+          modelBundleSession={loader}
+          liveRuntime={liveRuntime}
+        />,
+      );
+
+      await screen.findByText(/Verified model bundle browser-candidate/);
+      await startCamera();
+      await screen.findByText(/Models are ready/);
+      act(() => {
+        emit({
+          phase: "result",
+          stableResult: inferenceResult(decision, reason),
+          failureCode: null,
+        });
+      });
+
+      const resultCard = screen.getByRole("region", { name: "Latest recognition result" });
+      expect(within(resultCard).getByText(title, { selector: "strong" })).toBeVisible();
+      expect(within(resultCard).getByRole("list", { name: "Top calibrated scores" })).toBeVisible();
+      expect(screen.getByText("8 ms")).toBeVisible();
+      expect(within(resultCard).getByText("WASM")).toBeVisible();
+      expect(within(resultCard).getByText("browser-candidate 1.0.0")).toBeVisible();
+      fireEvent.click(screen.getByRole("button", { name: "Stop camera" }));
+      await waitFor(() => expect(close).toHaveBeenCalledOnce());
+      expect(frameSource.cancel).toHaveBeenCalledWith(expect.any(HTMLVideoElement), 7);
+    },
+  );
+
+  it("submits one captured bitmap and closes a late bitmap after stop", async () => {
+    const devices = new TestMediaDevices();
+    devices.getUserMedia.mockResolvedValue(cameraStream("front").stream);
+    devices.enumerateDevices.mockResolvedValue([]);
+    const bundle = { id: "browser-candidate", version: "1.0.0" } as VerifiedModelBundle;
+    const loader: Pick<ModelBundleSession, "load" | "status"> = {
+      status: { phase: "ready", active: { id: bundle.id, version: bundle.version } },
+      load: vi.fn(() => Promise.resolve(bundle)),
+    };
+    const callbacks: Array<(timestampMs: number) => void> = [];
+    const firstBitmap = { close: vi.fn() } as unknown as ImageBitmap;
+    const lateClose = vi.fn();
+    const lateBitmap = { close: lateClose } as unknown as ImageBitmap;
+    let resolveLate!: (bitmap: ImageBitmap) => void;
+    const lateCapture = new Promise<ImageBitmap>((resolve) => {
+      resolveLate = resolve;
+    });
+    const submitFrame = vi.fn();
+    const close = vi.fn(() => Promise.resolve());
+    const capture = vi.fn().mockResolvedValueOnce(firstBitmap).mockReturnValueOnce(lateCapture);
+    const liveRuntime: TestLiveRuntime = {
+      loadAssets: () =>
+        Promise.resolve({
+          handModelBuffer: new ArrayBuffer(1),
+          poseModelBuffer: new ArrayBuffer(1),
+        }),
+      createSession: () => ({ initialize: () => Promise.resolve(), submitFrame, close }),
+      request: vi.fn((_video: HTMLVideoElement, callback: (timestampMs: number) => void) => {
+        callbacks.push(callback);
+        return callbacks.length;
+      }),
+      cancel: vi.fn(),
+      capture,
+    };
+
+    render(
+      <LivePage
+        cameraEnvironment={cameraEnvironment(devices).environment}
+        modelBundleUrl="https://example.test/bundle/"
+        modelBundleSession={loader}
+        liveRuntime={liveRuntime}
+      />,
+    );
+
+    await startCamera();
+    await waitFor(() => expect(callbacks).toHaveLength(1));
+    act(() => callbacks[0]!(1_250));
+    await waitFor(() => expect(submitFrame).toHaveBeenCalledWith(firstBitmap, 1_250));
+    await waitFor(() => expect(callbacks).toHaveLength(2));
+    act(() => callbacks[1]!(1_500));
+    await waitFor(() => expect(capture).toHaveBeenCalledTimes(2));
+    fireEvent.click(screen.getByRole("button", { name: "Stop camera" }));
+    await waitFor(() => expect(close).toHaveBeenCalledOnce());
+    await act(async () => {
+      resolveLate(lateBitmap);
+      await lateCapture;
+    });
+
+    expect(lateClose).toHaveBeenCalledOnce();
+    expect(submitFrame).toHaveBeenCalledOnce();
+  });
+
+  it("recreates a failed runtime when the user retries", async () => {
+    const devices = new TestMediaDevices();
+    devices.getUserMedia.mockResolvedValue(cameraStream("front").stream);
+    devices.enumerateDevices.mockResolvedValue([]);
+    const bundle = { id: "browser-candidate", version: "1.0.0" } as VerifiedModelBundle;
+    const load: ModelBundleSession["load"] = () => Promise.resolve(bundle);
+    const loader: Pick<ModelBundleSession, "load" | "status"> = {
+      status: { phase: "ready", active: { id: bundle.id, version: bundle.version } },
+      load: vi.fn(load),
+    };
+    const createFailedSession: TestLiveSessionFactory = (_bundle, _buffers, onState) => ({
+      initialize: () => {
+        onState({ phase: "failed", stableResult: null, failureCode: "test.failure" });
+        return Promise.resolve();
+      },
+      submitFrame: vi.fn(),
+      close: vi.fn(() => Promise.resolve()),
+    });
+    const factory = vi.fn(createFailedSession);
+
+    render(
+      <LivePage
+        cameraEnvironment={cameraEnvironment(devices).environment}
+        modelBundleUrl="https://example.test/bundle/"
+        modelBundleSession={loader}
+        liveRuntime={{
+          loadAssets: () =>
+            Promise.resolve({
+              handModelBuffer: new ArrayBuffer(1),
+              poseModelBuffer: new ArrayBuffer(1),
+            }),
+          createSession: factory,
+          request: () => 1,
+          cancel: vi.fn(),
+          capture: vi.fn(),
+        }}
+      />,
+    );
+
+    await startCamera();
+    const retry = await screen.findByRole("button", { name: "Retry recognition" });
+    fireEvent.click(retry);
+    await waitFor(() => expect(factory).toHaveBeenCalledTimes(2));
   });
 });

--- a/apps/web/src/app/routeDefinitions.ts
+++ b/apps/web/src/app/routeDefinitions.ts
@@ -15,7 +15,7 @@ export const livePageDefinition = {
   label: "Live demo",
   eyebrow: "Local camera preview",
   heading: "Live recognition",
-  summary: "Start a private camera preview when you are ready. Recognition is not connected yet.",
+  summary: "Start a private camera preview and turn one gesture into an on-device result.",
   status: "Camera is off. Nothing is being captured.",
   detailsTitle: "Camera privacy",
   details: [],
@@ -96,10 +96,10 @@ export const staticPages = [
     summary:
       "The completed browser demo is intended to process camera frames on the user’s device. Raw video will not be uploaded or stored by default.",
     status:
-      "The live route requests camera access only after an explicit start action. The app does not store feedback, run inference, or include analytics.",
+      "Camera access is explicit. Inference stays on-device, with no stored feedback or analytics.",
     detailsTitle: "Current privacy facts",
     details: [
-      "This page loads only static application files.",
+      "The live path downloads only its configured model bundle and two integrity-checked MediaPipe model files.",
       "There is no application server or user account.",
       "The live preview remains on-device and releases its camera when stopped or interrupted.",
     ],
@@ -111,8 +111,7 @@ export const staticPages = [
     heading: "What SignLab does—and does not—claim",
     summary:
       "SignLab is a research prototype for recognizing isolated performances of five predefined hand gestures within continuous webcam video. No sign-language or translation capability is claimed.",
-    status:
-      "No approved model performance result exists yet, and the browser inference path is not connected.",
+    status: "The browser path is connected, but no approved model performance result exists yet.",
     detailsTitle: "Known limitations",
     details: [
       "Five predefined prompts only—not an open vocabulary.",

--- a/apps/web/src/app/routes.tsx
+++ b/apps/web/src/app/routes.tsx
@@ -7,7 +7,19 @@ import {
   type CameraEnvironment,
   type CameraStatus,
 } from "../camera/useCameraSession";
-import { ModelBundleSession, type ModelBundleStatus } from "../modelBundle/modelBundleSession";
+import {
+  loadLandmarkModelAssets,
+  type LandmarkModelAssetBuffers,
+} from "../landmarks/landmarkModelAssets";
+import {
+  LiveRecognitionSession,
+  type LiveRecognitionSnapshot,
+} from "../live/liveRecognitionSession";
+import {
+  ModelBundleSession,
+  type ModelBundleStatus,
+  type VerifiedModelBundle,
+} from "../modelBundle/modelBundleSession";
 
 function usePageHeading(title: string) {
   const headingRef = useRef<HTMLHeadingElement>(null);
@@ -38,6 +50,37 @@ const startableStatuses = new Set<CameraStatus>([
 ]);
 
 type BundleLoader = Pick<ModelBundleSession, "load" | "status">;
+type LiveSession = Pick<LiveRecognitionSession, "initialize" | "submitFrame" | "close">;
+
+interface LiveRuntime {
+  loadAssets(): Promise<LandmarkModelAssetBuffers>;
+  createSession(
+    bundle: VerifiedModelBundle,
+    buffers: LandmarkModelAssetBuffers,
+    onState: (snapshot: LiveRecognitionSnapshot) => void,
+  ): LiveSession;
+  request(video: HTMLVideoElement, callback: (captureTimestampMs: number) => void): number;
+  cancel(video: HTMLVideoElement, requestId: number): void;
+  capture(video: HTMLVideoElement): Promise<ImageBitmap>;
+}
+
+const browserLiveRuntime: LiveRuntime = {
+  loadAssets: loadLandmarkModelAssets,
+  createSession: (bundle, taskBuffers, onState) =>
+    new LiveRecognitionSession({ bundle, taskBuffers, onState }),
+  request(video, callback) {
+    if (typeof video.requestVideoFrameCallback !== "function") {
+      throw new Error("live.recognition.video_frames.unsupported");
+    }
+    return video.requestVideoFrameCallback((_now, metadata) =>
+      callback(metadata.mediaTime * 1_000),
+    );
+  },
+  cancel(video, requestId) {
+    video.cancelVideoFrameCallback(requestId);
+  },
+  capture: (video) => globalThis.createImageBitmap(video),
+};
 
 function bundleStatusMessage(status: ModelBundleStatus): string {
   const active =
@@ -50,14 +93,41 @@ function bundleStatusMessage(status: ModelBundleStatus): string {
   return `${status.failureReason ?? fallback}${active === null ? "" : ` ${active} remains active.`}`;
 }
 
+const livePhaseMessages = {
+  loading: "Preparing the on-device models.",
+  ready: "Models are ready. Hold still, then perform one gesture.",
+  watching: "Watching for the start of a gesture.",
+  recording: "Movement detected. Finish the gesture naturally.",
+  classifying: "Classifying the completed gesture.",
+  result: "Result ready. Hold still before the next gesture.",
+  failed: "Recognition stopped safely. Retry or restart the camera.",
+} as const;
+
+const readableLabel = (label: string) =>
+  label.replaceAll("_", " ").replace(/^./, (letter) => letter.toUpperCase());
+
+function decisionTitle(result: NonNullable<LiveRecognitionSnapshot["stableResult"]>): string {
+  if (!("label" in result.decision)) return "No confident match";
+  if (result.decision.kind === "other") return "Other movement";
+  return readableLabel(result.decision.label);
+}
+
+function decisionReason(result: NonNullable<LiveRecognitionSnapshot["stableResult"]>): string {
+  if (result.reason === "below_threshold") return "The model abstained because confidence was low.";
+  if (result.reason === "accepted_other") return "The event looked unlike the five target prompts.";
+  return "The top calibrated score passed the decision threshold.";
+}
+
 export function LivePage({
   cameraEnvironment,
   modelBundleUrl,
   modelBundleSession,
+  liveRuntime = browserLiveRuntime,
 }: {
   cameraEnvironment?: CameraEnvironment;
   modelBundleUrl?: string;
   modelBundleSession?: BundleLoader;
+  liveRuntime?: LiveRuntime;
 }) {
   const headingRef = usePageHeading(livePageDefinition.label);
   const videoRef = useRef<HTMLVideoElement>(null);
@@ -67,17 +137,22 @@ export function LivePage({
     [modelBundleSession],
   );
   const [bundleStatus, setBundleStatus] = useState(bundleLoader.status);
+  const [verifiedBundle, setVerifiedBundle] = useState<VerifiedModelBundle | null>(null);
+  const [liveSnapshot, setLiveSnapshot] = useState<LiveRecognitionSnapshot | null>(null);
+  const [runtimeAttempt, setRuntimeAttempt] = useState(0);
   const { state, canRequest, start, pause, resume, stop, switchCamera } =
     useCameraSession(cameraEnvironment);
 
   useEffect(() => {
     const configuredUrl = modelBundleUrl ?? import.meta.env.VITE_SIGNLAB_MODEL_BUNDLE_URL;
-    if (configuredUrl?.trim() === "") return;
-    if (configuredUrl === undefined) return;
+    if (configuredUrl === undefined || configuredUrl.trim() === "") return;
     let mounted = true;
     void bundleLoader
       .load(configuredUrl, (status) => {
         if (mounted) setBundleStatus(status);
+      })
+      .then((bundle) => {
+        if (mounted) setVerifiedBundle(bundle);
       })
       .catch(() => undefined);
     return () => {
@@ -94,8 +169,92 @@ export function LivePage({
     };
   }, [state.stream]);
 
+  useEffect(() => {
+    const video = videoRef.current;
+    if (
+      state.status !== "active" ||
+      state.stream === null ||
+      verifiedBundle === null ||
+      video === null
+    ) {
+      return;
+    }
+
+    let disposed = false;
+    let halted = false;
+    let frameRequestId: number | null = null;
+    let liveSession: LiveSession | null = null;
+    setLiveSnapshot({ phase: "loading", stableResult: null, failureCode: null });
+
+    const stopPump = () => {
+      halted = true;
+      if (frameRequestId !== null) liveRuntime.cancel(video, frameRequestId);
+      frameRequestId = null;
+    };
+    const failStartup = () => {
+      if (disposed) return;
+      stopPump();
+      setLiveSnapshot((previous) => ({
+        phase: "failed",
+        stableResult: previous?.stableResult ?? null,
+        failureCode: "live.recognition.startup.failed",
+      }));
+      void liveSession?.close();
+    };
+    const scheduleFrame = () => {
+      if (disposed || halted || liveSession === null) return;
+      try {
+        frameRequestId = liveRuntime.request(video, (captureTimestampMs) => {
+          frameRequestId = null;
+          void (async () => {
+            try {
+              const bitmap = await liveRuntime.capture(video);
+              if (disposed || halted) bitmap.close();
+              else liveSession?.submitFrame(bitmap, captureTimestampMs);
+            } catch {
+              failStartup();
+            }
+            if (!disposed && !halted) scheduleFrame();
+          })();
+        });
+      } catch {
+        failStartup();
+      }
+    };
+
+    void (async () => {
+      try {
+        const taskBuffers = await liveRuntime.loadAssets();
+        if (disposed) return;
+        liveSession = liveRuntime.createSession(verifiedBundle, taskBuffers, (snapshot) => {
+          if (disposed) return;
+          setLiveSnapshot(snapshot);
+          if (snapshot.phase === "failed") stopPump();
+        });
+        await liveSession.initialize();
+        if (disposed) await liveSession.close();
+        else scheduleFrame();
+      } catch {
+        failStartup();
+      }
+    })();
+
+    return () => {
+      disposed = true;
+      stopPump();
+      void liveSession?.close();
+    };
+  }, [liveRuntime, runtimeAttempt, state.status, state.stream, verifiedBundle]);
+
   const hasStream = state.stream !== null;
   const canStart = canRequest && startableStatuses.has(state.status);
+  const recognitionMessage =
+    liveSnapshot?.failureCode === "live.recognition.candidate.invalid"
+      ? "That event could not be classified. Hold still, then try again."
+      : state.status !== "active" || liveSnapshot === null
+        ? "Recognition starts when the camera and model are ready."
+        : livePhaseMessages[liveSnapshot.phase];
+  const stableResult = liveSnapshot?.stableResult ?? null;
 
   return (
     <section className="live-page" aria-labelledby="live-heading">
@@ -119,9 +278,14 @@ export function LivePage({
             {bundleStatusMessage(bundleStatus)}
           </StatusBanner>
         </div>
+        <div className="model-bundle-status">
+          <p className="card-label">Recognition</p>
+          <StatusBanner label="Recognition status">{recognitionMessage}</StatusBanner>
+        </div>
         <p className="page-note">
-          Model execution and recognition are not connected yet. Preview mirroring changes only what
-          you see, never the camera stream or future model coordinates.
+          Perform one prompt at a time with your hands and upper body in frame. Preview mirroring
+          changes only what you see; model coordinates remain unmirrored. This five-prompt research
+          prototype is not sign-language translation.
         </p>
       </div>
 
@@ -164,6 +328,11 @@ export function LivePage({
               Stop camera
             </button>
           ) : null}
+          {state.status === "active" && liveSnapshot?.phase === "failed" ? (
+            <button type="button" onClick={() => setRuntimeAttempt((attempt) => attempt + 1)}>
+              Retry recognition
+            </button>
+          ) : null}
         </div>
 
         {hasStream ? (
@@ -194,6 +363,36 @@ export function LivePage({
             </label>
           </div>
         ) : null}
+
+        {stableResult === null ? null : (
+          <section className="recognition-result" aria-label="Latest recognition result">
+            <p className="card-label">Latest event</p>
+            <strong>{decisionTitle(stableResult)}</strong>
+            <p>{decisionReason(stableResult)}</p>
+            <ol aria-label="Top calibrated scores">
+              {stableResult.rankedScores.slice(0, 3).map(({ label, confidence }) => (
+                <li key={label}>
+                  <span>{readableLabel(label)}</span>
+                  <span>{Math.round(confidence * 100)}%</span>
+                </li>
+              ))}
+            </ol>
+            <dl>
+              <div>
+                <dt>Latency</dt>
+                <dd>{Math.round(stableResult.timings.totalMs)} ms</dd>
+              </div>
+              <div>
+                <dt>Runtime</dt>
+                <dd>{stableResult.backend.toUpperCase()}</dd>
+              </div>
+              <div>
+                <dt>Bundle</dt>
+                <dd>{`${stableResult.bundle.id} ${stableResult.bundle.version}`}</dd>
+              </div>
+            </dl>
+          </section>
+        )}
       </div>
     </section>
   );
@@ -216,14 +415,14 @@ export function OverviewPage() {
             movement or uncertainty for a result.
           </p>
           <StatusBanner>
-            Browser interface in progress: local camera preview is available; model inference is not
-            connected yet.
+            Browser interface in progress: the private camera-to-result path now runs on-device;
+            replay and release checks remain.
           </StatusBanner>
         </div>
 
         <aside className="research-card" aria-label="Current research boundary">
           <p className="card-label">Current boundary</p>
-          <strong>Data ready. Evaluation next.</strong>
+          <strong>Live path connected. Evaluation next.</strong>
           <dl>
             <div>
               <dt>Vocabulary</dt>
@@ -235,7 +434,7 @@ export function OverviewPage() {
             </div>
             <div>
               <dt>Browser model</dt>
-              <dd>Pending</dd>
+              <dd>On-device</dd>
             </div>
           </dl>
         </aside>

--- a/apps/web/src/landmarks/landmarkModelAssets.test.ts
+++ b/apps/web/src/landmarks/landmarkModelAssets.test.ts
@@ -1,0 +1,106 @@
+import landmarkerConfig from "../../../../src/signlab/resources/extraction/config/mediapipe-extraction-config-1.default.json";
+import { describe, expect, it, vi } from "vitest";
+
+import { loadLandmarkModelAssets, type LandmarkModelAssetEnvironment } from "./landmarkModelAssets";
+
+const HAND_SIZE = landmarkerConfig.hand_task_asset.size_bytes;
+const POSE_SIZE = landmarkerConfig.pose_task_asset.size_bytes;
+const HAND_URL =
+  "https://storage.googleapis.com/mediapipe-models/hand_landmarker/hand_landmarker/float16/1/hand_landmarker.task?generation=1682480004222387";
+const POSE_URL =
+  "https://storage.googleapis.com/mediapipe-models/pose_landmarker/pose_landmarker_lite/float16/1/pose_landmarker_lite.task?generation=1682624736756847";
+
+function bytesForSha256(value: string): ArrayBuffer {
+  const hex = value.replace("sha256:", "");
+  return Uint8Array.from(hex.match(/.{2}/g) ?? [], (byte) => Number.parseInt(byte, 16)).buffer;
+}
+
+function digestForSize(size: number): ArrayBuffer {
+  return bytesForSha256(
+    size === HAND_SIZE
+      ? landmarkerConfig.hand_task_asset.sha256
+      : landmarkerConfig.pose_task_asset.sha256,
+  );
+}
+
+function mockSubtle(digest: SubtleCrypto["digest"]): SubtleCrypto {
+  return { digest } as unknown as SubtleCrypto;
+}
+
+function environment(
+  overrides: Partial<LandmarkModelAssetEnvironment> = {},
+): LandmarkModelAssetEnvironment {
+  return {
+    fetch: vi.fn((url: URL) => {
+      const size = url.href === HAND_URL ? HAND_SIZE : POSE_SIZE;
+      return Promise.resolve(new Response(new Uint8Array(size)));
+    }),
+    subtle: mockSubtle(
+      vi.fn((_algorithm: AlgorithmIdentifier, data: BufferSource) =>
+        Promise.resolve(digestForSize(data.byteLength)),
+      ),
+    ),
+    ...overrides,
+  };
+}
+
+async function expectedCode(promise: Promise<unknown>, code: string): Promise<void> {
+  await expect(promise).rejects.toThrow(code);
+}
+
+describe("loadLandmarkModelAssets", () => {
+  it("loads the exact supplied pair after checking canonical sizes and digests", async () => {
+    const injected = environment();
+
+    const result = await loadLandmarkModelAssets(injected);
+
+    expect(result.handModelBuffer.byteLength).toBe(HAND_SIZE);
+    expect(result.poseModelBuffer.byteLength).toBe(POSE_SIZE);
+    expect(injected.fetch).toHaveBeenCalledTimes(2);
+    expect(injected.fetch).toHaveBeenNthCalledWith(1, new URL(HAND_URL));
+    expect(injected.fetch).toHaveBeenNthCalledWith(2, new URL(POSE_URL));
+  });
+
+  it("rejects an exact-size mismatch without revealing its URL", async () => {
+    const injected = environment({
+      fetch: vi.fn(() => Promise.resolve(new Response(new Uint8Array(HAND_SIZE - 1)))),
+    });
+    const promise = loadLandmarkModelAssets(injected);
+
+    await expectedCode(promise, "landmark.models.size_mismatch");
+    await expect(promise).rejects.not.toThrow("models.example");
+  });
+
+  it("rejects a digest mismatch", async () => {
+    const injected = environment({
+      subtle: mockSubtle(vi.fn(() => Promise.resolve(new Uint8Array(32).buffer))),
+    });
+
+    await expectedCode(loadLandmarkModelAssets(injected), "landmark.models.digest_mismatch");
+  });
+
+  it("rejects unavailable or failing cryptography with one stable code", async () => {
+    const withoutCrypto = environment({ subtle: undefined });
+    await expectedCode(
+      loadLandmarkModelAssets(withoutCrypto),
+      "landmark.models.environment.unsupported",
+    );
+    expect(withoutCrypto.fetch).not.toHaveBeenCalled();
+    const subtle = mockSubtle(vi.fn(() => Promise.reject(new Error("implementation detail"))));
+    await expectedCode(
+      loadLandmarkModelAssets(environment({ subtle })),
+      "landmark.models.environment.unsupported",
+    );
+  });
+
+  it("sanitizes network and response failures", async () => {
+    for (const fetch of [
+      vi.fn(() => Promise.reject(new Error(`failed at ${HAND_URL}`))),
+      vi.fn(() => Promise.resolve(new Response(null, { status: 503 }))),
+    ]) {
+      const promise = loadLandmarkModelAssets(environment({ fetch }));
+      await expectedCode(promise, "landmark.models.unavailable");
+      await expect(promise).rejects.not.toThrow("models.example");
+    }
+  });
+});

--- a/apps/web/src/landmarks/landmarkModelAssets.ts
+++ b/apps/web/src/landmarks/landmarkModelAssets.ts
@@ -1,0 +1,71 @@
+import landmarkerConfig from "../../../../src/signlab/resources/extraction/config/mediapipe-extraction-config-1.default.json";
+
+export interface LandmarkModelAssetEnvironment {
+  readonly fetch: (input: URL) => Promise<Response>;
+  readonly subtle?: SubtleCrypto;
+}
+
+export interface LandmarkModelAssetBuffers {
+  readonly handModelBuffer: ArrayBuffer;
+  readonly poseModelBuffer: ArrayBuffer;
+}
+
+const TASKS = [
+  {
+    url: "https://storage.googleapis.com/mediapipe-models/hand_landmarker/hand_landmarker/float16/1/hand_landmarker.task?generation=1682480004222387",
+    spec: landmarkerConfig.hand_task_asset,
+  },
+  {
+    url: "https://storage.googleapis.com/mediapipe-models/pose_landmarker/pose_landmarker_lite/float16/1/pose_landmarker_lite.task?generation=1682624736756847",
+    spec: landmarkerConfig.pose_task_asset,
+  },
+] as const;
+
+function fail(code: string): never {
+  throw new Error(code);
+}
+
+function digestString(buffer: ArrayBuffer): string {
+  return `sha256:${Array.from(new Uint8Array(buffer), (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join("")}`;
+}
+
+async function loadOne(
+  task: (typeof TASKS)[number],
+  environment: LandmarkModelAssetEnvironment,
+): Promise<ArrayBuffer> {
+  let buffer: ArrayBuffer;
+  try {
+    const response = await environment.fetch(new URL(task.url));
+    if (!response.ok) fail("landmark.models.unavailable");
+    buffer = await response.arrayBuffer();
+  } catch {
+    fail("landmark.models.unavailable");
+  }
+  if (buffer.byteLength !== task.spec.size_bytes) fail("landmark.models.size_mismatch");
+
+  let digest: ArrayBuffer;
+  try {
+    if (environment.subtle === undefined) fail("landmark.models.environment.unsupported");
+    digest = await environment.subtle.digest("SHA-256", new Uint8Array(buffer));
+  } catch {
+    fail("landmark.models.environment.unsupported");
+  }
+  if (digestString(digest) !== task.spec.sha256) fail("landmark.models.digest_mismatch");
+  return buffer;
+}
+
+export async function loadLandmarkModelAssets(
+  environment: LandmarkModelAssetEnvironment = {
+    fetch: (input) => globalThis.fetch(input),
+    subtle: globalThis.crypto?.subtle,
+  },
+): Promise<LandmarkModelAssetBuffers> {
+  if (environment.subtle === undefined) fail("landmark.models.environment.unsupported");
+  const [handModelBuffer, poseModelBuffer] = await Promise.all([
+    loadOne(TASKS[0], environment),
+    loadOne(TASKS[1], environment),
+  ]);
+  return { handModelBuffer, poseModelBuffer };
+}

--- a/apps/web/src/live/liveRecognitionSession.test.ts
+++ b/apps/web/src/live/liveRecognitionSession.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it, vi } from "vitest";
+
+import config from "../../../../configs/evaluation/candidate-event-detector-v1.json";
+import type { CandidateInferenceClientEvent } from "../inference/CandidateInferenceWorkerClient";
+import {
+  CANDIDATE_INFERENCE_PROTOCOL_VERSION,
+  type CandidateInferenceInput,
+  type CandidateInferenceResult,
+} from "../inference/candidateInferenceProtocol";
+import type { LandmarkClientEvent } from "../landmarks/LandmarkWorkerClient";
+import {
+  LANDMARK_WORKER_PROTOCOL_VERSION,
+  absentBodyAnchors,
+  absentHandSlots,
+  type HandSlot,
+  type LandmarkFrameMessage,
+  type LandmarkPoint,
+} from "../landmarks/protocol";
+import type { VerifiedModelBundle } from "../modelBundle/modelBundleSession";
+import {
+  LiveRecognitionSession,
+  type LiveInferenceClient,
+  type LiveLandmarkClient,
+  type LiveRecognitionSnapshot,
+} from "./liveRecognitionSession";
+
+const SEGMENTER_SHA256 = "sha256:0443badf68d34347a00096682cf049b6f49b5253c12e47bf61b068a597aa162d";
+const QUALITY_SHA256 = "sha256:680b0904e1cc5d8e03119032e92920a3a0185917a600c4293323b7925da9a545";
+
+const bundle = {
+  id: "test-bundle",
+  version: "1",
+  manifest: {
+    components: {
+      segmenter_sha256: SEGMENTER_SHA256,
+      quality_policy_sha256: QUALITY_SHA256,
+    },
+  },
+  bytesByRole: { segmenter: new Blob([JSON.stringify(config)]) },
+} as unknown as VerifiedModelBundle;
+
+const point = (x: number): LandmarkPoint => ({
+  x,
+  y: 0,
+  z: 0,
+  visibility: null,
+  presence: null,
+});
+
+function hand(x: number): HandSlot {
+  const landmarks = Array.from({ length: 21 }, () => point(x));
+  return {
+    slotId: "hand_0",
+    present: true,
+    detectorIndex: 0,
+    trackingId: "hand_0",
+    handedness: "left",
+    handednessConfidence: 0.9,
+    imageLandmarks: landmarks,
+    worldLandmarks: landmarks,
+  };
+}
+
+function frame(
+  frameId: number,
+  timestampUs: number,
+  x: number | null,
+  valid = true,
+): LandmarkFrameMessage {
+  const hands = absentHandSlots();
+  const base = {
+    type: "frame" as const,
+    protocolVersion: LANDMARK_WORKER_PROTOCOL_VERSION,
+    frameId,
+    relativeTimestampUs: timestampUs,
+    taskTimestampMs: Math.floor(timestampUs / 1_000),
+    hands: x === null ? hands : ([hand(x), hands[1]] as const),
+    bodyAnchors: absentBodyAnchors(),
+    processingMs: 1,
+    failureCount: 0,
+  };
+  return valid
+    ? { ...base, valid: true, invalidReason: null, failureCode: null }
+    : {
+        ...base,
+        valid: false,
+        invalidReason: "task_inference_failed",
+        failureCode: "extraction.runtime.inference.failed",
+      };
+}
+
+const result = (requestId: number): CandidateInferenceResult => ({
+  type: "result",
+  protocolVersion: CANDIDATE_INFERENCE_PROTOCOL_VERSION,
+  requestId,
+  bundle: { id: bundle.id, version: bundle.version },
+  backend: "wasm",
+  decision: { kind: "target", label: "hello", confidence: 0.9 },
+  reason: "accepted_target",
+  rankedScores: [{ label: "hello", confidence: 0.9 }],
+  timings: { preprocessingMs: 1, inferenceMs: 2, decisionMs: 1, totalMs: 4 },
+});
+
+function harness() {
+  let emitLandmark: (event: LandmarkClientEvent) => void = () => undefined;
+  let emitInference: (event: CandidateInferenceClientEvent) => void = () => undefined;
+  let frameId = 0;
+  const snapshots: LiveRecognitionSnapshot[] = [];
+  const classifyCalls: Array<{ requestId: number; input: CandidateInferenceInput }> = [];
+  const landmark: LiveLandmarkClient = {
+    initialize: vi.fn(() =>
+      emitLandmark({
+        type: "ready",
+        protocolVersion: LANDMARK_WORKER_PROTOCOL_VERSION,
+        startupMs: 1,
+        failureCount: 0,
+      }),
+    ),
+    submitFrame: vi.fn(() => frameId++),
+    close: vi.fn(() => Promise.resolve()),
+  };
+  const inference: LiveInferenceClient = {
+    initialize: vi.fn(() => {
+      emitInference({
+        type: "ready",
+        protocolVersion: CANDIDATE_INFERENCE_PROTOCOL_VERSION,
+        bundle: { id: bundle.id, version: bundle.version },
+        backend: "wasm",
+        startupMs: 1,
+      });
+      return Promise.resolve();
+    }),
+    classify: vi.fn((requestId: number, input: CandidateInferenceInput) =>
+      classifyCalls.push({ requestId, input }),
+    ),
+    close: vi.fn(),
+  };
+  const session = new LiveRecognitionSession({
+    bundle,
+    taskBuffers: { handModelBuffer: new ArrayBuffer(1), poseModelBuffer: new ArrayBuffer(1) },
+    onState: (snapshot) => snapshots.push(snapshot),
+    createLandmarkClient: (onEvent) => {
+      emitLandmark = onEvent;
+      return landmark;
+    },
+    createInferenceClient: (onEvent) => {
+      emitInference = onEvent;
+      return inference;
+    },
+  });
+  return {
+    session,
+    snapshots,
+    classifyCalls,
+    landmark,
+    inference,
+    emitLandmark: (event: LandmarkClientEvent) => emitLandmark(event),
+    emitInference: (event: CandidateInferenceClientEvent) => emitInference(event),
+  };
+}
+
+function emitActiveEvent(emit: (event: LandmarkClientEvent) => void, invalidInside = false): void {
+  [0, 50_000, 100_000, 150_000, 200_000].forEach((timestampUs, index) =>
+    emit(frame(index, timestampUs, index * 0.05)),
+  );
+  if (invalidInside) {
+    emit(frame(5, 225_000, null, false));
+    emit(frame(6, 250_000, 0.25));
+    [275_000, 300_000, 325_000].forEach((timestampUs, offset) =>
+      emit(frame(offset + 7, timestampUs, null, false)),
+    );
+  } else {
+    [225_000, 250_000, 275_000].forEach((timestampUs, offset) =>
+      emit(frame(offset + 5, timestampUs, null, false)),
+    );
+  }
+}
+
+describe("LiveRecognitionSession", () => {
+  it("classifies one exact event with rebased frames and publishes its result", async () => {
+    const runtime = harness();
+    await runtime.session.initialize();
+    expect(runtime.snapshots.at(-1)?.phase).toBe("ready");
+
+    emitActiveEvent(runtime.emitLandmark);
+
+    expect(runtime.classifyCalls).toHaveLength(1);
+    const request = runtime.classifyCalls[0]!;
+    expect(request.input.frames.map((candidate) => candidate.relativeTimestampUs)).toEqual([
+      0, 50_000, 100_000, 150_000, 200_000,
+    ]);
+    expect(request.input).toMatchObject({
+      sourceMirrorState: "not_mirrored",
+      quality: { timestampDiscontinuityCount: 0, gaps: [] },
+    });
+    expect(runtime.snapshots.at(-1)?.phase).toBe("classifying");
+
+    const stable = result(request.requestId);
+    runtime.emitInference(stable);
+    expect(runtime.snapshots.at(-1)).toMatchObject({ phase: "result", stableResult: stable });
+  });
+
+  it("discards an event containing an invalid frame without classifying", async () => {
+    const runtime = harness();
+    await runtime.session.initialize();
+    emitActiveEvent(runtime.emitLandmark, true);
+    expect(runtime.classifyCalls).toHaveLength(0);
+    expect(runtime.snapshots.at(-1)).toMatchObject({
+      phase: "result",
+      stableResult: null,
+      failureCode: "live.recognition.candidate.invalid",
+    });
+  });
+
+  it("keeps only the configured timestamp window", async () => {
+    const runtime = harness();
+    await runtime.session.initialize();
+    for (let index = 0; index <= 10; index += 1) {
+      runtime.emitLandmark(frame(index, index * 1_000_000, null));
+    }
+    expect(Reflect.get(runtime.session, "bufferedFrames")).toHaveLength(5);
+  });
+
+  it("keeps the last result stable while watching the next frames", async () => {
+    const runtime = harness();
+    await runtime.session.initialize();
+    emitActiveEvent(runtime.emitLandmark);
+    const stable = result(runtime.classifyCalls[0]!.requestId);
+    runtime.emitInference(stable);
+    runtime.emitLandmark(frame(20, 500_000, null));
+    expect(runtime.snapshots.at(-1)).toMatchObject({ phase: "watching", stableResult: stable });
+  });
+
+  it("fails closed, clears buffered data, and closes both workers", async () => {
+    const runtime = harness();
+    await runtime.session.initialize();
+    runtime.emitLandmark(frame(0, 0, null));
+    runtime.emitLandmark({
+      type: "failure",
+      protocolVersion: LANDMARK_WORKER_PROTOCOL_VERSION,
+      stage: "protocol",
+      code: "extraction.protocol.invalid",
+      failureCount: 1,
+    });
+
+    expect(runtime.snapshots.at(-1)).toMatchObject({
+      phase: "failed",
+      failureCode: "extraction.protocol.invalid",
+    });
+    expect(Reflect.get(runtime.session, "bufferedFrames")).toHaveLength(0);
+    expect(runtime.landmark.close).toHaveBeenCalledOnce();
+    expect(runtime.inference.close).toHaveBeenCalledOnce();
+    await runtime.session.close();
+    expect(runtime.landmark.close).toHaveBeenCalledOnce();
+    expect(runtime.inference.close).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/live/liveRecognitionSession.ts
+++ b/apps/web/src/live/liveRecognitionSession.ts
@@ -1,0 +1,254 @@
+import {
+  createCandidateInferenceWorkerClient,
+  type CandidateInferenceClientEvent,
+  type CandidateInferenceWorkerClient,
+} from "../inference/CandidateInferenceWorkerClient";
+import {
+  CandidateObservationProjector,
+  createCandidateEventDetector,
+  type CandidateEvent,
+  type CandidateEventDetector,
+} from "../inference/candidateEvents";
+import type {
+  CandidateInferenceInput,
+  CandidateInferenceResult,
+} from "../inference/candidateInferenceProtocol";
+import {
+  createLandmarkWorkerClient,
+  type LandmarkClientEvent,
+  type LandmarkWorkerClient,
+} from "../landmarks/LandmarkWorkerClient";
+import type { LandmarkModelAssetBuffers } from "../landmarks/landmarkModelAssets";
+import type { LandmarkFrameMessage } from "../landmarks/protocol";
+import type { VerifiedModelBundle } from "../modelBundle/modelBundleSession";
+
+export type LiveRecognitionPhase =
+  "loading" | "ready" | "watching" | "recording" | "classifying" | "result" | "failed";
+
+export interface LiveRecognitionSnapshot {
+  readonly phase: LiveRecognitionPhase;
+  readonly stableResult: CandidateInferenceResult | null;
+  readonly failureCode: string | null;
+}
+
+export type LiveLandmarkClient = Pick<LandmarkWorkerClient, "initialize" | "submitFrame" | "close">;
+export type LiveInferenceClient = Pick<
+  CandidateInferenceWorkerClient,
+  "initialize" | "classify" | "close"
+>;
+type Factory<Event, Client> = (onEvent: (event: Event) => void) => Client;
+
+export interface LiveRecognitionSessionOptions {
+  readonly bundle: VerifiedModelBundle;
+  readonly taskBuffers: LandmarkModelAssetBuffers;
+  readonly onState: (snapshot: LiveRecognitionSnapshot) => void;
+  readonly createLandmarkClient?: Factory<LandmarkClientEvent, LiveLandmarkClient>;
+  readonly createInferenceClient?: Factory<CandidateInferenceClientEvent, LiveInferenceClient>;
+}
+
+type BufferedFrame = readonly [detectorIndex: number, frame: LandmarkFrameMessage];
+
+const QUALITY_EVIDENCE = { timestampDiscontinuityCount: 0, gaps: [] } as const;
+const INITIAL_SNAPSHOT = { phase: "loading", stableResult: null, failureCode: null } as const;
+
+export class LiveRecognitionSession {
+  private snapshotValue: LiveRecognitionSnapshot = INITIAL_SNAPSHOT;
+  private readonly projector = new CandidateObservationProjector();
+  private detector: CandidateEventDetector | null = null;
+  private landmarkClient: LiveLandmarkClient | null = null;
+  private inferenceClient: LiveInferenceClient | null = null;
+  private readyWorkers = 0;
+  private closed = false;
+  private landmarkClosePromise: Promise<void> = Promise.resolve();
+  private nextDetectorIndex = 0;
+  private nextRequestId = 0;
+  private activeRequestId: number | null = null;
+  private bufferedFrames: BufferedFrame[] = [];
+  private retentionUs = 0;
+
+  constructor(private readonly options: LiveRecognitionSessionOptions) {
+    options.onState(this.snapshotValue);
+  }
+
+  async initialize(): Promise<void> {
+    try {
+      this.detector = await createCandidateEventDetector(this.options.bundle);
+      if (this.closed) return;
+      const config = this.detector.config;
+      this.retentionUs =
+        config.maximum_event_duration_us +
+        config.pre_roll_us +
+        config.finalization_duration_us +
+        config.maximum_gap_us;
+      const landmarkFactory = this.options.createLandmarkClient ?? createLandmarkWorkerClient;
+      const inferenceFactory =
+        this.options.createInferenceClient ?? createCandidateInferenceWorkerClient;
+      this.landmarkClient = landmarkFactory((event) => this.handleLandmarkEvent(event));
+      this.inferenceClient = inferenceFactory((event) => this.handleInferenceEvent(event));
+      this.landmarkClient.initialize(
+        this.options.taskBuffers.handModelBuffer,
+        this.options.taskBuffers.poseModelBuffer,
+      );
+      await this.inferenceClient.initialize(this.options.bundle);
+    } catch {
+      this.fail("live.recognition.initialization.failed");
+    }
+  }
+
+  submitFrame(frame: ImageBitmap, captureTimestampMs: number): number | null {
+    if (
+      this.closed ||
+      this.landmarkClient === null ||
+      ["failed", "loading", "classifying"].includes(this.snapshotValue.phase)
+    ) {
+      frame.close();
+      return null;
+    }
+    if (["ready", "result"].includes(this.snapshotValue.phase)) this.publish("watching");
+    try {
+      return this.landmarkClient.submitFrame(frame, captureTimestampMs);
+    } catch {
+      this.fail("live.recognition.frame_submission.failed");
+      return null;
+    }
+  }
+
+  close(): Promise<void> {
+    if (!this.closed) {
+      this.closed = true;
+      this.bufferedFrames = [];
+      this.projector.reset();
+      if (this.snapshotValue.phase !== "failed") this.closeClients();
+    }
+    return this.landmarkClosePromise;
+  }
+
+  private handleLandmarkEvent(event: LandmarkClientEvent): void {
+    if (this.closed || this.snapshotValue.phase === "failed") return;
+    switch (event.type) {
+      case "ready":
+        if (++this.readyWorkers === 2) this.publish("ready");
+        return;
+      case "frame-dropped":
+        return;
+      case "frame":
+        if (this.snapshotValue.phase !== "classifying") this.handleLandmarkFrame(event);
+        return;
+      case "failure":
+      case "worker-transport-failure":
+        return this.fail(event.code);
+      default:
+        return this.fail("live.recognition.landmark_worker.stopped");
+    }
+  }
+
+  private handleLandmarkFrame(frame: LandmarkFrameMessage): void {
+    const detector = this.detector!;
+    try {
+      const detectorIndex = this.nextDetectorIndex++;
+      this.bufferedFrames.push([detectorIndex, frame]);
+      const cutoff = frame.relativeTimestampUs - this.retentionUs;
+      while ((this.bufferedFrames[0]?.[1].relativeTimestampUs ?? cutoff) < cutoff)
+        this.bufferedFrames.shift();
+      const event = detector.push(this.projector.project(frame));
+      if (event !== null) this.classify(event);
+      else
+        this.publish(
+          ["arming", "recording", "finalizing"].includes(detector.state) ? "recording" : "watching",
+        );
+    } catch {
+      this.fail("live.recognition.landmark_frame.invalid");
+    }
+  }
+
+  private classify(event: CandidateEvent): void {
+    const input = this.buildInput(event);
+    while ((this.bufferedFrames[0]?.[0] ?? event.lastFrameIndex + 1) <= event.lastFrameIndex)
+      this.bufferedFrames.shift();
+    if (input === null) return this.publish("result", null, "live.recognition.candidate.invalid");
+    const client = this.inferenceClient;
+    if (client === null || this.activeRequestId !== null)
+      return this.fail("live.recognition.inference.unavailable");
+    const requestId = this.nextRequestId++;
+    this.activeRequestId = requestId;
+    this.publish("classifying");
+    try {
+      client.classify(requestId, input);
+    } catch {
+      this.fail("live.recognition.classification.failed");
+    }
+  }
+
+  private buildInput(event: CandidateEvent): CandidateInferenceInput | null {
+    const expectedCount = event.lastFrameIndex - event.firstFrameIndex + 1;
+    const frames = this.bufferedFrames.filter(
+      ([index]) => index >= event.firstFrameIndex && index <= event.lastFrameIndex,
+    );
+    if (
+      expectedCount <= 0 ||
+      frames.length !== expectedCount ||
+      frames[0]?.[1].relativeTimestampUs !== event.firstTimestampUs ||
+      frames.at(-1)?.[1].relativeTimestampUs !== event.lastTimestampUs ||
+      frames.some(
+        ([detectorIndex, frame], index) =>
+          detectorIndex !== event.firstFrameIndex + index ||
+          !frame.valid ||
+          (index > 0 && frame.relativeTimestampUs <= frames[index - 1]![1].relativeTimestampUs),
+      )
+    )
+      return null;
+    const firstTimestampUs = frames[0][1].relativeTimestampUs;
+    return {
+      frames: frames.map(([, frame]) => ({
+        relativeTimestampUs: frame.relativeTimestampUs - firstTimestampUs,
+        valid: frame.valid,
+        hands: frame.hands,
+        bodyAnchors: frame.bodyAnchors,
+      })),
+      sourceMirrorState: "not_mirrored",
+      quality: QUALITY_EVIDENCE,
+    };
+  }
+
+  private handleInferenceEvent(event: CandidateInferenceClientEvent): void {
+    if (this.closed || this.snapshotValue.phase === "failed") return;
+    switch (event.type) {
+      case "ready":
+        if (++this.readyWorkers === 2) this.publish("ready");
+        return;
+      case "result":
+        if (event.requestId !== this.activeRequestId)
+          return this.fail("live.recognition.inference.result_mismatch");
+        this.activeRequestId = null;
+        return this.publish("result", event);
+      case "failure":
+      case "worker-transport-failure":
+        return this.fail(event.code);
+      default:
+        return this.fail("live.recognition.inference_worker.stopped");
+    }
+  }
+
+  private publish(
+    phase: LiveRecognitionPhase,
+    stableResult = this.snapshotValue.stableResult,
+    failureCode: string | null = null,
+  ): void {
+    this.snapshotValue = Object.freeze({ phase, stableResult, failureCode });
+    this.options.onState(this.snapshotValue);
+  }
+
+  private fail(code: string): void {
+    if (this.closed || this.snapshotValue.phase === "failed") return;
+    this.bufferedFrames = [];
+    this.projector.reset();
+    this.activeRequestId = null;
+    this.publish("failed", this.snapshotValue.stableResult, code);
+    this.closeClients();
+  }
+
+  private closeClients(): void {
+    this.inferenceClient?.close();
+    this.landmarkClosePromise = this.landmarkClient?.close() ?? Promise.resolve();
+  }
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -471,6 +471,55 @@ h1 {
   accent-color: #e8623c;
 }
 
+.recognition-result {
+  padding: 1rem;
+  margin-top: 1rem;
+  border: 1px solid rgb(242 241 233 / 18%);
+  border-radius: 1rem;
+  background: rgb(9 27 26 / 72%);
+}
+
+.recognition-result > strong {
+  display: block;
+  color: #f5a58b;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 2rem;
+  font-weight: 500;
+  letter-spacing: -0.03em;
+}
+
+.recognition-result > p:not(.card-label) {
+  color: #adc0bd;
+}
+
+.recognition-result ol {
+  padding: 0;
+  margin: 1rem 0;
+  list-style: none;
+}
+
+.recognition-result li,
+.recognition-result dl div {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.45rem 0;
+  border-top: 1px solid rgb(242 241 233 / 12%);
+}
+
+.recognition-result dl {
+  margin: 0;
+  color: #adc0bd;
+  font-size: 0.78rem;
+}
+
+.recognition-result dd {
+  margin: 0;
+  color: #f2f1e9;
+  overflow-wrap: anywhere;
+  text-align: right;
+}
+
 .content-page h1 {
   max-width: 13ch;
   font-size: clamp(3.2rem, 7vw, 6.5rem);

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -42,10 +42,11 @@ configured subpath without server-side route rewrites.
 The feature routes describe their intended behavior but deliberately do not imitate
 unfinished features. The live route requests camera permission only after an explicit
 user action and can show a local preview. It stops camera tracks on stop, navigation,
-page hiding, or device interruption; it does not upload, record, persist, or submit
-frames to the worker. The shell makes no runtime data request, loads no model, reads
-no replay input, and stores no feedback. Those capabilities retain separate evidence
-gates.
+page hiding, or device interruption. After a bundle is verified, it loads the two
+size- and digest-pinned MediaPipe task files, sends disposable frame bitmaps through
+the landmark worker, detects one bounded event, and runs ONNX inference in a second
+worker. It does not upload, record, or persist camera frames or landmarks. Replay and
+feedback remain disconnected and retain separate evidence gates.
 
 The intended bundle-loading flow is manifest-first:
 
@@ -57,13 +58,14 @@ Static model-bundle files
   -> expose readiness or a clear failure to the route UI
 ```
 
-The shell now contains a dormant `@mediapipe/tasks-vision@1.0.1` landmark worker.
-It initializes one hand/pose task pair from externally verified buffers, returns
+The shell uses one `@mediapipe/tasks-vision@1.0.1` landmark worker. It initializes one
+hand/pose task pair from externally verified buffers, returns
 typed timestamps, two-hand slots, six body anchors, validity, and confidence, keeps
 only the newest waiting frame, emits sanitized timing/drop/failure measurements, and
-releases replaced or processed images and task resources. The camera preview remains
-disconnected from that worker. Bundle verification and loading, replay input, ONNX
-inference, and event detection remain separate gates; no browser model is usable yet.
+releases replaced or processed images and task resources. A bounded live coordinator
+feeds those frames through the shared event detector and the WASM ONNX worker, then
+keeps one event-level decision stable in the React view. Replay remains a separate
+gate and will exercise this assembled post-landmark path rather than a parallel one.
 
 The [licensed external-data boundary](external-datasets.md) is intentionally
 separate from participant ingest. It registers source, license, attribution,


### PR DESCRIPTION
Closes #47

## What changed

- retain the verified browser bundle and load the exact pinned MediaPipe task assets with byte-size and SHA-256 verification
- connect camera frames through the existing landmark worker, event detector, bounded event slice, and inference worker
- show stable target, other, or abstain results with calibrated scores, latency, backend, and bundle identity
- fail closed and release workers, buffered landmarks, pending callbacks, and late bitmaps on stop, pause, switch, retry, hide, or unmount

## Scope checkpoint

- 498 nonblank added production TypeScript/TSX lines (target: no more than 500)
- two narrow production modules
- replay, diagnostics, history, storage, overlays, and polish remain deferred

## Verification

- 98 web tests passed, including 25 focused live-path tests
- TypeScript, ESLint, and Prettier passed
- root-domain and `/signlab/` production builds passed
- repository hygiene and candidate-runtime golden checks passed
- two independent final reviews found no correctness, lifecycle, privacy, test, or scope blockers

The automated browser integration test exercises callback → bitmap → session submission and proves that a bitmap resolving after camera stop is closed rather than submitted.