### PR TITLE
Store explicitly consented feedback in IndexedDB

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -27,6 +27,7 @@
         "eslint": "10.9.1",
         "eslint-plugin-react-hooks": "7.1.1",
         "eslint-plugin-react-refresh": "0.5.5",
+        "fake-indexeddb": "6.2.5",
         "globals": "17.11.0",
         "jsdom": "29.1.1",
         "prettier": "3.9.6",
@@ -2270,6 +2271,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-deep-equal": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -38,6 +38,7 @@
     "eslint": "10.9.1",
     "eslint-plugin-react-hooks": "7.1.1",
     "eslint-plugin-react-refresh": "0.5.5",
+    "fake-indexeddb": "6.2.5",
     "globals": "17.11.0",
     "jsdom": "29.1.1",
     "prettier": "3.9.6",

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -1,6 +1,7 @@
 import { Route, Routes } from "react-router-dom";
 
 import { AppShell } from "./AppShell";
+import { FeedbackPage } from "../feedback/Feedback";
 import { staticPages } from "./routeDefinitions";
 import { LivePage, NotFoundPage, OverviewPage, StaticPage } from "./routes";
 
@@ -11,7 +12,11 @@ export function App() {
         <Route path="/" element={<OverviewPage />} />
         <Route path="/live" element={<LivePage />} />
         {staticPages.map((page) => (
-          <Route key={page.path} path={page.path} element={<StaticPage page={page} />} />
+          <Route
+            key={page.path}
+            path={page.path}
+            element={page.path === "/feedback" ? <FeedbackPage /> : <StaticPage page={page} />}
+          />
         ))}
         <Route path="*" element={<NotFoundPage />} />
       </Routes>

--- a/apps/web/src/app/LivePage.test.tsx
+++ b/apps/web/src/app/LivePage.test.tsx
@@ -513,6 +513,21 @@ describe("live on-device result", () => {
         emit({
           phase: "result",
           stableResult: inferenceResult(decision, reason),
+          feedbackContext: {
+            event: {
+              firstFrameIndex: 0,
+              lastFrameIndex: 0,
+              firstTimestampUs: 0,
+              lastTimestampUs: 0,
+              terminationReason: "settled",
+              configSha256: "sha256:detector",
+            },
+            input: {
+              frames: [],
+              sourceMirrorState: "not_mirrored",
+              quality: { timestampDiscontinuityCount: 0, gaps: [] },
+            },
+          },
           failureCode: null,
           diagnostics: {
             detectorState: "recording",
@@ -541,6 +556,9 @@ describe("live on-device result", () => {
       expect(within(resultCard).getByText("WASM")).toBeVisible();
       expect(within(resultCard).getByText("browser-candidate 1.0.0")).toBeVisible();
       expect(within(resultCard).getByText(/stronger model matches, not guarantees/)).toBeVisible();
+      expect(
+        within(resultCard).getByRole("heading", { name: "Save feedback locally" }),
+      ).toBeVisible();
       fireEvent.click(screen.getByText("Session diagnostics"));
       const diagnostics = screen.getByLabelText("Session diagnostics");
       expect(within(diagnostics).getByText("Result")).toBeVisible();

--- a/apps/web/src/app/accessibility.test.tsx
+++ b/apps/web/src/app/accessibility.test.tsx
@@ -5,7 +5,7 @@ import { describe, expect, it } from "vitest";
 
 import { App } from "./App";
 
-const routes = ["/", "/live", "/privacy", "/missing"] as const;
+const routes = ["/", "/live", "/feedback", "/privacy", "/missing"] as const;
 
 describe("automated accessibility smoke", () => {
   it.each(routes)("has no detectable A/AA violations on %s", async (path) => {

--- a/apps/web/src/app/routeDefinitions.ts
+++ b/apps/web/src/app/routeDefinitions.ts
@@ -78,10 +78,10 @@ export const staticPages = [
     eyebrow: "Local by default",
     heading: "Feedback stays local by default",
     summary:
-      "The completed demo will let users review a prediction and choose whether to save a correction locally.",
+      "Review corrections saved in this browser. They are never uploaded and do not become training data.",
     status:
-      "Feedback collection is not active. This scaffold stores no feedback and sends nothing anywhere.",
-    detailsTitle: "Planned safeguards",
+      "Nothing is saved automatically. Browser storage may be unavailable or cleared by the browser.",
+    detailsTitle: "Local safeguards",
     details: [
       "Nothing is saved without a clear user action.",
       "Local corrections remain separate from research training data.",
@@ -96,7 +96,7 @@ export const staticPages = [
     summary:
       "The completed browser demo is intended to process camera frames on the user’s device. Raw video will not be uploaded or stored by default.",
     status:
-      "Camera access is explicit. Inference stays on-device, with no stored feedback or analytics.",
+      "Camera access and local feedback storage are explicit. There are no uploads or analytics.",
     detailsTitle: "Current privacy facts",
     details: [
       "The live path downloads only its configured model bundle and two integrity-checked MediaPipe model files.",

--- a/apps/web/src/app/routes.tsx
+++ b/apps/web/src/app/routes.tsx
@@ -2,6 +2,8 @@ import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { Link } from "react-router-dom";
 
 import { livePageDefinition, type StaticPageDefinition } from "./routeDefinitions";
+import { FeedbackSaveForm } from "../feedback/Feedback";
+import type { FeedbackStore } from "../feedback/feedbackStore";
 import {
   useCameraSession,
   type CameraEnvironment,
@@ -141,11 +143,13 @@ export function LivePage({
   modelBundleUrl,
   modelBundleSession,
   liveRuntime = browserLiveRuntime,
+  feedbackStore,
 }: {
   cameraEnvironment?: CameraEnvironment;
   modelBundleUrl?: string;
   modelBundleSession?: BundleLoader;
   liveRuntime?: LiveRuntime;
+  feedbackStore?: FeedbackStore;
 }) {
   const headingRef = usePageHeading(livePageDefinition.label);
   const videoRef = useRef<HTMLVideoElement>(null);
@@ -270,6 +274,7 @@ export function LivePage({
   const canStart = canRequest && startableStatuses.has(state.status);
   const requestingCamera = state.status === "requesting";
   const stableResult = liveSnapshot?.stableResult ?? null;
+  const feedbackContext = liveSnapshot?.feedbackContext ?? null;
   const recognitionMessage =
     liveSnapshot?.failureCode === "live.recognition.candidate.invalid"
       ? "That event could not be classified. Hold still, then try again."
@@ -442,6 +447,15 @@ export function LivePage({
                 <dd>{`${stableResult.bundle.id} ${stableResult.bundle.version}`}</dd>
               </div>
             </dl>
+            {feedbackContext === null ? null : (
+              <FeedbackSaveForm
+                key={`${stableResult.bundle.id}:${stableResult.requestId}:${feedbackContext.event.firstTimestampUs}`}
+                result={stableResult}
+                context={feedbackContext}
+                previewMirrored={previewMirrored}
+                store={feedbackStore}
+              />
+            )}
           </section>
         )}
 

--- a/apps/web/src/feedback/Feedback.test.tsx
+++ b/apps/web/src/feedback/Feedback.test.tsx
@@ -1,0 +1,127 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { IDBFactory } from "fake-indexeddb";
+import { describe, expect, it } from "vitest";
+
+import {
+  CANDIDATE_INFERENCE_PROTOCOL_VERSION,
+  type CandidateInferenceResult,
+} from "../inference/candidateInferenceProtocol";
+import { CANDIDATE_LABELS } from "../inference/candidateDecision";
+import type { LiveFeedbackContext } from "../live/liveRecognitionSession";
+import { FeedbackPage, FeedbackSaveForm } from "./Feedback";
+import { NativeFeedbackStore } from "./feedbackStore";
+
+const result: CandidateInferenceResult = {
+  type: "result",
+  protocolVersion: CANDIDATE_INFERENCE_PROTOCOL_VERSION,
+  requestId: 1,
+  bundle: { id: "candidate", version: "1" },
+  backend: "wasm",
+  decision: { kind: "target", label: "hello", confidence: 0.8 },
+  reason: "accepted_target",
+  rankedScores: CANDIDATE_LABELS.map((label) => ({ label, confidence: 0.8 })),
+  timings: { preprocessingMs: 1, inferenceMs: 2, decisionMs: 1, totalMs: 4 },
+};
+const context: LiveFeedbackContext = {
+  event: {
+    firstFrameIndex: 1,
+    lastFrameIndex: 2,
+    firstTimestampUs: 10,
+    lastTimestampUs: 20,
+    terminationReason: "settled",
+    configSha256: "sha256:detector",
+  },
+  input: {
+    frames: [],
+    sourceMirrorState: "not_mirrored",
+    quality: { timestampDiscontinuityCount: 0, gaps: [] },
+  },
+};
+
+function store(name: string) {
+  let id = 0;
+  return new NativeFeedbackStore(
+    new IDBFactory(),
+    name,
+    () => "2026-08-31T12:00:00.000Z",
+    () => `${name}-${++id}`,
+  );
+}
+
+function submitFeedback() {
+  fireEvent.change(screen.getByLabelText("Correct outcome"), { target: { value: "yes" } });
+  fireEvent.click(screen.getByLabelText(/Save these fields in this browser/));
+  fireEvent.submit(screen.getByRole("button", { name: "Save in this browser" }).closest("form")!);
+}
+
+describe("local feedback UI", () => {
+  it("requires event consent and keeps landmarks separately off by default", async () => {
+    const feedback = store("save-form");
+    const props = { result, context, store: feedback };
+    const view = render(<FeedbackSaveForm {...props} previewMirrored />);
+    fireEvent.change(screen.getByLabelText("Correct outcome"), { target: { value: "yes" } });
+    fireEvent.submit(screen.getByRole("button", { name: "Save in this browser" }).closest("form")!);
+    expect((await feedback.list()).records).toHaveLength(0);
+
+    view.rerender(<FeedbackSaveForm {...props} previewMirrored={false} />);
+    submitFeedback();
+    await screen.findByText("Feedback saved in this browser.");
+    expect((await feedback.list()).records[0]).not.toHaveProperty("landmarks");
+    expect((await feedback.list()).records[0]?.conditions.previewMirrored).toBe(true);
+
+    view.rerender(
+      <FeedbackSaveForm
+        {...props}
+        key="next-event"
+        result={{ ...result, requestId: 2 }}
+        previewMirrored={false}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText("Include derived landmark coordinates"));
+    submitFeedback();
+    await waitFor(async () => expect((await feedback.list()).records).toHaveLength(2));
+    expect((await feedback.list()).records[1]).toHaveProperty("landmarks");
+  });
+
+  it("lists, inspects, updates, deletes, and clears local records", async () => {
+    const feedback = store("feedback-page");
+    await feedback.save({
+      result,
+      context,
+      correction: "hello",
+      includeLandmarks: false,
+      previewMirrored: true,
+    });
+    await feedback.save({
+      result,
+      context,
+      correction: "yes",
+      includeLandmarks: false,
+      previewMirrored: true,
+    });
+    render(<FeedbackPage store={feedback} />);
+
+    await screen.findByText("2 feedback record(s) saved locally.");
+    fireEvent.change(screen.getAllByLabelText("Correct outcome")[0]!, {
+      target: { value: "inactive" },
+    });
+    await waitFor(async () =>
+      expect(
+        (await feedback.list()).records.some(({ correction }) => correction === "inactive"),
+      ).toBe(true),
+    );
+    fireEvent.click(screen.getAllByText("Inspect every saved field")[0]!);
+    expect(await screen.findByText(/signlab-feedback-record\/1/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Delete this record" })[0]!);
+    await screen.findByText("1 feedback record(s) saved locally.");
+    fireEvent.click(screen.getByRole("button", { name: "Clear all local feedback" }));
+    await screen.findByText("No feedback is saved in this browser.");
+    expect((await feedback.list()).records).toHaveLength(0);
+  });
+
+  it("explains unavailable storage without falling back", async () => {
+    render(<FeedbackPage store={new NativeFeedbackStore(null)} />);
+    expect(await screen.findByText(/Local feedback storage is unavailable/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/feedback/Feedback.tsx
+++ b/apps/web/src/feedback/Feedback.tsx
@@ -1,0 +1,202 @@
+import { useEffect, useRef, useState, type FormEvent } from "react";
+
+import type { CandidateInferenceResult } from "../inference/candidateInferenceProtocol";
+import type { LiveFeedbackContext } from "../live/liveRecognitionSession";
+import {
+  FEEDBACK_LABELS,
+  NativeFeedbackStore,
+  type FeedbackLabel,
+  type FeedbackListResult,
+  type FeedbackRecord,
+  type FeedbackStore,
+} from "./feedbackStore";
+
+const browserStore = new NativeFeedbackStore();
+
+function FeedbackOptions() {
+  return FEEDBACK_LABELS.map((value) => (
+    <option key={value} value={value}>
+      {value.replaceAll("_", " ").replace(/^./, (letter) => letter.toUpperCase())}
+    </option>
+  ));
+}
+
+function feedbackStorageMessage(error: unknown): string {
+  const code = String(Reflect.get(Object(error), "code"));
+  if (code.includes("quota")) return "This browser has no space available for feedback.";
+  if (code.includes("blocked")) return "Close other SignLab tabs, then try again.";
+  if (code.includes("version")) return "This feedback was created by a newer SignLab version.";
+  return "Local feedback storage is unavailable. Nothing was saved.";
+}
+
+export function FeedbackSaveForm({
+  result,
+  context,
+  previewMirrored,
+  store = browserStore,
+}: {
+  result: CandidateInferenceResult;
+  context: LiveFeedbackContext;
+  previewMirrored: boolean;
+  store?: FeedbackStore;
+}) {
+  const previewMirroredAtResult = useRef(previewMirrored).current;
+  const [status, setStatus] = useState<"idle" | "saving" | "saved">("idle");
+  const [message, setMessage] = useState("");
+  const save = async (event: FormEvent) => {
+    event.preventDefault();
+    const fields = new FormData(event.currentTarget as HTMLFormElement);
+    const correction = fields.get("correction");
+    if (
+      typeof correction !== "string" ||
+      !FEEDBACK_LABELS.includes(correction as FeedbackLabel) ||
+      !fields.has("consent") ||
+      status !== "idle"
+    )
+      return;
+    setStatus("saving");
+    try {
+      await store.save({
+        result,
+        context,
+        correction: correction as FeedbackLabel,
+        includeLandmarks: fields.has("landmarks"),
+        previewMirrored: previewMirroredAtResult,
+      });
+      setStatus("saved");
+      setMessage("Feedback saved in this browser.");
+    } catch (error) {
+      setStatus("idle");
+      setMessage(feedbackStorageMessage(error));
+    }
+  };
+
+  return (
+    <form className="feedback-save" onSubmit={(event) => void save(event)}>
+      <h3>Save feedback locally</h3>
+      <fieldset disabled={status !== "idle"}>
+        <label>
+          Correct outcome
+          <select name="correction" defaultValue="" required>
+            <option value="">Choose an outcome</option>
+            <FeedbackOptions />
+          </select>
+        </label>
+        <p>
+          Saved: record ID/time, model bundle, prediction/reason, scores/timings, correction, event
+          boundaries/duration/termination/detector version, mirror conditions, consent, and—if
+          selected—landmarks. Never: video, audio, device details, or free text.
+        </p>
+        <label className="feedback-check">
+          <input name="landmarks" type="checkbox" /> Include derived landmark coordinates
+        </label>
+        <label className="feedback-check">
+          <input name="consent" type="checkbox" required /> Save these fields in this browser
+          only—not for upload or training.
+        </label>
+        <button type="submit">
+          {status === "saving" ? "Saving" : status === "saved" ? "Saved" : "Save in this browser"}
+        </button>
+      </fieldset>
+      {message && <p role="status">{message}</p>}
+    </form>
+  );
+}
+
+function RecordDetails({ record }: { record: FeedbackRecord }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <details onToggle={(event) => setOpen(event.currentTarget.open)}>
+      <summary>Inspect every saved field</summary>
+      {open && <pre>{JSON.stringify(record, null, 2)}</pre>}
+    </details>
+  );
+}
+
+export function FeedbackPage({ store = browserStore }: { store?: FeedbackStore }) {
+  const headingRef = useRef<HTMLHeadingElement>(null);
+  const [items, setItems] = useState<FeedbackListResult>({ records: [], damagedKeys: [] });
+  const [message, setMessage] = useState("Loading local feedback.");
+  const [revision, setRevision] = useState(0);
+  useEffect(() => {
+    document.title = "Feedback | SignLab";
+    headingRef.current?.focus();
+    void store.list().then(
+      (next) => {
+        setItems(next);
+        setMessage(
+          next.records.length
+            ? `${next.records.length} feedback record(s) saved locally.`
+            : "No feedback is saved in this browser.",
+        );
+      },
+      (error: unknown) => setMessage(feedbackStorageMessage(error)),
+    );
+  }, [revision, store]);
+  const mutate = async (operation: () => Promise<void>) => {
+    try {
+      await operation();
+      setRevision((value) => value + 1);
+    } catch (error) {
+      setMessage(feedbackStorageMessage(error));
+    }
+  };
+
+  return (
+    <section className="content-page feedback-page" aria-labelledby="feedback-heading">
+      <div className="content-intro">
+        <p className="eyebrow">Local by default</p>
+        <h1 id="feedback-heading" ref={headingRef} tabIndex={-1}>
+          Feedback stays local by default
+        </h1>
+        <p className="page-summary">
+          Local corrections are not uploaded or training data. The browser may clear them.
+        </p>
+        <p className="status-banner" role="status">
+          {message}
+        </p>
+        <button
+          className="danger-action"
+          type="button"
+          disabled={items.records.length + items.damagedKeys.length === 0}
+          onClick={() => void mutate(() => store.clear())}
+        >
+          Clear all local feedback
+        </button>
+      </div>
+      <section className="feedback-list" aria-label="Locally saved feedback">
+        {items.records.map((record) => (
+          <article key={record.id}>
+            <strong>{new Date(record.savedAt).toLocaleString()}</strong>
+            <label>
+              Correct outcome
+              <select
+                value={record.correction}
+                onChange={(event) =>
+                  void mutate(() =>
+                    store.updateCorrection(record.id, event.target.value as FeedbackLabel),
+                  )
+                }
+              >
+                <FeedbackOptions />
+              </select>
+            </label>
+            <RecordDetails record={record} />
+            <button type="button" onClick={() => void mutate(() => store.delete(record.id))}>
+              Delete this record
+            </button>
+          </article>
+        ))}
+        {items.damagedKeys.map((key, index) => (
+          <article key={index}>
+            <strong>Unreadable local record</strong>
+            <p>This entry is damaged or from an unsupported format.</p>
+            <button type="button" onClick={() => void mutate(() => store.delete(key))}>
+              Delete damaged record
+            </button>
+          </article>
+        ))}
+      </section>
+    </section>
+  );
+}

--- a/apps/web/src/feedback/feedbackStore.test.ts
+++ b/apps/web/src/feedback/feedbackStore.test.ts
@@ -1,0 +1,174 @@
+import { IDBFactory } from "fake-indexeddb";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { absentBodyAnchors, absentHandSlots } from "../landmarks/protocol";
+import type { LiveFeedbackContext } from "../live/liveRecognitionSession";
+import {
+  CANDIDATE_INFERENCE_PROTOCOL_VERSION,
+  type CandidateInferenceResult,
+} from "../inference/candidateInferenceProtocol";
+import {
+  mapFeedbackStoreError,
+  NativeFeedbackStore,
+  type FeedbackSubmission,
+} from "./feedbackStore";
+
+const result: CandidateInferenceResult = {
+  type: "result",
+  protocolVersion: CANDIDATE_INFERENCE_PROTOCOL_VERSION,
+  requestId: 4,
+  bundle: { id: "candidate", version: "1" },
+  backend: "wasm",
+  decision: { kind: "target", label: "hello", confidence: 0.7 },
+  reason: "accepted_target",
+  rankedScores: [
+    { label: "hello", confidence: 0.7 },
+    { label: "no", confidence: 0.1 },
+    { label: "please", confidence: 0.08 },
+    { label: "thank_you", confidence: 0.05 },
+    { label: "yes", confidence: 0.04 },
+    { label: "other", confidence: 0.03 },
+  ],
+  timings: { preprocessingMs: 1, inferenceMs: 2, decisionMs: 1, totalMs: 4 },
+};
+
+const context: LiveFeedbackContext = {
+  event: {
+    firstFrameIndex: 2,
+    lastFrameIndex: 2,
+    firstTimestampUs: 10,
+    lastTimestampUs: 10,
+    terminationReason: "settled",
+    configSha256: "sha256:detector",
+  },
+  input: {
+    frames: [
+      {
+        relativeTimestampUs: 0,
+        valid: true,
+        hands: absentHandSlots(),
+        bodyAnchors: absentBodyAnchors(),
+      },
+    ],
+    sourceMirrorState: "not_mirrored",
+    quality: { timestampDiscontinuityCount: 0, gaps: [] },
+  },
+};
+
+const submission = (includeLandmarks = false): FeedbackSubmission => ({
+  result,
+  context,
+  correction: "yes",
+  includeLandmarks,
+  previewMirrored: true,
+});
+
+function store(factory = new IDBFactory(), name = "feedback-test") {
+  let id = 0;
+  return new NativeFeedbackStore(
+    factory,
+    name,
+    () => "2026-08-31T12:00:00.000Z",
+    () => `feedback-${++id}`,
+  );
+}
+
+function open(factory: IDBFactory, name: string, version: number): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = factory.open(name, version);
+    request.onerror = () => reject(request.error ?? new Error("database open failed"));
+    request.onsuccess = () => resolve(request.result);
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("NativeFeedbackStore", () => {
+  it("writes only the disclosed v1 fields and causes no network request", async () => {
+    const feedback = store();
+    const fetchSpy = vi.fn();
+    const socketSpy = vi.fn();
+    const beaconSpy = vi.fn();
+    const xhrSpy = vi.spyOn(XMLHttpRequest.prototype, "send");
+    vi.stubGlobal("fetch", fetchSpy);
+    vi.stubGlobal("WebSocket", socketSpy);
+    vi.stubGlobal("navigator", { sendBeacon: beaconSpy });
+
+    const saved = await feedback.save({
+      ...submission(),
+      rawVideo: new Blob(["private"]),
+      deviceId: "camera-name",
+    } as FeedbackSubmission);
+    expect(Object.keys(saved).sort()).toEqual([
+      "bundle",
+      "conditions",
+      "consent",
+      "correction",
+      "event",
+      "format",
+      "id",
+      "prediction",
+      "savedAt",
+      "scores",
+      "timings",
+    ]);
+    expect(saved).not.toHaveProperty("landmarks");
+    expect(JSON.stringify(saved)).not.toContain("private");
+    expect(JSON.stringify(saved)).not.toContain("camera-name");
+
+    const withLandmarks = await feedback.save(submission(true));
+    expect(withLandmarks).toHaveProperty("landmarks.0.hands");
+    expect((await feedback.list()).records).toHaveLength(2);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(xhrSpy).not.toHaveBeenCalled();
+    expect(socketSpy).not.toHaveBeenCalled();
+    expect(beaconSpy).not.toHaveBeenCalled();
+  });
+
+  it("updates, deletes, clears, and isolates damaged records", async () => {
+    const factory = new IDBFactory();
+    const feedback = store(factory);
+    const first = await feedback.save(submission());
+    const second = await feedback.save(submission());
+    await feedback.updateCorrection(first.id, "inactive");
+    await feedback.delete(second.id);
+    expect((await feedback.list()).records[0]?.correction).toBe("inactive");
+
+    const database = await open(factory, "feedback-test", 1);
+    const transaction = database.transaction("events", "readwrite");
+    // prettier-ignore
+    const damaged: Record<string, unknown>[] = [
+      { ...structuredClone(first), id: "bad-time", savedAt: "garbage", consent: { ...first.consent, grantedAt: "garbage" } },
+      { ...structuredClone(first), id: "no-scores", scores: [] },
+      { ...structuredClone(first), id: "cyclic" },
+    ];
+    damaged[2]!.prediction = { decision: damaged[2], reason: "accepted_target" };
+    damaged.forEach((record) => transaction.objectStore("events").put(record));
+    await new Promise<void>((resolve, reject) => {
+      transaction.oncomplete = () => resolve();
+      transaction.onabort = () => reject(transaction.error ?? new Error("transaction failed"));
+    });
+    database.close();
+    expect((await feedback.list()).records).toHaveLength(1);
+    expect((await feedback.list()).damagedKeys).toEqual(["bad-time", "cyclic", "no-scores"]);
+    await feedback.clear();
+    expect(await feedback.list()).toEqual({ records: [], damagedKeys: [] });
+  });
+
+  it("reports unavailable, quota, and newer-version storage safely", async () => {
+    await expect(new NativeFeedbackStore(null).list()).rejects.toMatchObject({
+      code: "unavailable",
+    });
+    expect(mapFeedbackStoreError(new DOMException("full", "QuotaExceededError")).code).toBe(
+      "quota",
+    );
+    const factory = new IDBFactory();
+    (await open(factory, "future-feedback", 2)).close();
+    await expect(store(factory, "future-feedback").list()).rejects.toMatchObject({
+      code: "version",
+    });
+  });
+});

--- a/apps/web/src/feedback/feedbackStore.ts
+++ b/apps/web/src/feedback/feedbackStore.ts
@@ -1,0 +1,263 @@
+import type { CandidateInferenceResult } from "../inference/candidateInferenceProtocol";
+import { BODY_ANCHOR_NAMES, HAND_SLOT_IDS } from "../landmarks/protocol";
+import type { LiveFeedbackContext } from "../live/liveRecognitionSession";
+
+// prettier-ignore
+export const FEEDBACK_LABELS = ["hello", "no", "please", "thank_you", "yes", "other", "inactive"] as const;
+export type FeedbackLabel = (typeof FEEDBACK_LABELS)[number];
+
+export interface FeedbackSubmission {
+  readonly result: CandidateInferenceResult;
+  readonly context: LiveFeedbackContext;
+  readonly correction: FeedbackLabel;
+  readonly includeLandmarks: boolean;
+  readonly previewMirrored: boolean;
+}
+
+export interface FeedbackListResult {
+  readonly records: readonly FeedbackRecord[];
+  readonly damagedKeys: readonly IDBValidKey[];
+}
+
+export interface FeedbackStore {
+  save(submission: FeedbackSubmission): Promise<FeedbackRecord>;
+  list(): Promise<FeedbackListResult>;
+  updateCorrection(id: string, correction: FeedbackLabel): Promise<void>;
+  delete(key: IDBValidKey): Promise<void>;
+  clear(): Promise<void>;
+}
+
+export class FeedbackStoreError extends Error {
+  constructor(readonly code: "unavailable" | "blocked" | "quota" | "version") {
+    super(`feedback.storage.${code}`);
+  }
+}
+
+function buildRecord(submission: FeedbackSubmission, id: string, savedAt: string) {
+  const { result, context } = submission;
+  const record = {
+    format: "signlab-feedback-record/1" as const,
+    id,
+    savedAt,
+    bundle: { ...result.bundle },
+    prediction: { decision: structuredClone(result.decision), reason: result.reason },
+    scores: result.rankedScores.map(({ label, confidence }) => ({ label, confidence })),
+    timings: { ...result.timings },
+    event: {
+      ...context.event,
+      durationUs: context.event.lastTimestampUs - context.event.firstTimestampUs,
+    },
+    conditions: {
+      sourceMirrorState: context.input.sourceMirrorState,
+      previewMirrored: submission.previewMirrored,
+    },
+    correction: submission.correction,
+    consent: {
+      mode: "per_event" as const,
+      scope: "local_feedback_only" as const,
+      grantedAt: savedAt,
+      landmarksIncluded: submission.includeLandmarks,
+    },
+  };
+  return submission.includeLandmarks
+    ? { ...record, landmarks: structuredClone(context.input.frames) }
+    : record;
+}
+
+export type FeedbackRecord = Readonly<ReturnType<typeof buildRecord>>;
+
+const object = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+type Rule = ((value: unknown) => boolean) | { readonly [field: string]: Rule };
+function matches(value: unknown, rule: Rule): boolean {
+  if (typeof rule === "function") return rule(value);
+  if (!object(value)) return false;
+  const fields = Object.entries(rule);
+  return (
+    Object.keys(value).length === fields.length &&
+    fields.every(([field, child]) => Object.hasOwn(value, field) && matches(value[field], child))
+  );
+}
+
+const oneOf =
+  (...allowed: unknown[]): Rule =>
+  (value) =>
+    allowed.includes(value);
+const nullable =
+  (rule: Rule): Rule =>
+  (value) =>
+    value === null || matches(value, rule);
+const list =
+  (rule: Rule): Rule =>
+  (value) =>
+    Array.isArray(value) && value.every((item) => matches(item, rule));
+const tuple =
+  (...rules: Rule[]): Rule =>
+  (value) =>
+    Array.isArray(value) &&
+    value.length === rules.length &&
+    rules.every((rule, index) => matches(value[index], rule));
+const text = (value: unknown) => typeof value === "string";
+const bool = (value: unknown) => typeof value === "boolean";
+const iso = (value: unknown) =>
+  typeof value === "string" &&
+  !Number.isNaN(Date.parse(value)) &&
+  new Date(value).toISOString() === value;
+const finite = (value: unknown): value is number =>
+  typeof value === "number" && Number.isFinite(value);
+const nonnegative = (value: unknown): value is number => finite(value) && value >= 0;
+const whole = (value: unknown): value is number =>
+  nonnegative(value) && Number.isSafeInteger(value);
+const probability = (value: unknown): value is number => nonnegative(value) && value <= 1;
+
+// prettier-ignore
+const pointRule = { x: finite, y: finite, z: finite, visibility: nullable(probability), presence: nullable(probability) } satisfies Rule;
+// prettier-ignore
+const handRule = (slotId: string): Rule => ({ slotId: oneOf(slotId), present: bool, detectorIndex: nullable(whole), trackingId: nullable(oneOf(...HAND_SLOT_IDS)), handedness: nullable(oneOf("left", "right")), handednessConfidence: nullable(probability), imageLandmarks: nullable(list(pointRule)), worldLandmarks: nullable(list(pointRule)) });
+// prettier-ignore
+const anchorRule = (name: string): Rule => ({ name: oneOf(name), present: bool, imagePoint: nullable(pointRule), worldPoint: nullable(pointRule) });
+// prettier-ignore
+const frameRule = { relativeTimestampUs: whole, valid: bool, hands: tuple(...HAND_SLOT_IDS.map(handRule)), bodyAnchors: tuple(...BODY_ANCHOR_NAMES.map(anchorRule)) } satisfies Rule;
+// prettier-ignore
+const decisionRule: Rule = (value) => matches(value, { kind: oneOf("abstain") }) || matches(value, { kind: oneOf("other"), label: oneOf("other"), confidence: probability }) || matches(value, { kind: oneOf("target"), label: oneOf(...FEEDBACK_LABELS.slice(0, 5)), confidence: probability });
+// prettier-ignore
+const RECORD_RULE = {
+  format: oneOf("signlab-feedback-record/1"), id: text, savedAt: iso,
+  bundle: { id: text, version: text },
+  prediction: { decision: decisionRule, reason: oneOf("accepted_target", "accepted_other", "below_threshold") },
+  scores: list({ label: oneOf(...FEEDBACK_LABELS.slice(0, 6)), confidence: probability }),
+  timings: { preprocessingMs: nonnegative, inferenceMs: nonnegative, decisionMs: nonnegative, totalMs: nonnegative },
+  event: { firstFrameIndex: whole, lastFrameIndex: whole, firstTimestampUs: whole, lastTimestampUs: whole, terminationReason: oneOf("settled", "signal_gap", "max_duration", "stream_end"), configSha256: text, durationUs: nonnegative },
+  conditions: { sourceMirrorState: oneOf("mirrored", "not_mirrored"), previewMirrored: bool },
+  correction: oneOf(...FEEDBACK_LABELS),
+  consent: { mode: oneOf("per_event"), scope: oneOf("local_feedback_only"), grantedAt: iso, landmarksIncluded: bool },
+} satisfies Record<string, Rule>;
+
+function isRecord(value: unknown): value is FeedbackRecord {
+  const hasLandmarks = object(value) && Object.hasOwn(value, "landmarks");
+  if (!matches(value, hasLandmarks ? { ...RECORD_RULE, landmarks: list(frameRule) } : RECORD_RULE))
+    return false;
+  const record = value as FeedbackRecord;
+  return (
+    record.consent.grantedAt === record.savedAt &&
+    record.consent.landmarksIncluded === hasLandmarks &&
+    record.scores.length === 6 &&
+    new Set(record.scores.map(({ label }) => label)).size === 6 &&
+    record.event.lastFrameIndex >= record.event.firstFrameIndex &&
+    record.event.durationUs === record.event.lastTimestampUs - record.event.firstTimestampUs
+  );
+}
+
+export function mapFeedbackStoreError(error: unknown): FeedbackStoreError {
+  const name = object(error) ? error.name : "";
+  if (name === "QuotaExceededError") return new FeedbackStoreError("quota");
+  if (name === "VersionError") return new FeedbackStoreError("version");
+  return error instanceof FeedbackStoreError ? error : new FeedbackStoreError("unavailable");
+}
+
+const requested = <T>(request: IDBRequest<T>) =>
+  new Promise<T>((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(mapFeedbackStoreError(request.error));
+  });
+
+export class NativeFeedbackStore implements FeedbackStore {
+  constructor(
+    private readonly factory: IDBFactory | null = globalThis.indexedDB ?? null,
+    private readonly databaseName = "signlab-feedback",
+    private readonly now = () => new Date().toISOString(),
+    private readonly createId: () => string = () => globalThis.crypto.randomUUID(),
+  ) {}
+
+  private open(): Promise<IDBDatabase> {
+    if (this.factory === null) return Promise.reject(new FeedbackStoreError("unavailable"));
+    return new Promise((resolve, reject) => {
+      let blocked = false;
+      let request: IDBOpenDBRequest;
+      try {
+        request = this.factory!.open(this.databaseName, 1);
+      } catch (error) {
+        reject(mapFeedbackStoreError(error));
+        return;
+      }
+      request.onupgradeneeded = () => {
+        if (!request.result.objectStoreNames.contains("events"))
+          request.result.createObjectStore("events", { keyPath: "id" });
+      };
+      request.onblocked = () => {
+        blocked = true;
+        reject(new FeedbackStoreError("blocked"));
+      };
+      request.onerror = () => reject(mapFeedbackStoreError(request.error));
+      request.onsuccess = () => {
+        if (blocked) return request.result.close();
+        request.result.onversionchange = () => request.result.close();
+        resolve(request.result);
+      };
+    });
+  }
+
+  private async transact<T>(
+    mode: IDBTransactionMode,
+    action: (store: IDBObjectStore) => Promise<T>,
+  ): Promise<T> {
+    const database = await this.open();
+    try {
+      const transaction = database.transaction("events", mode);
+      const completed = new Promise<void>((resolve, reject) => {
+        transaction.oncomplete = () => resolve();
+        transaction.onabort = transaction.onerror = () =>
+          reject(mapFeedbackStoreError(transaction.error));
+      });
+      const [result] = await Promise.all([action(transaction.objectStore("events")), completed]);
+      return result;
+    } catch (error) {
+      throw mapFeedbackStoreError(error);
+    } finally {
+      database.close();
+    }
+  }
+
+  async save(submission: FeedbackSubmission): Promise<FeedbackRecord> {
+    const record = buildRecord(submission, this.createId(), this.now());
+    if (!isRecord(record)) throw new FeedbackStoreError("unavailable");
+    return this.transact("readwrite", (store) => requested(store.put(record)).then(() => record));
+  }
+
+  list(): Promise<FeedbackListResult> {
+    return this.transact(
+      "readonly",
+      (store) =>
+        new Promise((resolve, reject) => {
+          const records: FeedbackRecord[] = [];
+          const damagedKeys: IDBValidKey[] = [];
+          const request = store.openCursor();
+          request.onerror = () => reject(mapFeedbackStoreError(request.error));
+          request.onsuccess = () => {
+            const cursor = request.result;
+            if (cursor === null) return resolve({ records, damagedKeys });
+            if (isRecord(cursor.value)) records.push(cursor.value);
+            else damagedKeys.push(cursor.primaryKey);
+            cursor.continue();
+          };
+        }),
+    );
+  }
+
+  updateCorrection(id: string, correction: FeedbackLabel): Promise<void> {
+    return this.transact("readwrite", async (store) => {
+      const record: unknown = await requested(store.get(id));
+      if (!isRecord(record)) throw new FeedbackStoreError("unavailable");
+      await requested(store.put({ ...record, correction }));
+    });
+  }
+
+  delete(key: IDBValidKey): Promise<void> {
+    return this.transact("readwrite", async (store) => void (await requested(store.delete(key))));
+  }
+
+  clear(): Promise<void> {
+    return this.transact("readwrite", async (store) => void (await requested(store.clear())));
+  }
+}

--- a/apps/web/src/live/liveRecognitionSession.test.ts
+++ b/apps/web/src/live/liveRecognitionSession.test.ts
@@ -229,6 +229,10 @@ describe("LiveRecognitionSession", () => {
     const stable = result(request.requestId);
     runtime.emitInference(stable);
     expect(runtime.snapshots.at(-1)).toMatchObject({ phase: "result", stableResult: stable });
+    expect(runtime.snapshots.at(-1)?.feedbackContext).toMatchObject({
+      event: { firstFrameIndex: 0, lastFrameIndex: 4, terminationReason: "signal_gap" },
+      input: request.input,
+    });
   });
 
   it("discards an event containing an invalid frame without classifying", async () => {

--- a/apps/web/src/live/liveRecognitionSession.ts
+++ b/apps/web/src/live/liveRecognitionSession.ts
@@ -35,9 +35,15 @@ export interface LiveRecognitionDiagnostics {
   readonly bundle: { readonly id: string; readonly version: string } | null;
 }
 
+export interface LiveFeedbackContext {
+  readonly event: CandidateEvent;
+  readonly input: CandidateInferenceInput;
+}
+
 export interface LiveRecognitionSnapshot {
   readonly phase: LiveRecognitionPhase;
   readonly stableResult: CandidateInferenceResult | null;
+  readonly feedbackContext?: LiveFeedbackContext | null;
   readonly failureCode: string | null;
   readonly diagnostics?: LiveRecognitionDiagnostics;
 }
@@ -75,6 +81,7 @@ export class LiveRecognitionSession {
   private nextDetectorIndex = 0;
   private nextRequestId = 0;
   private activeRequestId: number | null = null;
+  private pendingFeedbackContext: LiveFeedbackContext | null = null;
   private bufferedFrames: BufferedFrame[] = [];
   private retentionUs = 0;
 
@@ -142,6 +149,7 @@ export class LiveRecognitionSession {
     if (!this.closed) {
       this.closed = true;
       this.bufferedFrames = [];
+      this.pendingFeedbackContext = null;
       this.projector.reset();
       if (this.snapshotValue.phase !== "failed") this.closeClients();
     }
@@ -203,6 +211,7 @@ export class LiveRecognitionSession {
       return this.fail("live.recognition.inference.unavailable");
     const requestId = this.nextRequestId++;
     this.activeRequestId = requestId;
+    this.pendingFeedbackContext = Object.freeze({ event, input });
     this.publish("classifying");
     try {
       client.classify(requestId, input);
@@ -249,11 +258,14 @@ export class LiveRecognitionSession {
         this.updateDiagnostics({ backend: event.backend, bundle: event.bundle });
         if (++this.readyWorkers === 2) this.publish("ready");
         return;
-      case "result":
-        if (event.requestId !== this.activeRequestId)
+      case "result": {
+        if (event.requestId !== this.activeRequestId || this.pendingFeedbackContext === null)
           return this.fail("live.recognition.inference.result_mismatch");
+        const feedbackContext = this.pendingFeedbackContext;
         this.activeRequestId = null;
-        return this.publish("result", event);
+        this.pendingFeedbackContext = null;
+        return this.publish("result", event, null, feedbackContext);
+      }
       case "failure":
       case "worker-transport-failure":
         return this.fail(event.code);
@@ -266,10 +278,12 @@ export class LiveRecognitionSession {
     phase: LiveRecognitionPhase,
     stableResult = this.snapshotValue.stableResult,
     failureCode: string | null = null,
+    feedbackContext = this.snapshotValue.feedbackContext ?? null,
   ): void {
     this.snapshotValue = Object.freeze({
       phase,
       stableResult,
+      feedbackContext,
       failureCode,
       diagnostics: this.diagnosticsValue,
     });
@@ -285,6 +299,7 @@ export class LiveRecognitionSession {
     this.bufferedFrames = [];
     this.projector.reset();
     this.activeRequestId = null;
+    this.pendingFeedbackContext = null;
     this.publish("failed", this.snapshotValue.stableResult, code);
     this.closeClients();
   }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -571,6 +571,73 @@ h1 {
   text-align: right;
 }
 
+.feedback-save {
+  display: grid;
+  gap: 0.75rem;
+  padding-top: 1rem;
+  margin-top: 1rem;
+  border-top: 1px solid rgb(242 241 233 / 18%);
+}
+
+.feedback-save fieldset {
+  display: contents;
+}
+
+.feedback-save label:not(.feedback-check) {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.feedback-save select,
+.feedback-list select {
+  padding: 0.55rem;
+  border-radius: 0.5rem;
+  font: inherit;
+}
+
+.feedback-check {
+  display: flex;
+  gap: 0.5rem;
+  align-items: start;
+  color: #d4dfdc;
+  font-size: 0.82rem;
+}
+
+.feedback-save button,
+.feedback-list button,
+.danger-action {
+  width: fit-content;
+  padding: 0.65rem 0.85rem;
+  border: 1px solid currentcolor;
+  border-radius: 999px;
+  font: inherit;
+  font-weight: 750;
+  cursor: pointer;
+}
+
+.feedback-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.feedback-list article {
+  padding: 1.25rem;
+  border: 1px solid rgb(21 48 47 / 16%);
+  border-radius: 1rem;
+  background: rgb(255 255 255 / 55%);
+}
+
+.feedback-list label {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.feedback-list pre {
+  overflow: auto;
+  max-height: 24rem;
+  font-size: 0.72rem;
+}
+
 .live-diagnostics {
   padding-top: 1rem;
   margin-top: 1rem;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -45,8 +45,10 @@ user action and can show a local preview. It stops camera tracks on stop, naviga
 page hiding, or device interruption. After a bundle is verified, it loads the two
 size- and digest-pinned MediaPipe task files, sends disposable frame bitmaps through
 the landmark worker, detects one bounded event, and runs ONNX inference in a second
-worker. It does not upload, record, or persist camera frames or landmarks. Replay and
-feedback remain disconnected and retain separate evidence gates.
+worker. It does not upload or record camera frames. Recognition retains only the
+latest result; an optional, separately consented feedback action may persist that
+event's derived landmarks. Replay remains disconnected and retains a separate
+evidence gate.
 
 The intended bundle-loading flow is manifest-first:
 
@@ -66,6 +68,11 @@ releases replaced or processed images and task resources. A bounded live coordin
 feeds those frames through the shared event detector and the WASM ONNX worker, then
 keeps one event-level decision stable in the React view. Replay remains a separate
 gate and will exercise this assembled post-landmark path rather than a parallel one.
+
+Feedback is a separate, explicit browser-local action. One completed event may be
+stored in IndexedDB with its correction and disclosed metadata; derived landmark
+coordinates require an additional opt-in. Raw video is never part of that record,
+and local consent does not authorize upload, export, research use, or training.
 
 The [licensed external-data boundary](external-datasets.md) is intentionally
 separate from participant ingest. It registers source, license, attribution,


### PR DESCRIPTION
Closes #50

## What changed

- adds an explicit per-result consent form with a separate landmark opt-in
- stores one exact `signlab-feedback-record/1` record in native IndexedDB
- adds a local feedback page to inspect, correct, delete, and clear records
- rejects malformed, cyclic, and future records without deleting them or falling back
- freezes event metadata, including the preview mirror setting, at the recognized result
- documents the local-only privacy boundary and adds zero-network tests

## Verification

- 114 web tests passed
- TypeScript checks passed
- ESLint passed
- Prettier check passed
- root and `/signlab/` production builds passed
- independent code and privacy reviews found no remaining blockers

## Scope evidence

- production TS/TSX: 475 added nonblank lines (exactly the hard stop)
- CSS: 57 added nonblank lines
- focused tests: 300 added nonblank lines
- one exact-pinned dev dependency: `fake-indexeddb@6.2.5`
- no backend, account, export, training, analytics, or generic persistence framework