### PR TITLE
Polish the live demo experience

### DIFF
--- a/apps/web/src/app/LivePage.test.tsx
+++ b/apps/web/src/app/LivePage.test.tsx
@@ -100,6 +100,15 @@ describe("consent-first camera preview", () => {
     expect(
       screen.getByText(/asks for permission only after you select Start camera/),
     ).toBeVisible();
+    expect(screen.getByRole("heading", { name: "How to try it" })).toBeVisible();
+    expect(
+      screen.getByText(/Choose one prompt: Hello, No, Please, Thank you, or Yes/),
+    ).toBeVisible();
+    expect(screen.getByText(/even light facing you, not behind you/)).toBeVisible();
+    expect(screen.getByRole("link", { name: "Read its limitations." })).toHaveAttribute(
+      "href",
+      "#/limitations",
+    );
     expect(screen.getByRole("status", { name: "Model bundle status" })).toHaveTextContent(
       "No model bundle is configured.",
     );
@@ -357,6 +366,34 @@ describe("model bundle status", () => {
     expect(await screen.findByText(message)).toBeVisible();
     expect(loader.load).toHaveBeenCalledOnce();
   });
+
+  it("retries a blocked bundle load without reloading the page", async () => {
+    const bundle = { id: "browser-candidate", version: "1.0.0" } as VerifiedModelBundle;
+    let attempt = 0;
+    const load: ModelBundleSession["load"] = (_url, onStatus) => {
+      attempt += 1;
+      if (attempt === 1) {
+        onStatus?.({
+          phase: "error",
+          active: null,
+          failureReason: "The model bundle could not be downloaded.",
+        });
+        return Promise.reject(new Error("simulated download failure"));
+      }
+      onStatus?.({ phase: "ready", active: { id: bundle.id, version: bundle.version } });
+      return Promise.resolve(bundle);
+    };
+    const loader: Pick<ModelBundleSession, "load" | "status"> = {
+      status: { phase: "idle", active: null },
+      load: vi.fn(load),
+    };
+
+    render(<LivePage modelBundleUrl="https://example.test/bundle/" modelBundleSession={loader} />);
+    fireEvent.click(await screen.findByRole("button", { name: "Retry setup" }));
+
+    await waitFor(() => expect(loader.load).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText(/Verified model bundle browser-candidate/)).toBeVisible();
+  });
 });
 
 const resultCases = [
@@ -458,9 +495,17 @@ describe("live on-device result", () => {
       await screen.findByText(/Models are ready/);
       act(() => {
         emit({
-          phase: "result",
+          phase: "recording",
           stableResult: inferenceResult(decision, reason),
           failureCode: null,
+          diagnostics: {
+            detectorState: "recording",
+            landmarkState: "usable",
+            detectedHands: 2,
+            droppedFrames: 3,
+            backend: "wasm",
+            bundle: { id: bundle.id, version: bundle.version },
+          },
         });
       });
 
@@ -470,6 +515,14 @@ describe("live on-device result", () => {
       expect(screen.getByText("8 ms")).toBeVisible();
       expect(within(resultCard).getByText("WASM")).toBeVisible();
       expect(within(resultCard).getByText("browser-candidate 1.0.0")).toBeVisible();
+      expect(within(resultCard).getByText(/stronger model matches, not guarantees/)).toBeVisible();
+      fireEvent.click(screen.getByText("Session diagnostics"));
+      const diagnostics = screen.getByLabelText("Session diagnostics");
+      expect(within(diagnostics).getAllByText("Gesture in progress")).toHaveLength(2);
+      expect(within(diagnostics).getByText("2 hands detected")).toBeVisible();
+      expect(within(diagnostics).getByText("3")).toBeVisible();
+      expect(within(diagnostics).getByText("WASM")).toBeVisible();
+      expect(within(diagnostics).getByText("browser-candidate 1.0.0")).toBeVisible();
       fireEvent.click(screen.getByRole("button", { name: "Stop camera" }));
       await waitFor(() => expect(close).toHaveBeenCalledOnce());
       expect(frameSource.cancel).toHaveBeenCalledWith(expect.any(HTMLVideoElement), 7);
@@ -538,6 +591,69 @@ describe("live on-device result", () => {
     expect(submitFrame).toHaveBeenCalledOnce();
   });
 
+  it("keeps the last diagnostics when frame capture fails", async () => {
+    const devices = new TestMediaDevices();
+    devices.getUserMedia.mockResolvedValue(cameraStream("front").stream);
+    devices.enumerateDevices.mockResolvedValue([]);
+    const bundle = { id: "browser-candidate", version: "1.0.0" } as VerifiedModelBundle;
+    const callbacks: Array<(timestampMs: number) => void> = [];
+    const liveRuntime: TestLiveRuntime = {
+      loadAssets: () =>
+        Promise.resolve({
+          handModelBuffer: new ArrayBuffer(1),
+          poseModelBuffer: new ArrayBuffer(1),
+        }),
+      createSession: (_bundle, _buffers, onState) => ({
+        initialize: () => {
+          onState({
+            phase: "ready",
+            stableResult: null,
+            failureCode: null,
+            diagnostics: {
+              detectorState: "inactive",
+              landmarkState: "usable",
+              detectedHands: 1,
+              droppedFrames: 4,
+              backend: "wasm",
+              bundle: { id: bundle.id, version: bundle.version },
+            },
+          });
+          return Promise.resolve();
+        },
+        submitFrame: vi.fn(),
+        close: vi.fn(() => Promise.resolve()),
+      }),
+      request: vi.fn((_video: HTMLVideoElement, callback: (timestampMs: number) => void) => {
+        callbacks.push(callback);
+        return callbacks.length;
+      }),
+      cancel: vi.fn(),
+      capture: vi.fn(() => Promise.reject(new Error("simulated capture failure"))),
+    };
+
+    render(
+      <LivePage
+        cameraEnvironment={cameraEnvironment(devices).environment}
+        modelBundleUrl="https://example.test/bundle/"
+        modelBundleSession={{
+          status: { phase: "ready", active: { id: bundle.id, version: bundle.version } },
+          load: vi.fn(() => Promise.resolve(bundle)),
+        }}
+        liveRuntime={liveRuntime}
+      />,
+    );
+
+    await startCamera();
+    await waitFor(() => expect(callbacks).toHaveLength(1));
+    act(() => callbacks[0]!(1_250));
+    await screen.findByRole("button", { name: "Retry setup" });
+    fireEvent.click(screen.getByText("Session diagnostics"));
+    const diagnostics = screen.getByLabelText("Session diagnostics");
+    expect(within(diagnostics).getByText("Inactive")).toBeVisible();
+    expect(within(diagnostics).getByText("1 hand detected")).toBeVisible();
+    expect(within(diagnostics).getByText("4")).toBeVisible();
+  });
+
   it("recreates a failed runtime when the user retries", async () => {
     const devices = new TestMediaDevices();
     devices.getUserMedia.mockResolvedValue(cameraStream("front").stream);
@@ -578,8 +694,12 @@ describe("live on-device result", () => {
     );
 
     await startCamera();
-    const retry = await screen.findByRole("button", { name: "Retry recognition" });
+    const retry = await screen.findByRole("button", { name: "Retry setup" });
     fireEvent.click(retry);
     await waitFor(() => expect(factory).toHaveBeenCalledTimes(2));
+    fireEvent.click(screen.getByRole("button", { name: "Stop camera" }));
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: "Retry setup" })).not.toBeInTheDocument(),
+    );
   });
 });

