### PR TITLE
Make the public demo accessible

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -23,6 +23,7 @@
         "@types/react": "19.2.18",
         "@types/react-dom": "19.2.5",
         "@vitejs/plugin-react": "6.1.1",
+        "axe-core": "4.13.0",
         "eslint": "10.9.1",
         "eslint-plugin-react-hooks": "7.1.1",
         "eslint-plugin-react-refresh": "0.5.5",
@@ -1732,6 +1733,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.13.0.tgz",
+      "integrity": "sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/balanced-match": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -34,6 +34,7 @@
     "@types/react": "19.2.18",
     "@types/react-dom": "19.2.5",
     "@vitejs/plugin-react": "6.1.1",
+    "axe-core": "4.13.0",
     "eslint": "10.9.1",
     "eslint-plugin-react-hooks": "7.1.1",
     "eslint-plugin-react-refresh": "0.5.5",

--- a/apps/web/src/app/AppShell.tsx
+++ b/apps/web/src/app/AppShell.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from "react";
+import { useRef, useState, type MouseEvent, type ReactNode } from "react";
 import { NavLink } from "react-router-dom";
 
 import { navigationItems } from "./routeDefinitions";
@@ -9,14 +9,19 @@ interface AppShellProps {
 
 export function AppShell({ children }: AppShellProps) {
   const [menuOpen, setMenuOpen] = useState(false);
+  const mainRef = useRef<HTMLElement>(null);
 
   const closeMenu = () => {
     setMenuOpen(false);
   };
+  const skipToMain = (event: MouseEvent<HTMLAnchorElement>) => {
+    event.preventDefault();
+    mainRef.current?.focus();
+  };
 
   return (
     <div className="site-shell">
-      <a className="skip-link" href="#main-content">
+      <a className="skip-link" href="#main-content" onClick={skipToMain}>
         Skip to content
       </a>
       <header className="site-header">
@@ -62,7 +67,9 @@ export function AppShell({ children }: AppShellProps) {
         </nav>
       </header>
 
-      <main id="main-content">{children}</main>
+      <main ref={mainRef} id="main-content" tabIndex={-1}>
+        {children}
+      </main>
 
       <footer className="site-footer">
         <p>SignLab is a research prototype, not a sign-language translator.</p>

--- a/apps/web/src/app/LivePage.test.tsx
+++ b/apps/web/src/app/LivePage.test.tsx
@@ -113,7 +113,14 @@ describe("consent-first camera preview", () => {
       "No model bundle is configured.",
     );
 
-    await startCamera();
+    const cameraButton = screen.getByRole("button", { name: "Start camera" });
+    cameraButton.focus();
+    fireEvent.click(cameraButton);
+    await screen.findByText(
+      "Camera is on. Raw video stays on this page and is not saved or uploaded.",
+    );
+    expect(screen.getByRole("button", { name: "Stop camera" })).toBe(cameraButton);
+    expect(cameraButton).toHaveFocus();
 
     expect(devices.getUserMedia).toHaveBeenCalledWith({
       audio: false,
@@ -126,15 +133,24 @@ describe("consent-first camera preview", () => {
     fireEvent.click(screen.getByRole("checkbox", { name: "Mirror preview" }));
     expect(video).not.toHaveClass("is-mirrored");
 
-    fireEvent.click(screen.getByRole("button", { name: "Pause preview" }));
+    const previewButton = screen.getByRole("button", { name: "Pause preview" });
+    previewButton.focus();
+    fireEvent.click(previewButton);
     expect(track.enabled).toBe(false);
     expect(screen.getByText(/Stop the camera to release it completely/)).toBeVisible();
+    expect(screen.getByRole("button", { name: "Resume preview" })).toBe(previewButton);
+    expect(previewButton).toHaveFocus();
 
-    fireEvent.click(screen.getByRole("button", { name: "Resume preview" }));
+    fireEvent.click(previewButton);
     expect(track.enabled).toBe(true);
+    expect(screen.getByRole("button", { name: "Pause preview" })).toBe(previewButton);
+    expect(previewButton).toHaveFocus();
 
-    fireEvent.click(screen.getByRole("button", { name: "Stop camera" }));
+    cameraButton.focus();
+    fireEvent.click(cameraButton);
     expect(track.stop).toHaveBeenCalledOnce();
+    expect(screen.getByRole("button", { name: "Start camera" })).toBe(cameraButton);
+    expect(cameraButton).toHaveFocus();
     expect(screen.queryByLabelText("Local camera preview")).not.toBeInTheDocument();
     expect(fetchSpy).not.toHaveBeenCalled();
     expect(xhrSpy).not.toHaveBeenCalled();
@@ -495,7 +511,7 @@ describe("live on-device result", () => {
       await screen.findByText(/Models are ready/);
       act(() => {
         emit({
-          phase: "recording",
+          phase: "result",
           stableResult: inferenceResult(decision, reason),
           failureCode: null,
           diagnostics: {
@@ -511,6 +527,15 @@ describe("live on-device result", () => {
 
       const resultCard = screen.getByRole("region", { name: "Latest recognition result" });
       expect(within(resultCard).getByText(title, { selector: "strong" })).toBeVisible();
+      const recognitionStatus = screen.getByRole("status", { name: "Recognition status" });
+      expect(recognitionStatus).toHaveTextContent(`Result: ${title}.`);
+      expect(recognitionStatus).toHaveTextContent(
+        reason === "below_threshold"
+          ? "confidence was low"
+          : reason === "accepted_other"
+            ? "unlike the five target prompts"
+            : "calibrated score",
+      );
       expect(within(resultCard).getByRole("list", { name: "Top calibrated scores" })).toBeVisible();
       expect(screen.getByText("8 ms")).toBeVisible();
       expect(within(resultCard).getByText("WASM")).toBeVisible();
@@ -518,7 +543,8 @@ describe("live on-device result", () => {
       expect(within(resultCard).getByText(/stronger model matches, not guarantees/)).toBeVisible();
       fireEvent.click(screen.getByText("Session diagnostics"));
       const diagnostics = screen.getByLabelText("Session diagnostics");
-      expect(within(diagnostics).getAllByText("Gesture in progress")).toHaveLength(2);
+      expect(within(diagnostics).getByText("Result")).toBeVisible();
+      expect(within(diagnostics).getByText("Gesture in progress")).toBeVisible();
       expect(within(diagnostics).getByText("2 hands detected")).toBeVisible();
       expect(within(diagnostics).getByText("3")).toBeVisible();
       expect(within(diagnostics).getByText("WASM")).toBeVisible();

--- a/apps/web/src/app/accessibility.test.tsx
+++ b/apps/web/src/app/accessibility.test.tsx
@@ -1,0 +1,35 @@
+import { render } from "@testing-library/react";
+import axe from "axe-core";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+
+import { App } from "./App";
+
+const routes = ["/", "/live", "/privacy", "/missing"] as const;
+
+describe("automated accessibility smoke", () => {
+  it.each(routes)("has no detectable A/AA violations on %s", async (path) => {
+    const { container } = render(
+      <MemoryRouter initialEntries={[path]}>
+        <App />
+      </MemoryRouter>,
+    );
+    const results = await axe.run(container, {
+      runOnly: {
+        type: "tag",
+        values: ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "wcag22aa", "best-practice"],
+      },
+      rules: {
+        "color-contrast": { enabled: false },
+        "link-in-text-block": { enabled: false },
+      },
+    });
+
+    expect(
+      results.violations.map(({ id, nodes }) => ({
+        id,
+        targets: nodes.flatMap(({ target }) => target),
+      })),
+    ).toEqual([]);
+  });
+});

--- a/apps/web/src/app/routes.test.tsx
+++ b/apps/web/src/app/routes.test.tsx
@@ -31,7 +31,7 @@ describe("static application routes", () => {
         </MemoryRouter>,
       );
 
-      expect(screen.getByRole("heading", { level: 1, name: heading })).toBeInTheDocument();
+      expect(screen.getByRole("heading", { level: 1, name: heading })).toHaveFocus();
       expect(screen.getByRole("navigation", { name: "Primary navigation" })).toBeInTheDocument();
       expect(document.title).toBe(`${title} | SignLab`);
       expect(fetchSpy).not.toHaveBeenCalled();
@@ -82,5 +82,18 @@ describe("static application routes", () => {
       "href",
       "/",
     );
+  });
+
+  it("moves focus to the main content without changing the route", () => {
+    render(
+      <MemoryRouter initialEntries={["/live"]}>
+        <App />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "Skip to content" }));
+
+    expect(screen.getByRole("main")).toHaveFocus();
+    expect(screen.getByRole("heading", { level: 1, name: "Live recognition" })).toBeVisible();
   });
 });

--- a/apps/web/src/app/routes.tsx
+++ b/apps/web/src/app/routes.tsx
@@ -27,7 +27,7 @@ function usePageHeading(title: string) {
 
   useEffect(() => {
     document.title = `${title} | SignLab`;
-    headingRef.current?.focus({ preventScroll: true });
+    headingRef.current?.focus();
   }, [title]);
 
   return headingRef;
@@ -110,16 +110,22 @@ const readableLabel = (label: string) =>
 const diagnosticStateLabel = (state: string) =>
   state === "recording" ? "Gesture in progress" : readableLabel(state);
 
-function decisionTitle(result: NonNullable<LiveRecognitionSnapshot["stableResult"]>): string {
+type StableResult = NonNullable<LiveRecognitionSnapshot["stableResult"]>;
+
+function decisionTitle(result: StableResult): string {
   if (!("label" in result.decision)) return "No confident match";
   if (result.decision.kind === "other") return "Other movement";
   return readableLabel(result.decision.label);
 }
 
-function decisionReason(result: NonNullable<LiveRecognitionSnapshot["stableResult"]>): string {
+function decisionReason(result: StableResult): string {
   if (result.reason === "below_threshold") return "The model abstained because confidence was low.";
   if (result.reason === "accepted_other") return "The event looked unlike the five target prompts.";
   return "The top calibrated score passed the decision threshold.";
+}
+
+function resultStatusMessage(result: StableResult): string {
+  return `Result: ${decisionTitle(result)}. ${decisionReason(result)}`;
 }
 
 function landmarkSummary(diagnostics: LiveRecognitionDiagnostics | undefined): string {
@@ -262,13 +268,16 @@ export function LivePage({
 
   const hasStream = state.stream !== null;
   const canStart = canRequest && startableStatuses.has(state.status);
+  const requestingCamera = state.status === "requesting";
+  const stableResult = liveSnapshot?.stableResult ?? null;
   const recognitionMessage =
     liveSnapshot?.failureCode === "live.recognition.candidate.invalid"
       ? "That event could not be classified. Hold still, then try again."
       : state.status !== "active" || liveSnapshot === null
         ? "Recognition starts when the camera and model are ready."
-        : livePhaseMessages[liveSnapshot.phase];
-  const stableResult = liveSnapshot?.stableResult ?? null;
+        : liveSnapshot.phase === "result" && stableResult !== null
+          ? resultStatusMessage(stableResult)
+          : livePhaseMessages[liveSnapshot.phase];
   const diagnostics = liveSnapshot?.diagnostics;
   const bundleBlocked = bundleStatus.phase === "error" && bundleStatus.active === null;
   const runtimeFailed = state.status === "active" && liveSnapshot?.phase === "failed";
@@ -350,25 +359,24 @@ export function LivePage({
           )}
         </div>
 
-        <div className="camera-controls" aria-label="Camera controls">
-          {canStart ? (
-            <button className="primary-action" type="button" onClick={() => void start()}>
-              Start camera
+        <div className="camera-controls" role="group" aria-label="Camera controls">
+          {canStart || requestingCamera || hasStream ? (
+            <button
+              className={hasStream ? undefined : "primary-action"}
+              type="button"
+              aria-disabled={requestingCamera || undefined}
+              onClick={() => {
+                if (requestingCamera) return;
+                if (hasStream) stop();
+                else void start();
+              }}
+            >
+              {hasStream ? "Stop camera" : requestingCamera ? "Starting camera" : "Start camera"}
             </button>
           ) : null}
-          {state.status === "active" ? (
-            <button type="button" onClick={pause}>
-              Pause preview
-            </button>
-          ) : null}
-          {state.status === "paused" ? (
-            <button type="button" onClick={resume}>
-              Resume preview
-            </button>
-          ) : null}
-          {hasStream ? (
-            <button type="button" onClick={() => stop()}>
-              Stop camera
+          {state.status === "active" || state.status === "paused" ? (
+            <button type="button" onClick={state.status === "active" ? pause : resume}>
+              {state.status === "active" ? "Pause preview" : "Resume preview"}
             </button>
           ) : null}
         </div>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -38,7 +38,7 @@ a {
 }
 
 :focus-visible {
-  outline: 3px solid #b54428;
+  outline: 3px solid #cf5d3f;
   outline-offset: 4px;
 }
 
@@ -470,8 +470,8 @@ h1 {
 }
 
 .camera-controls .primary-action {
-  border-color: #e8623c;
-  background: #e8623c;
+  border-color: #b54428;
+  background: #b54428;
 }
 
 .camera-controls button:hover {
@@ -532,6 +532,11 @@ h1 {
   font-size: 2rem;
   font-weight: 500;
   letter-spacing: -0.03em;
+}
+
+.recognition-result .card-label,
+.principles .section-index {
+  color: #f5a58b;
 }
 
 .recognition-result > p:not(.card-label) {

--- a/docs/accessibility-release-checklist.md
+++ b/docs/accessibility-release-checklist.md
@@ -1,0 +1,42 @@
+# Public demo accessibility release check
+
+Story: #48  
+Scope: public overview, live demo, privacy, and not-found routes
+
+## Automated checks
+
+- [x] Axe WCAG A/AA and best-practice smoke passes on representative routes.
+- [x] `color-contrast` and `link-in-text-block` are checked in a real browser; axe documents
+      them as unreliable in jsdom.
+- [x] Web tests, type checks, lint, formatting, and production builds pass.
+
+## Keyboard and focus
+
+- [x] Skip link is visible on focus, moves focus to main, and does not change the hash route.
+- [x] Route changes focus the new page heading.
+- [x] Start/Stop and Pause/Resume work by keyboard and retain focus when labels change.
+- [x] Menu, links, camera choices, mirror option, retry, and diagnostics have visible focus.
+- [x] Focus order follows the visual reading order with no trap.
+
+## Visual and responsive checks
+
+- [x] Text and focus indicators meet WCAG 2.2 AA contrast.
+- [x] Meaning does not depend on color alone.
+- [x] Pages reflow at 320 px and 390 px without horizontal scrolling or hidden controls.
+- [x] Pages remain usable at 200% browser zoom and at a 1440×900 desktop viewport.
+- [x] Reduced-motion preference removes meaningful motion.
+
+## Semantics and announcements
+
+- [x] Browser accessibility tree exposes landmarks, headings, labels, and control groups clearly.
+- [x] Readiness, failures, and completed predictions use bounded polite status updates.
+- [x] Camera preview has an accurate name; no canvas or landmark overlay exists in this release.
+- [x] Narrator or NVDA listen-through confirms understandable names, focus, and announcement pace.
+
+## Evidence
+
+- Commit: tracked by Story #48 and its pull request.
+- Automated run: 107 tests; axe found zero violations on four representative routes.
+- Browser matrix: Chromium at 320, 390, 640 zoom-equivalent, and 1440×900; no overflow.
+- Contrast: primary text 4.85:1; focus ring 3.50:1 or better; gradient label 7.55:1.
+- Screen-reader walkthrough: Windows Narrator, user-confirmed 2026-08-31.


### PR DESCRIPTION
Closes #48

## Summary
- keep keyboard focus stable across Start/Stop and Pause/Resume camera states
- repair the hash-router skip link and visible route-heading focus
- announce completed recognition decisions without frame-level updates
- correct text and focus contrast while preserving reduced-motion behavior
- add a bounded axe-core smoke test and a completed manual release checklist

## Verification
- 107 web tests
- lint, formatting, and TypeScript checks
- root-domain and subpath production builds
- Chromium axe scan on overview, live, privacy, and not-found routes
- Chromium reflow checks at 320, 390, 640 zoom-equivalent, and 1440×900
- Windows Narrator walkthrough confirmed by the user

## Scope
- 40 nonblank production TypeScript/TSX additions
- 8 nonblank CSS additions
- one direct axe-core development dependency