--- a/apps/web/src/app/routes.tsx
+++ b/apps/web/src/app/routes.tsx
@@ -13,6 +13,7 @@ import {
 } from "../landmarks/landmarkModelAssets";
 import {
   LiveRecognitionSession,
+  type LiveRecognitionDiagnostics,
   type LiveRecognitionSnapshot,
 } from "../live/liveRecognitionSession";
 import {
@@ -106,6 +107,9 @@ const livePhaseMessages = {
 const readableLabel = (label: string) =>
   label.replaceAll("_", " ").replace(/^./, (letter) => letter.toUpperCase());
 
+const diagnosticStateLabel = (state: string) =>
+  state === "recording" ? "Gesture in progress" : readableLabel(state);
+
 function decisionTitle(result: NonNullable<LiveRecognitionSnapshot["stableResult"]>): string {
   if (!("label" in result.decision)) return "No confident match";
   if (result.decision.kind === "other") return "Other movement";
@@ -116,6 +120,14 @@ function decisionReason(result: NonNullable<LiveRecognitionSnapshot["stableResul
   if (result.reason === "below_threshold") return "The model abstained because confidence was low.";
   if (result.reason === "accepted_other") return "The event looked unlike the five target prompts.";
   return "The top calibrated score passed the decision threshold.";
+}
+
+function landmarkSummary(diagnostics: LiveRecognitionDiagnostics | undefined): string {
+  if (diagnostics === undefined || diagnostics.landmarkState === "waiting")
+    return "Waiting for frames";
+  if (diagnostics.landmarkState === "invalid") return "Latest frame unavailable";
+  if (diagnostics.landmarkState === "no_hands") return "No hands detected";
+  return `${diagnostics.detectedHands} ${diagnostics.detectedHands === 1 ? "hand" : "hands"} detected`;
 }
 
 export function LivePage({
@@ -139,6 +151,7 @@ export function LivePage({
   const [bundleStatus, setBundleStatus] = useState(bundleLoader.status);
   const [verifiedBundle, setVerifiedBundle] = useState<VerifiedModelBundle | null>(null);
   const [liveSnapshot, setLiveSnapshot] = useState<LiveRecognitionSnapshot | null>(null);
+  const [bundleAttempt, setBundleAttempt] = useState(0);
   const [runtimeAttempt, setRuntimeAttempt] = useState(0);
   const { state, canRequest, start, pause, resume, stop, switchCamera } =
     useCameraSession(cameraEnvironment);
@@ -158,7 +171,7 @@ export function LivePage({
     return () => {
       mounted = false;
     };
-  }, [bundleLoader, modelBundleUrl]);
+  }, [bundleAttempt, bundleLoader, modelBundleUrl]);
 
   useEffect(() => {
     const video = videoRef.current;
@@ -198,6 +211,7 @@ export function LivePage({
         phase: "failed",
         stableResult: previous?.stableResult ?? null,
         failureCode: "live.recognition.startup.failed",
+        diagnostics: previous?.diagnostics,
       }));
       void liveSession?.close();
     };
@@ -255,6 +269,18 @@ export function LivePage({
         ? "Recognition starts when the camera and model are ready."
         : livePhaseMessages[liveSnapshot.phase];
   const stableResult = liveSnapshot?.stableResult ?? null;
+  const diagnostics = liveSnapshot?.diagnostics;
+  const bundleBlocked = bundleStatus.phase === "error" && bundleStatus.active === null;
+  const runtimeFailed = state.status === "active" && liveSnapshot?.phase === "failed";
+  const retryAvailable = bundleBlocked || runtimeFailed;
+  const diagnosticBundle = diagnostics?.bundle ?? stableResult?.bundle ?? verifiedBundle;
+  const retrySetup = () => {
+    if (bundleBlocked) {
+      setVerifiedBundle(null);
+      setBundleAttempt((attempt) => attempt + 1);
+    }
+    if (runtimeFailed) setRuntimeAttempt((attempt) => attempt + 1);
+  };
 
   return (
     <section className="live-page" aria-labelledby="live-heading">
@@ -271,6 +297,20 @@ export function LivePage({
             this device; the page does not upload, save, or record raw video.
           </p>
         </div>
+        <section className="live-guide" aria-labelledby="live-guide-heading">
+          <h2 id="live-guide-heading">How to try it</h2>
+          <ol>
+            <li>Choose one prompt: Hello, No, Please, Thank you, or Yes.</li>
+            <li>
+              Keep your hands and upper body in frame with even light facing you, not behind you.
+            </li>
+            <li>Hold still, perform one prompt naturally, then hold still for the result.</li>
+          </ol>
+          <p>
+            Mirroring changes only the preview. This five-prompt research prototype is not
+            sign-language translation. <a href="#/limitations">Read its limitations.</a>
+          </p>
+        </section>
         <StatusBanner>{state.message}</StatusBanner>
         <div className="model-bundle-status">
           <p className="card-label">Model bundle</p>
@@ -282,11 +322,14 @@ export function LivePage({
           <p className="card-label">Recognition</p>
           <StatusBanner label="Recognition status">{recognitionMessage}</StatusBanner>
         </div>
-        <p className="page-note">
-          Perform one prompt at a time with your hands and upper body in frame. Preview mirroring
-          changes only what you see; model coordinates remain unmirrored. This five-prompt research
-          prototype is not sign-language translation.
-        </p>
+        {retryAvailable ? (
+          <div className="recovery-action">
+            <button type="button" onClick={retrySetup}>
+              Retry setup
+            </button>
+            <span>Retries the failed setup without reloading this page.</span>
+          </div>
+        ) : null}
       </div>
 
       <div className="camera-card">
@@ -328,11 +371,6 @@ export function LivePage({
               Stop camera
             </button>
           ) : null}
-          {state.status === "active" && liveSnapshot?.phase === "failed" ? (
-            <button type="button" onClick={() => setRuntimeAttempt((attempt) => attempt + 1)}>
-              Retry recognition
-            </button>
-          ) : null}
         </div>
 
         {hasStream ? (
@@ -369,6 +407,11 @@ export function LivePage({
             <p className="card-label">Latest event</p>
             <strong>{decisionTitle(stableResult)}</strong>
             <p>{decisionReason(stableResult)}</p>
+            <p className="score-note">
+              Higher calibrated scores are stronger model matches, not guarantees. Alternatives show
+              what the model considered; decision time covers on-device preprocessing, inference,
+              and scoring for this completed event.
+            </p>
             <ol aria-label="Top calibrated scores">
               {stableResult.rankedScores.slice(0, 3).map(({ label, confidence }) => (
                 <li key={label}>
@@ -379,7 +422,7 @@ export function LivePage({
             </ol>
             <dl>
               <div>
-                <dt>Latency</dt>
+                <dt>Decision time</dt>
                 <dd>{Math.round(stableResult.timings.totalMs)} ms</dd>
               </div>
               <div>
@@ -393,6 +436,47 @@ export function LivePage({
             </dl>
           </section>
         )}
+
+        <details className="live-diagnostics">
+          <summary>Session diagnostics</summary>
+          <p>Most recent session facts only. They are not saved or uploaded.</p>
+          <dl aria-label="Session diagnostics">
+            <div>
+              <dt>Recognition</dt>
+              <dd>
+                {liveSnapshot === null ? "Not started" : diagnosticStateLabel(liveSnapshot.phase)}
+              </dd>
+            </div>
+            <div>
+              <dt>Detector</dt>
+              <dd>
+                {diagnostics === undefined
+                  ? "Not ready"
+                  : diagnosticStateLabel(diagnostics.detectorState)}
+              </dd>
+            </div>
+            <div>
+              <dt>Landmarks</dt>
+              <dd>{landmarkSummary(diagnostics)}</dd>
+            </div>
+            <div>
+              <dt>Dropped frames</dt>
+              <dd>{diagnostics?.droppedFrames ?? 0}</dd>
+            </div>
+            <div>
+              <dt>Runtime</dt>
+              <dd>{diagnostics?.backend?.toUpperCase() ?? "Waiting"}</dd>
+            </div>
+            <div>
+              <dt>Bundle</dt>
+              <dd>
+                {diagnosticBundle === null
+                  ? "Not ready"
+                  : `${diagnosticBundle.id} ${diagnosticBundle.version}`}
+              </dd>
+            </div>
+          </dl>
+        </details>
       </div>
     </section>
   );

--- a/apps/web/src/live/liveRecognitionSession.test.ts
+++ b/apps/web/src/live/liveRecognitionSession.test.ts
@@ -177,6 +177,37 @@ function emitActiveEvent(emit: (event: LandmarkClientEvent) => void, invalidInsi
 }
 
 describe("LiveRecognitionSession", () => {
+  it("publishes current-session diagnostics from existing worker events", async () => {
+    const runtime = harness();
+    await runtime.session.initialize();
+    expect(runtime.snapshots.at(-1)?.diagnostics).toEqual({
+      detectorState: "inactive",
+      landmarkState: "waiting",
+      detectedHands: 0,
+      droppedFrames: 0,
+      backend: "wasm",
+      bundle: { id: bundle.id, version: bundle.version },
+    });
+
+    const snapshotCount = runtime.snapshots.length;
+    runtime.emitLandmark({ type: "frame-dropped", frameId: 0, droppedFrames: 2 });
+    expect(runtime.snapshots).toHaveLength(snapshotCount);
+    runtime.emitLandmark(frame(0, 0, 0.4));
+    expect(runtime.snapshots.at(-1)?.diagnostics).toMatchObject({
+      detectorState: "inactive",
+      landmarkState: "usable",
+      detectedHands: 1,
+      droppedFrames: 2,
+    });
+
+    runtime.emitLandmark(frame(1, 50_000, null));
+    expect(runtime.snapshots.at(-1)?.diagnostics).toMatchObject({
+      landmarkState: "no_hands",
+      detectedHands: 0,
+      droppedFrames: 2,
+    });
+  });
+
   it("classifies one exact event with rebased frames and publishes its result", async () => {
     const runtime = harness();
     await runtime.session.initialize();

--- a/apps/web/src/live/liveRecognitionSession.ts
+++ b/apps/web/src/live/liveRecognitionSession.ts
@@ -8,6 +8,7 @@ import {
   createCandidateEventDetector,
   type CandidateEvent,
   type CandidateEventDetector,
+  type CandidateEventState,
 } from "../inference/candidateEvents";
 import type {
   CandidateInferenceInput,
@@ -25,10 +26,20 @@ import type { VerifiedModelBundle } from "../modelBundle/modelBundleSession";
 export type LiveRecognitionPhase =
   "loading" | "ready" | "watching" | "recording" | "classifying" | "result" | "failed";
 
+export interface LiveRecognitionDiagnostics {
+  readonly detectorState: CandidateEventState | "not_ready";
+  readonly landmarkState: "waiting" | "usable" | "no_hands" | "invalid";
+  readonly detectedHands: 0 | 1 | 2;
+  readonly droppedFrames: number;
+  readonly backend: "wasm" | null;
+  readonly bundle: { readonly id: string; readonly version: string } | null;
+}
+
 export interface LiveRecognitionSnapshot {
   readonly phase: LiveRecognitionPhase;
   readonly stableResult: CandidateInferenceResult | null;
   readonly failureCode: string | null;
+  readonly diagnostics?: LiveRecognitionDiagnostics;
 }
 
 export type LiveLandmarkClient = Pick<LandmarkWorkerClient, "initialize" | "submitFrame" | "close">;
@@ -52,7 +63,8 @@ const QUALITY_EVIDENCE = { timestampDiscontinuityCount: 0, gaps: [] } as const;
 const INITIAL_SNAPSHOT = { phase: "loading", stableResult: null, failureCode: null } as const;
 
 export class LiveRecognitionSession {
-  private snapshotValue: LiveRecognitionSnapshot = INITIAL_SNAPSHOT;
+  private snapshotValue: LiveRecognitionSnapshot;
+  private diagnosticsValue: LiveRecognitionDiagnostics;
   private readonly projector = new CandidateObservationProjector();
   private detector: CandidateEventDetector | null = null;
   private landmarkClient: LiveLandmarkClient | null = null;
@@ -67,6 +79,18 @@ export class LiveRecognitionSession {
   private retentionUs = 0;
 
   constructor(private readonly options: LiveRecognitionSessionOptions) {
+    this.diagnosticsValue = Object.freeze({
+      detectorState: "not_ready",
+      landmarkState: "waiting",
+      detectedHands: 0,
+      droppedFrames: 0,
+      backend: null,
+      bundle: null,
+    });
+    this.snapshotValue = Object.freeze({
+      ...INITIAL_SNAPSHOT,
+      diagnostics: this.diagnosticsValue,
+    });
     options.onState(this.snapshotValue);
   }
 
@@ -74,6 +98,7 @@ export class LiveRecognitionSession {
     try {
       this.detector = await createCandidateEventDetector(this.options.bundle);
       if (this.closed) return;
+      this.updateDiagnostics({ detectorState: this.detector.state });
       const config = this.detector.config;
       this.retentionUs =
         config.maximum_event_duration_us +
@@ -130,6 +155,7 @@ export class LiveRecognitionSession {
         if (++this.readyWorkers === 2) this.publish("ready");
         return;
       case "frame-dropped":
+        this.updateDiagnostics({ droppedFrames: event.droppedFrames });
         return;
       case "frame":
         if (this.snapshotValue.phase !== "classifying") this.handleLandmarkFrame(event);
@@ -151,6 +177,12 @@ export class LiveRecognitionSession {
       while ((this.bufferedFrames[0]?.[1].relativeTimestampUs ?? cutoff) < cutoff)
         this.bufferedFrames.shift();
       const event = detector.push(this.projector.project(frame));
+      const detectedHands = frame.hands.filter((hand) => hand.present).length as 0 | 1 | 2;
+      this.updateDiagnostics({
+        detectorState: detector.state,
+        landmarkState: !frame.valid ? "invalid" : detectedHands === 0 ? "no_hands" : "usable",
+        detectedHands,
+      });
       if (event !== null) this.classify(event);
       else
         this.publish(
@@ -214,6 +246,7 @@ export class LiveRecognitionSession {
     if (this.closed || this.snapshotValue.phase === "failed") return;
     switch (event.type) {
       case "ready":
+        this.updateDiagnostics({ backend: event.backend, bundle: event.bundle });
         if (++this.readyWorkers === 2) this.publish("ready");
         return;
       case "result":
@@ -234,8 +267,17 @@ export class LiveRecognitionSession {
     stableResult = this.snapshotValue.stableResult,
     failureCode: string | null = null,
   ): void {
-    this.snapshotValue = Object.freeze({ phase, stableResult, failureCode });
+    this.snapshotValue = Object.freeze({
+      phase,
+      stableResult,
+      failureCode,
+      diagnostics: this.diagnosticsValue,
+    });
     this.options.onState(this.snapshotValue);
+  }
+
+  private updateDiagnostics(update: Partial<LiveRecognitionDiagnostics>): void {
+    this.diagnosticsValue = Object.freeze({ ...this.diagnosticsValue, ...update });
   }
 
   private fail(code: string): void {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -326,7 +326,7 @@ h1 {
   display: grid;
   grid-template-columns: minmax(0, 0.85fr) minmax(24rem, 1.15fr);
   gap: clamp(3rem, 7vw, 8rem);
-  align-items: center;
+  align-items: start;
   width: min(100% - 3rem, 82rem);
   min-height: calc(100vh - 15rem);
   margin: 0 auto;
@@ -352,12 +352,58 @@ h1 {
   color: #415a58;
 }
 
+.live-guide {
+  max-width: 42rem;
+  padding: 1rem 1.1rem;
+  margin-bottom: 1.25rem;
+  border: 1px solid rgb(21 48 47 / 14%);
+  border-radius: 0.85rem;
+  background: rgb(255 255 255 / 38%);
+}
+
+.live-guide h2 {
+  margin: 0 0 0.65rem;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 1.25rem;
+}
+
+.live-guide ol {
+  padding-left: 1.2rem;
+  margin: 0;
+}
+
+.live-guide p {
+  margin: 0.75rem 0 0;
+  color: #415a58;
+}
+
 .model-bundle-status {
   margin-top: 1.25rem;
 }
 
 .model-bundle-status .card-label {
   margin-bottom: 0.5rem;
+}
+
+.recovery-action {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  margin-top: 1rem;
+  color: #415a58;
+  font-size: 0.82rem;
+}
+
+.recovery-action button {
+  flex: none;
+  padding: 0.65rem 0.9rem;
+  border: 0;
+  border-radius: 999px;
+  color: #fff;
+  background: #bd4727;
+  font: inherit;
+  font-weight: 800;
+  cursor: pointer;
 }
 
 .camera-card {
@@ -518,6 +564,42 @@ h1 {
   color: #f2f1e9;
   overflow-wrap: anywhere;
   text-align: right;
+}
+
+.live-diagnostics {
+  padding-top: 1rem;
+  margin-top: 1rem;
+  border-top: 1px solid rgb(242 241 233 / 18%);
+}
+
+.live-diagnostics summary {
+  color: #f2f1e9;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.live-diagnostics > p {
+  margin: 0.65rem 0;
+  color: #adc0bd;
+  font-size: 0.78rem;
+}
+
+.live-diagnostics dl {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.65rem 1.25rem;
+  margin: 0;
+}
+
+.live-diagnostics dt {
+  color: #adc0bd;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+}
+
+.live-diagnostics dd {
+  margin: 0.15rem 0 0;
+  overflow-wrap: anywhere;
 }
 
 .content-page h1 {
@@ -691,7 +773,7 @@ h1 {
   }
 
   .live-page {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
     min-height: auto;
   }
 
@@ -735,6 +817,16 @@ h1 {
 
   h1 {
     font-size: clamp(3.3rem, 19vw, 5rem);
+  }
+
+  .camera-options label:not(.mirror-option),
+  .camera-options select {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .live-diagnostics dl {
+    grid-template-columns: 1fr;
   }
 
   .site-footer {


### PR DESCRIPTION
Closes #112

## Summary

- add concise prompt, framing, lighting, privacy, mirroring, and limitation guidance
- expose current landmark, detector, dropped-frame, runtime, and bundle facts in a native diagnostics disclosure
- add one in-page recovery action for blocked bundle loads and failed live-runtime setup
- clarify calibrated scores and decision timing while keeping the latest target, other, or abstain result stable
- keep desktop controls in the initial viewport and preserve a one-column, overflow-free phone layout

## Scope guard

- 135 added nonblank production TypeScript/TSX lines (cap: 200)
- 80 added nonblank CSS lines (target: 80)
- no FPS estimator, telemetry subsystem, tutorial framework, persistence, new dependency, or inference-path change
- accurate performance metrics remain in #51; accessibility depth remains in #48; the deployed walkthrough remains in #57

## Verification

- `npm test` — 102 tests passed
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run build`
- `npm run build:subpath`
- `uv run --locked ruff check .`
- `uv run --locked ruff format --check .`
- `uv run --locked mypy`
- `uv run --locked pytest` — 1,447 passed, 14 Windows platform skips; Linux CI owns the authoritative 90% coverage gate
- repository hygiene and both golden checks
- visual checks at 1440×900 and an emulated 390×844 viewport; no horizontal overflow and diagnostics collapse to one column