### PR TITLE
Persist verified model bundles for offline recovery

### DIFF
--- a/apps/web/src/app/LivePage.test.tsx
+++ b/apps/web/src/app/LivePage.test.tsx
@@ -352,9 +352,38 @@ describe("model bundle status", () => {
       {
         phase: "ready",
         active: { id: "candidate_bundle", version: "1.2.3" },
+        source: "network",
       } satisfies ModelBundleStatus,
       false,
-      "Verified model bundle candidate_bundle version 1.2.3 is ready.",
+      "Verified model bundle candidate_bundle version 1.2.3 is ready and saved in this browser.",
+    ],
+    [
+      {
+        phase: "ready",
+        active: { id: "candidate_bundle", version: "1.2.3" },
+        source: "fallback",
+      } satisfies ModelBundleStatus,
+      false,
+      "Using verified cached model bundle candidate_bundle version 1.2.3 because the bundle endpoint is unavailable.",
+    ],
+    [
+      {
+        phase: "ready",
+        active: { id: "candidate_bundle", version: "1.2.3" },
+        source: "cache",
+      } satisfies ModelBundleStatus,
+      false,
+      "Verified cached model bundle candidate_bundle version 1.2.3 is ready.",
+    ],
+    [
+      {
+        phase: "ready",
+        active: { id: "candidate_bundle", version: "1.2.3" },
+        source: "network",
+        cacheWarning: "Browser storage is unavailable.",
+      } satisfies ModelBundleStatus,
+      false,
+      "Verified model bundle candidate_bundle version 1.2.3 is ready for this session. Browser storage is unavailable.",
     ],
     [
       {
@@ -381,6 +410,83 @@ describe("model bundle status", () => {
 
     expect(await screen.findByText(message)).toBeVisible();
     expect(loader.load).toHaveBeenCalledOnce();
+    expect(
+      screen.queryByRole("button", { name: "Restore previous model" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("restores the previous verified bundle only after rollback succeeds", async () => {
+    const current = { id: "candidate_bundle", version: "2.0.0" } as VerifiedModelBundle;
+    const previous = { id: "candidate_bundle", version: "1.0.0" } as VerifiedModelBundle;
+    const rollback: ModelBundleSession["rollback"] = (onStatus) => {
+      onStatus?.({
+        phase: "ready",
+        active: { id: previous.id, version: previous.version },
+        source: "rollback",
+        rollbackAvailable: true,
+      });
+      return Promise.resolve(previous);
+    };
+    const load: ModelBundleSession["load"] = (_url, onStatus) => {
+      onStatus?.({
+        phase: "ready",
+        active: { id: current.id, version: current.version },
+        source: "network",
+        rollbackAvailable: true,
+      });
+      return Promise.resolve(current);
+    };
+    const loader = {
+      status: { phase: "idle", active: null } satisfies ModelBundleStatus,
+      load: vi.fn(load),
+      rollback: vi.fn(rollback),
+    };
+
+    render(<LivePage modelBundleUrl="https://example.test/bundle/" modelBundleSession={loader} />);
+    fireEvent.click(await screen.findByRole("button", { name: "Restore previous model" }));
+
+    expect(await screen.findByText(/Restored previous verified model bundle/)).toBeVisible();
+    fireEvent.click(screen.getByText("Session diagnostics"));
+    expect(
+      within(screen.getByLabelText("Session diagnostics")).getByText("candidate_bundle 1.0.0"),
+    ).toBeVisible();
+  });
+
+  it("keeps the current bundle when rollback fails", async () => {
+    const current = { id: "candidate_bundle", version: "2.0.0" } as VerifiedModelBundle;
+    const load: ModelBundleSession["load"] = (_url, onStatus) => {
+      onStatus?.({
+        phase: "ready",
+        active: { id: current.id, version: current.version },
+        source: "network",
+        rollbackAvailable: true,
+      });
+      return Promise.resolve(current);
+    };
+    const rollback: ModelBundleSession["rollback"] = (onStatus) => {
+      onStatus?.({
+        phase: "error",
+        active: { id: current.id, version: current.version },
+        failureReason: "The cached model bundle is incomplete or damaged.",
+        source: "network",
+        rollbackAvailable: true,
+      });
+      return Promise.reject(new Error("simulated damaged rollback"));
+    };
+    const loader = {
+      status: { phase: "idle", active: null } satisfies ModelBundleStatus,
+      load: vi.fn(load),
+      rollback: vi.fn(rollback),
+    };
+
+    render(<LivePage modelBundleUrl="https://example.test/bundle/" modelBundleSession={loader} />);
+    fireEvent.click(await screen.findByRole("button", { name: "Restore previous model" }));
+
+    expect(await screen.findByText(/incomplete or damaged/)).toBeVisible();
+    fireEvent.click(screen.getByText("Session diagnostics"));
+    expect(
+      within(screen.getByLabelText("Session diagnostics")).getByText("candidate_bundle 2.0.0"),
+    ).toBeVisible();
   });
 
   it("retries a blocked bundle load without reloading the page", async () => {

--- a/apps/web/src/app/routes.tsx
+++ b/apps/web/src/app/routes.tsx
@@ -52,7 +52,8 @@ const startableStatuses = new Set<CameraStatus>([
   "error",
 ]);
 
-type BundleLoader = Pick<ModelBundleSession, "load" | "status">;
+type BundleLoader = Pick<ModelBundleSession, "load" | "status"> &
+  Partial<Pick<ModelBundleSession, "rollback">>;
 type LiveSession = Pick<LiveRecognitionSession, "initialize" | "submitFrame" | "close">;
 
 interface LiveRuntime {
@@ -91,7 +92,16 @@ function bundleStatusMessage(status: ModelBundleStatus): string {
   if (status.phase === "idle") return "No model bundle is configured.";
   if (status.phase === "loading") return "Loading the model bundle manifest and files.";
   if (status.phase === "verifying") return "Verifying every model bundle file.";
-  if (status.phase === "ready") return `Verified model bundle ${active ?? ""} is ready.`;
+  if (status.phase === "ready") {
+    if (status.source === "fallback")
+      return `Using verified cached model bundle ${active ?? ""} because the bundle endpoint is unavailable.`;
+    if (status.source === "cache") return `Verified cached model bundle ${active ?? ""} is ready.`;
+    if (status.source === "rollback")
+      return `Restored previous verified model bundle ${active ?? ""}.`;
+    if (status.source === "network")
+      return `Verified model bundle ${active ?? ""} is ready${status.cacheWarning === undefined ? " and saved in this browser." : ` for this session. ${status.cacheWarning}`}`;
+    return `Verified model bundle ${active ?? ""} is ready.`;
+  }
   const fallback = "The model bundle could not be activated.";
   return `${status.failureReason ?? fallback}${active === null ? "" : ` ${active} remains active.`}`;
 }
@@ -287,6 +297,8 @@ export function LivePage({
   const bundleBlocked = bundleStatus.phase === "error" && bundleStatus.active === null;
   const runtimeFailed = state.status === "active" && liveSnapshot?.phase === "failed";
   const retryAvailable = bundleBlocked || runtimeFailed;
+  const rollbackAvailable =
+    bundleStatus.rollbackAvailable === true && bundleLoader.rollback !== undefined;
   const diagnosticBundle = diagnostics?.bundle ?? stableResult?.bundle ?? verifiedBundle;
   const retrySetup = () => {
     if (bundleBlocked) {
@@ -294,6 +306,16 @@ export function LivePage({
       setBundleAttempt((attempt) => attempt + 1);
     }
     if (runtimeFailed) setRuntimeAttempt((attempt) => attempt + 1);
+  };
+  const restorePrevious = () => {
+    if (bundleLoader.rollback === undefined) return;
+    void bundleLoader
+      .rollback(setBundleStatus)
+      .then((bundle) => {
+        setLiveSnapshot(null);
+        setVerifiedBundle(bundle);
+      })
+      .catch(() => undefined);
   };
 
   return (
@@ -342,6 +364,18 @@ export function LivePage({
               Retry setup
             </button>
             <span>Retries the failed setup without reloading this page.</span>
+          </div>
+        ) : null}
+        {rollbackAvailable ? (
+          <div className="recovery-action">
+            <button
+              type="button"
+              disabled={bundleStatus.phase === "loading" || bundleStatus.phase === "verifying"}
+              onClick={restorePrevious}
+            >
+              Restore previous model
+            </button>
+            <span>Rechecks and restores the one previously verified model.</span>
           </div>
         ) : null}
       </div>

--- a/apps/web/src/modelBundle/modelBundleCache.ts
+++ b/apps/web/src/modelBundle/modelBundleCache.ts
@@ -1,0 +1,182 @@
+const CACHE = "signlab-model-bundles";
+const ROOT = "https://model-bundle-cache.signlab.invalid/v1";
+const POINTER = `${ROOT}/pointer`;
+const FORMAT = "signlab-model-bundle-pointer/1";
+const SHA256 = /^sha256:[0-9a-f]{64}$/;
+
+type Storage = Pick<CacheStorage, "open">;
+type Pointer = {
+  readonly format: typeof FORMAT;
+  readonly active: string;
+  readonly previous: string | null;
+};
+type PointerRead = Pointer | "missing" | "unsupported";
+
+export type ModelBundleCacheState = Pick<Pointer, "active" | "previous">;
+type Activation = { state: ModelBundleCacheState | null; saved: boolean };
+export interface CachedModelBundle {
+  readonly identity: string;
+  readonly manifest: Blob;
+  readonly state: ModelBundleCacheState | null;
+  asset(role: string): Promise<Blob | null>;
+}
+
+const url = (identity: string, name: string) =>
+  `${ROOT}/bundles/${encodeURIComponent(identity)}/${encodeURIComponent(name)}`;
+
+function validPointer(value: unknown): value is Pointer {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const pointer = value as Record<string, unknown>;
+  return (
+    pointer.format === FORMAT &&
+    typeof pointer.active === "string" &&
+    SHA256.test(pointer.active) &&
+    (pointer.previous === null ||
+      (typeof pointer.previous === "string" && SHA256.test(pointer.previous))) &&
+    pointer.active !== pointer.previous
+  );
+}
+
+async function readPointer(cache: Cache): Promise<PointerRead> {
+  try {
+    const response = await cache.match(POINTER);
+    if (response === undefined) return "missing";
+    const value: unknown = await response.json();
+    return validPointer(value) ? value : "unsupported";
+  } catch {
+    return "unsupported";
+  }
+}
+
+const stateOf = (value: PointerRead) => (typeof value === "string" ? null : value);
+
+function nextPointer(current: ModelBundleCacheState | null, identity: string): Pointer {
+  return {
+    format: FORMAT,
+    active: identity,
+    previous: current?.active === identity ? current.previous : (current?.active ?? null),
+  };
+}
+
+const putPointer = async (cache: Cache, pointer: Pointer) =>
+  await cache.put(
+    POINTER,
+    new Response(JSON.stringify(pointer), { headers: { "content-type": "application/json" } }),
+  );
+
+export class ModelBundleCache {
+  constructor(private readonly storage: Storage | undefined) {}
+
+  async read(identity: string): Promise<CachedModelBundle | null> {
+    if (!SHA256.test(identity)) return null;
+    const cache = await this.open();
+    if (cache === null) return null;
+    return await this.entry(cache, identity, stateOf(await readPointer(cache)));
+  }
+
+  async saveAndActivate(bundle: {
+    identity: string;
+    manifest: Blob;
+    bytesByRole: Readonly<Record<string, Blob>>;
+  }): Promise<Activation> {
+    return await this.store(bundle.identity, async (cache) => {
+      await cache.put(
+        url(bundle.identity, "manifest"),
+        new Response(await bundle.manifest.arrayBuffer()),
+      );
+      for (const [role, bytes] of Object.entries(bundle.bytesByRole)) {
+        await cache.put(url(bundle.identity, role), new Response(await bytes.arrayBuffer()));
+      }
+    });
+  }
+
+  async activate(identity: string): Promise<Activation> {
+    return await this.store(identity, () => Promise.resolve());
+  }
+
+  private async store(
+    identity: string,
+    stage: (cache: Cache) => Promise<void>,
+  ): Promise<Activation> {
+    const cache = await this.open();
+    if (cache === null || !SHA256.test(identity)) return { state: null, saved: false };
+    const stored = await readPointer(cache);
+    const current = stateOf(stored);
+    if (stored === "unsupported") return { state: current, saved: false };
+    try {
+      await stage(cache);
+      if (current?.active === identity) return { state: current, saved: true };
+      const next = nextPointer(current, identity);
+      await putPointer(cache, next);
+      const obsolete = current?.previous;
+      if (obsolete !== undefined && obsolete !== null && !Object.values(next).includes(obsolete)) {
+        await this.remove(cache, obsolete).catch(() => undefined);
+      }
+      return { state: next, saved: true };
+    } catch {
+      return { state: current, saved: false };
+    }
+  }
+
+  async rollback(identity: string): Promise<ModelBundleCacheState | null> {
+    const cache = await this.open();
+    if (cache === null) return null;
+    const stored = await readPointer(cache);
+    if (typeof stored === "string" || stored.previous !== identity) return null;
+    const next: Pointer = { format: FORMAT, active: identity, previous: stored.active };
+    try {
+      await putPointer(cache, next);
+      return next;
+    } catch {
+      return null;
+    }
+  }
+
+  async readSelected(key: "active" | "previous"): Promise<CachedModelBundle | null> {
+    const cache = await this.open();
+    if (cache === null) return null;
+    const pointer = await readPointer(cache);
+    if (typeof pointer === "string" || pointer[key] === null) return null;
+    return await this.entry(cache, pointer[key], pointer);
+  }
+
+  private async entry(
+    cache: Cache,
+    identity: string,
+    state: ModelBundleCacheState | null,
+  ): Promise<CachedModelBundle | null> {
+    try {
+      const response = await cache.match(url(identity, "manifest"));
+      if (response === undefined) return null;
+      return {
+        identity,
+        manifest: await response.blob(),
+        state,
+        asset: async (role) => {
+          try {
+            return (await cache.match(url(identity, role)))?.blob() ?? null;
+          } catch {
+            return null;
+          }
+        },
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  private async open(): Promise<Cache | null> {
+    try {
+      return (await this.storage?.open(CACHE)) ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  private async remove(cache: Cache, identity: string): Promise<void> {
+    const prefix = `${ROOT}/bundles/${encodeURIComponent(identity)}/`;
+    for (const request of await cache.keys()) {
+      if (request.url.startsWith(prefix)) await cache.delete(request);
+    }
+  }
+}

--- a/apps/web/src/modelBundle/modelBundleSession.test.ts
+++ b/apps/web/src/modelBundle/modelBundleSession.test.ts
@@ -1,4 +1,4 @@
-import { webcrypto } from "node:crypto";
+import { createHash, webcrypto } from "node:crypto";
 import { describe, expect, it, vi } from "vitest";
 
 import candidateDecisionPolicy from "../../../../docs/reports/popsign-constructed-calibration-policy-v1.json";
@@ -12,10 +12,12 @@ import {
   type ModelBundleAssetRole,
   type ModelBundleEnvironment,
   type ModelBundleStatus,
+  type VerifiedModelBundle,
 } from "./modelBundleSession";
 
 const BASE_URL = "https://example.test/models/candidate/";
 const MANIFEST_URL = `${BASE_URL}manifest.json`;
+const CACHE_POINTER = "https://model-bundle-cache.signlab.invalid/v1/pointer";
 const encoder = new TextEncoder();
 
 function jsonBytes(value: unknown): Uint8Array {
@@ -33,7 +35,66 @@ async function sha256(bytes: Uint8Array): Promise<string> {
   ).join("")}`;
 }
 
-async function fixture() {
+class MemoryCacheStorage {
+  readonly entries = new Map<string, Response>();
+  failPointerWrites = false;
+  failDeletes = false;
+  pointerWrites = 0;
+  deleteAttempts = 0;
+  pointerWriteGate?: Promise<void>;
+  readonly cache = {
+    match: vi.fn((request: RequestInfo | URL) =>
+      Promise.resolve(this.entries.get(this.key(request))?.clone()),
+    ),
+    put: vi.fn(async (request: RequestInfo | URL, response: Response) => {
+      const key = this.key(request);
+      if (key === CACHE_POINTER) {
+        this.pointerWrites += 1;
+        await this.pointerWriteGate;
+      }
+      if (this.failPointerWrites && key === CACHE_POINTER) {
+        throw new DOMException("quota reached", "QuotaExceededError");
+      }
+      this.entries.set(key, response.clone());
+    }),
+    keys: vi.fn(() => Promise.resolve([...this.entries.keys()].map((key) => new Request(key)))),
+    delete: vi.fn((request: RequestInfo | URL) => {
+      this.deleteAttempts += 1;
+      if (this.failDeletes) return Promise.reject(new Error("simulated cleanup failure"));
+      return Promise.resolve(this.entries.delete(this.key(request)));
+    }),
+  } as unknown as Cache;
+  readonly storage = {
+    open: vi.fn(() => Promise.resolve(this.cache)),
+  } as unknown as CacheStorage;
+
+  seedPointer(value: unknown) {
+    this.entries.set(CACHE_POINTER, new Response(JSON.stringify(value)));
+  }
+
+  async pointer(): Promise<Record<string, unknown> | null> {
+    const response = this.entries.get(CACHE_POINTER);
+    return response === undefined
+      ? null
+      : ((await response.clone().json()) as Record<string, unknown>);
+  }
+
+  replace(identity: string, role: ModelBundleAssetRole, body: BodyInit) {
+    const encoded = encodeURIComponent(identity);
+    const key = [...this.entries.keys()].find(
+      (candidate) => candidate.includes(`/bundles/${encoded}/`) && candidate.endsWith(`/${role}`),
+    );
+    if (key === undefined) throw new Error(`Missing cached ${role}`);
+    this.entries.set(key, new Response(body));
+  }
+
+  private key(request: RequestInfo | URL): string {
+    if (typeof request === "string") return request;
+    return request instanceof URL ? request.href : request.url;
+  }
+}
+
+async function fixture(version = manifestExample.version) {
   const bytes: Record<ModelBundleAssetRole, Uint8Array> = {
     decision_policy: jsonBytes(candidateDecisionPolicy),
     feature_plan: jsonBytes(candidateFeaturePlan),
@@ -45,6 +106,7 @@ async function fixture() {
     segmenter: jsonBytes(candidateEventConfig),
   };
   const manifest = structuredClone(manifestExample);
+  manifest.version = version;
   for (const asset of manifest.assets) {
     const raw = bytes[asset.role as ModelBundleAssetRole];
     asset.size_bytes = raw.byteLength;
@@ -57,13 +119,18 @@ function harness(
   manifest: typeof manifestExample,
   bytes: Record<ModelBundleAssetRole, Uint8Array>,
   manifestBody: unknown = manifest,
+  cache?: MemoryCacheStorage,
 ) {
   const requests: string[] = [];
   const responses = { ...bytes };
   const failures = new Set<ModelBundleAssetRole>();
+  const network = { manifestUnavailable: false };
   const fetch = vi.fn((input: URL): Promise<Response> => {
     requests.push(input.href);
     if (input.href === MANIFEST_URL) {
+      if (network.manifestUnavailable) {
+        return Promise.reject(new TypeError("simulated offline endpoint"));
+      }
       const body = typeof manifestBody === "string" ? manifestBody : JSON.stringify(manifestBody);
       return Promise.resolve(new Response(body, { status: 200 }));
     }
@@ -78,6 +145,7 @@ function harness(
   const environment: ModelBundleEnvironment = {
     fetch,
     subtle: webcrypto.subtle as SubtleCrypto,
+    cacheStorage: cache?.storage,
   };
   return {
     session: new ModelBundleSession(environment),
@@ -85,6 +153,7 @@ function harness(
     requests,
     responses,
     failures,
+    network,
   };
 }
 
@@ -233,6 +302,240 @@ describe("ModelBundleSession", () => {
       phase: "error",
       active: { id: first.id, version: first.version },
       failureReason: "A model bundle file failed its integrity check.",
+      source: "network",
+      rollbackAvailable: false,
+      cacheWarning:
+        "Offline model storage is unavailable, so this model may need to be downloaded again.",
     });
+  });
+
+  it("stores exact verified manifest bytes and reuses matching cached assets", async () => {
+    const data = await fixture();
+    const cache = new MemoryCacheStorage();
+    const first = harness(data.manifest, data.bytes, data.manifest, cache);
+    const manifestText = JSON.stringify(data.manifest);
+
+    const saved = await first.session.load(BASE_URL);
+
+    expect(await saved.manifestBytes.text()).toBe(manifestText);
+    expect(saved.manifestSha256).toBe(
+      `sha256:${createHash("sha256")
+        .update(await saved.manifestBytes.text())
+        .digest("hex")}`,
+    );
+    expect(await cache.pointer()).toMatchObject({
+      format: "signlab-model-bundle-pointer/1",
+      active: saved.manifestSha256,
+      previous: null,
+    });
+    expect(first.session.status).toMatchObject({
+      phase: "ready",
+      source: "network",
+      rollbackAvailable: false,
+    });
+    expect(first.session.status.cacheWarning).toBeUndefined();
+
+    const warm = harness(data.manifest, data.bytes, data.manifest, cache);
+    const reused = await warm.session.load(BASE_URL);
+
+    expect(reused.manifestSha256).toBe(saved.manifestSha256);
+    expect(warm.requests).toEqual([MANIFEST_URL]);
+    expect(warm.session.status).toMatchObject({ phase: "ready", source: "cache" });
+  });
+
+  it("restores and re-verifies the active cache when the model endpoint is unavailable", async () => {
+    const data = await fixture();
+    const cache = new MemoryCacheStorage();
+    const online = harness(data.manifest, data.bytes, data.manifest, cache);
+    const saved = await online.session.load(BASE_URL);
+    const offline = harness(data.manifest, data.bytes, data.manifest, cache);
+    offline.network.manifestUnavailable = true;
+
+    const restored = await offline.session.load(BASE_URL);
+
+    expect(restored.manifestSha256).toBe(saved.manifestSha256);
+    expect(offline.requests).toEqual([MANIFEST_URL]);
+    expect(offline.session.status).toMatchObject({
+      phase: "ready",
+      source: "fallback",
+      rollbackAvailable: false,
+    });
+  });
+
+  it("repairs a corrupt warm entry from verified network bytes", async () => {
+    const data = await fixture();
+    const cache = new MemoryCacheStorage();
+    const saved = await harness(data.manifest, data.bytes, data.manifest, cache).session.load(
+      BASE_URL,
+    );
+    cache.replace(saved.manifestSha256, "model", "damaged cache bytes");
+    const warm = harness(data.manifest, data.bytes, data.manifest, cache);
+
+    const repaired = await warm.session.load(BASE_URL);
+
+    expect(repaired.manifestSha256).toBe(saved.manifestSha256);
+    expect(warm.requests).toHaveLength(9);
+    expect(warm.session.status).toMatchObject({ phase: "ready", source: "network" });
+    const offline = harness(data.manifest, data.bytes, data.manifest, cache);
+    offline.network.manifestUnavailable = true;
+    await expect(offline.session.load(BASE_URL)).resolves.toMatchObject({
+      manifestSha256: saved.manifestSha256,
+    });
+  });
+
+  it("retains one previous bundle and verifies it before an explicit rollback", async () => {
+    const cache = new MemoryCacheStorage();
+    const version1 = await fixture("1.0.0");
+    const first = harness(version1.manifest, version1.bytes, version1.manifest, cache);
+    const saved1 = await first.session.load(BASE_URL);
+    const version2 = await fixture("1.1.0");
+    const second = harness(version2.manifest, version2.bytes, version2.manifest, cache);
+    const saved2 = await second.session.load(BASE_URL);
+
+    expect(second.session.status.rollbackAvailable).toBe(true);
+    cache.failPointerWrites = true;
+    const warm = harness(version2.manifest, version2.bytes, version2.manifest, cache);
+    await warm.session.load(BASE_URL);
+    expect(warm.session.status).toMatchObject({ rollbackAvailable: true });
+    expect(warm.session.status.cacheWarning).toBeUndefined();
+    cache.failPointerWrites = false;
+    const restored = await second.session.rollback();
+
+    expect(restored.version).toBe("1.0.0");
+    expect(second.session.status).toMatchObject({
+      phase: "ready",
+      source: "rollback",
+      rollbackAvailable: true,
+    });
+    expect(await cache.pointer()).toMatchObject({
+      active: saved1.manifestSha256,
+      previous: saved2.manifestSha256,
+    });
+  });
+
+  it("keeps rollback available when an offline active cache entry is corrupt", async () => {
+    const cache = new MemoryCacheStorage();
+    const version1 = await fixture("1.0.0");
+    await harness(version1.manifest, version1.bytes, version1.manifest, cache).session.load(
+      BASE_URL,
+    );
+    const version2 = await fixture("1.1.0");
+    const online = harness(version2.manifest, version2.bytes, version2.manifest, cache);
+    const active = await online.session.load(BASE_URL);
+    cache.replace(active.manifestSha256, "model", "damaged cache bytes");
+    const offline = harness(version2.manifest, version2.bytes, version2.manifest, cache);
+    offline.network.manifestUnavailable = true;
+
+    await expect(offline.session.load(BASE_URL)).rejects.toMatchObject({
+      code: "bundle.cache.corrupt",
+    });
+    expect(offline.session.status).toMatchObject({
+      phase: "error",
+      source: "fallback",
+      rollbackAvailable: true,
+    });
+
+    await expect(offline.session.rollback()).resolves.toMatchObject({ version: "1.0.0" });
+    expect(offline.session.status.source).toBe("rollback");
+  });
+
+  it("keeps an unpersisted network replacement ready without offering the wrong rollback", async () => {
+    const cache = new MemoryCacheStorage();
+    const version1 = await fixture("1.0.0");
+    const persisted = await harness(
+      version1.manifest,
+      version1.bytes,
+      version1.manifest,
+      cache,
+    ).session.load(BASE_URL);
+    cache.failPointerWrites = true;
+    const version2 = await fixture("1.1.0");
+    const test = harness(version2.manifest, version2.bytes, version2.manifest, cache);
+
+    await expect(test.session.load(BASE_URL)).resolves.toMatchObject({ version: "1.1.0" });
+    expect(test.session.status).toMatchObject({
+      phase: "ready",
+      source: "network",
+      rollbackAvailable: false,
+    });
+    expect(test.session.status.cacheWarning).toMatch(/Offline model storage is unavailable/);
+    expect(await cache.pointer()).toMatchObject({
+      active: persisted.manifestSha256,
+      previous: null,
+    });
+    await expect(test.session.rollback()).rejects.toMatchObject({
+      code: "bundle.cache.rollback_unavailable",
+    });
+  });
+
+  it("leaves unsupported pointer metadata untouched and reports a recoverable warning", async () => {
+    const data = await fixture();
+    const cache = new MemoryCacheStorage();
+    const futurePointer = {
+      format: "signlab-model-bundle-pointer/2",
+      active: `sha256:${"a".repeat(64)}`,
+      previous: null,
+    };
+    cache.seedPointer(futurePointer);
+    const test = harness(data.manifest, data.bytes, data.manifest, cache);
+
+    await expect(test.session.load(BASE_URL)).resolves.toMatchObject({
+      version: data.manifest.version,
+    });
+    expect(await cache.pointer()).toEqual(futurePointer);
+    expect(cache.entries.size).toBe(1);
+    expect(test.session.status.cacheWarning).toMatch(/Offline model storage is unavailable/);
+  });
+
+  it("keeps only active and previous entries while cleanup failure stays recoverable", async () => {
+    const cache = new MemoryCacheStorage();
+    const saved: VerifiedModelBundle[] = [];
+    for (const version of ["1.0.0", "1.1.0", "1.2.0"]) {
+      const data = await fixture(version);
+      saved.push(
+        await harness(data.manifest, data.bytes, data.manifest, cache).session.load(BASE_URL),
+      );
+    }
+    expect(
+      [...cache.entries.keys()].some((key) =>
+        key.includes(encodeURIComponent(saved[0]!.manifestSha256)),
+      ),
+    ).toBe(false);
+
+    cache.failDeletes = true;
+    const version4 = await fixture("1.3.0");
+    const latest = harness(version4.manifest, version4.bytes, version4.manifest, cache);
+    const active = await latest.session.load(BASE_URL);
+
+    expect(await cache.pointer()).toMatchObject({
+      active: active.manifestSha256,
+      previous: saved[2]!.manifestSha256,
+    });
+    expect(cache.deleteAttempts).toBeGreaterThan(0);
+    expect(latest.session.status).toMatchObject({ phase: "ready", source: "network" });
+    expect(latest.session.status.cacheWarning).toBeUndefined();
+  });
+
+  it("does not activate a load superseded during the persistent pointer commit", async () => {
+    const data = await fixture();
+    const cache = new MemoryCacheStorage();
+    let releasePointer!: () => void;
+    cache.pointerWriteGate = new Promise<void>((resolve) => {
+      releasePointer = resolve;
+    });
+    const test = harness(data.manifest, data.bytes, data.manifest, cache);
+
+    const superseded = test.session.load(BASE_URL);
+    await vi.waitFor(() => expect(cache.pointerWrites).toBe(1));
+    data.manifest.version = "1.1.0";
+    const current = test.session.load(BASE_URL);
+    releasePointer();
+
+    await expect(superseded).rejects.toMatchObject({ code: "bundle.load.superseded" });
+    const active = await current;
+    expect(test.session.active).toBe(active);
+    expect(active.version).toBe("1.1.0");
+    expect(await cache.pointer()).toMatchObject({ active: active.manifestSha256 });
+    expect(test.session.status).toMatchObject({ phase: "ready", active: { id: active.id } });
   });
 });

--- a/apps/web/src/modelBundle/modelBundleSession.ts
+++ b/apps/web/src/modelBundle/modelBundleSession.ts
@@ -6,6 +6,11 @@ import candidateFeaturePlan from "../../../../src/signlab/resources/features/con
 import mediaPipeConfig from "../../../../src/signlab/resources/extraction/config/mediapipe-extraction-config-1.default.json";
 import manifestSchema from "../../../../src/signlab/resources/model_bundles/schemas/browser-model-bundle-manifest-1.schema.json";
 import qualityPolicy from "../../../../src/signlab/resources/quality/config/landmark-quality-policy-1.default.json";
+import {
+  ModelBundleCache,
+  type CachedModelBundle,
+  type ModelBundleCacheState,
+} from "./modelBundleCache";
 
 const LABELS = ["hello", "no", "please", "thank_you", "yes", "other"] as const;
 const ASSETS = [
@@ -58,6 +63,7 @@ const PINNED_COMPONENTS = {
 
 export type ModelBundleAssetRole = (typeof ASSETS)[number][0];
 export type ModelBundlePhase = "idle" | "loading" | "verifying" | "ready" | "error";
+export type ModelBundleSource = "network" | "cache" | "fallback" | "rollback";
 export type ModelBundleFailureCode =
   | "bundle.environment.unsupported"
   | "bundle.load.superseded"
@@ -67,7 +73,9 @@ export type ModelBundleFailureCode =
   | "bundle.asset.unavailable"
   | "bundle.asset.size_mismatch"
   | "bundle.asset.digest_mismatch"
-  | "bundle.component.incompatible";
+  | "bundle.component.incompatible"
+  | "bundle.cache.corrupt"
+  | "bundle.cache.rollback_unavailable";
 
 interface ManifestAsset {
   readonly artifact_id: string;
@@ -94,6 +102,8 @@ export interface VerifiedModelBundle {
   readonly id: string;
   readonly version: string;
   readonly manifest: ModelBundleManifest;
+  readonly manifestBytes: Blob;
+  readonly manifestSha256: string;
   readonly bytesByRole: Readonly<Record<ModelBundleAssetRole, Blob>>;
 }
 
@@ -101,12 +111,16 @@ export interface ModelBundleStatus {
   readonly phase: ModelBundlePhase;
   readonly active: { readonly id: string; readonly version: string } | null;
   readonly failureReason?: string;
+  readonly source?: ModelBundleSource;
+  readonly rollbackAvailable?: boolean;
+  readonly cacheWarning?: string;
 }
 
 export interface ModelBundleEnvironment {
   readonly fetch: (input: URL) => Promise<Response>;
   readonly subtle?: SubtleCrypto;
   readonly documentBaseUrl?: string;
+  readonly cacheStorage?: Pick<CacheStorage, "open">;
 }
 
 const FAILURE_MESSAGES: Record<ModelBundleFailureCode, string> = {
@@ -119,7 +133,11 @@ const FAILURE_MESSAGES: Record<ModelBundleFailureCode, string> = {
   "bundle.asset.size_mismatch": "A model bundle file has the wrong size.",
   "bundle.asset.digest_mismatch": "A model bundle file failed its integrity check.",
   "bundle.component.incompatible": "The model bundle is incompatible with this demo.",
+  "bundle.cache.corrupt": "The cached model bundle is incomplete or damaged.",
+  "bundle.cache.rollback_unavailable": "No verified previous model bundle is available.",
 };
+const CACHE_WARNING =
+  "Offline model storage is unavailable, so this model may need to be downloaded again.";
 
 export class ModelBundleLoadError extends Error {
   constructor(readonly code: ModelBundleFailureCode) {
@@ -269,26 +287,51 @@ function statusFor(
   phase: ModelBundlePhase,
   active: VerifiedModelBundle | null,
   failureReason?: string,
+  source?: ModelBundleSource,
+  rollbackAvailable?: boolean,
+  cacheWarning?: string,
 ): ModelBundleStatus {
   return Object.freeze({
     phase,
     active: active === null ? null : Object.freeze({ id: active.id, version: active.version }),
     ...(failureReason === undefined ? {} : { failureReason }),
+    ...(source === undefined ? {} : { source }),
+    ...(rollbackAvailable === undefined ? {} : { rollbackAvailable }),
+    ...(cacheWarning === undefined ? {} : { cacheWarning }),
   });
 }
+
+interface PreparedManifest {
+  readonly manifest: ModelBundleManifest;
+  readonly buffer: ArrayBuffer;
+  readonly sha256: string;
+}
+
+type StatusUpdate = (
+  phase: ModelBundlePhase,
+  reason?: string,
+  source?: ModelBundleSource,
+  rollbackAvailable?: boolean,
+  cacheWarning?: string | null,
+) => void;
 
 export class ModelBundleSession {
   private activeValue: VerifiedModelBundle | null = null;
   private statusValue = statusFor("idle", null);
   private attempt = 0;
+  private readonly cache: ModelBundleCache;
+  private cacheMutation = Promise.resolve();
 
   constructor(
     private readonly environment: ModelBundleEnvironment = {
       fetch: (input) => globalThis.fetch(input),
       subtle: globalThis.crypto?.subtle,
       documentBaseUrl: globalThis.document?.baseURI,
+      cacheStorage: globalThis.caches,
     },
-  ) {}
+  ) {
+    this.cache = new ModelBundleCache(environment.cacheStorage);
+  }
 
   get active(): VerifiedModelBundle | null {
     return this.activeValue;
@@ -303,75 +346,271 @@ export class ModelBundleSession {
     onStatus: (status: ModelBundleStatus) => void = () => undefined,
   ): Promise<VerifiedModelBundle> {
     const attempt = ++this.attempt;
-    const update = (phase: ModelBundlePhase, reason?: string) => {
-      if (attempt !== this.attempt) fail("bundle.load.superseded");
-      this.statusValue = statusFor(phase, this.activeValue, reason);
-      onStatus(this.statusValue);
-    };
+    const update = this.updater(attempt, onStatus);
 
     try {
       update("loading");
       const manifestUrl = bundleManifestUrl(baseUrl, this.environment.documentBaseUrl);
-      const manifestBuffer = await this.fetchBytes(manifestUrl, "bundle.manifest.unavailable");
-      if (attempt !== this.attempt) fail("bundle.load.superseded");
-      const manifest = validateManifest(parseJson(manifestBuffer, "bundle.manifest.invalid"));
-      const subtle = this.environment.subtle;
-      if (subtle === undefined) fail("bundle.environment.unsupported");
-      const downloads = await Promise.all(
-        manifest.assets.map(async (asset) => ({
-          asset,
-          buffer: await this.fetchBytes(
-            assetUrl(manifestUrl, asset.locator.path),
-            "bundle.asset.unavailable",
-          ),
-        })),
-      );
-      update("verifying");
-      const buffers = {} as Record<ModelBundleAssetRole, ArrayBuffer>;
-      for (const { asset, buffer } of downloads) {
-        if (buffer.byteLength !== asset.size_bytes) fail("bundle.asset.size_mismatch");
-        let digest: ArrayBuffer;
+      let manifestBuffer: ArrayBuffer;
+      try {
+        manifestBuffer = await this.fetchBytes(manifestUrl, "bundle.manifest.unavailable");
+      } catch (error) {
+        return await this.restoreActive(error, update, attempt);
+      }
+      const prepared = await this.prepareManifest(manifestBuffer);
+
+      const warm = await this.cache.read(prepared.sha256);
+      if (warm !== null) {
         try {
-          digest = await subtle.digest("SHA-256", new Uint8Array(buffer));
-        } catch {
-          fail("bundle.environment.unsupported");
+          const verified = await this.verifyCached(warm, prepared.sha256, update);
+          const activation = await this.mutateCache(attempt, () =>
+            this.cache.activate(verified.manifestSha256),
+          );
+          return this.activate(
+            verified,
+            "cache",
+            activation.saved ? activation.state : null,
+            update,
+            attempt,
+            activation.saved ? undefined : CACHE_WARNING,
+          );
+        } catch (error) {
+          if (this.failureCode(error) !== "bundle.cache.corrupt") throw error;
         }
-        const actual = `sha256:${Array.from(new Uint8Array(digest), (byte) =>
-          byte.toString(16).padStart(2, "0"),
-        ).join("")}`;
-        if (actual !== asset.sha256) fail("bundle.asset.digest_mismatch");
-        buffers[asset.role] = buffer;
       }
-      verifyComponents(manifest, buffers);
-      if (attempt !== this.attempt) fail("bundle.load.superseded");
-      const bytesByRole = Object.freeze(
-        Object.fromEntries(
-          manifest.assets.map((asset) => [
-            asset.role,
-            new Blob([buffers[asset.role]], { type: asset.media_type }),
-          ]),
-        ) as Record<ModelBundleAssetRole, Blob>,
+
+      let verified: VerifiedModelBundle;
+      try {
+        verified = await this.verifyBundle(
+          prepared,
+          async (asset) =>
+            await this.fetchBytes(
+              assetUrl(manifestUrl, asset.locator.path),
+              "bundle.asset.unavailable",
+            ),
+          update,
+        );
+      } catch (error) {
+        if (this.failureCode(error) === "bundle.asset.unavailable") {
+          return await this.restoreActive(error, update, attempt);
+        }
+        throw error;
+      }
+      const activation = await this.mutateCache(attempt, () =>
+        this.cache.saveAndActivate({
+          identity: verified.manifestSha256,
+          manifest: verified.manifestBytes,
+          bytesByRole: verified.bytesByRole,
+        }),
       );
-      const verified = Object.freeze({
-        id: manifest.bundle_id,
-        version: manifest.version,
-        manifest,
-        bytesByRole,
-      });
-      this.activeValue = verified;
-      update("ready");
-      return verified;
+      return this.activate(
+        verified,
+        "network",
+        activation.saved ? activation.state : null,
+        update,
+        attempt,
+        activation.saved ? undefined : CACHE_WARNING,
+      );
     } catch (error) {
-      const failure =
-        error instanceof ModelBundleLoadError
-          ? error
-          : new ModelBundleLoadError("bundle.asset.unavailable");
-      if (attempt === this.attempt) {
-        this.statusValue = statusFor("error", this.activeValue, failure.message);
-        onStatus(this.statusValue);
-      }
-      throw failure;
+      return this.finishFailure(error, "bundle.asset.unavailable", attempt, onStatus);
     }
+  }
+
+  async rollback(
+    onStatus: (status: ModelBundleStatus) => void = () => undefined,
+  ): Promise<VerifiedModelBundle> {
+    const attempt = ++this.attempt;
+    const update = this.updater(attempt, onStatus);
+    try {
+      update("loading", undefined, "rollback");
+      const cached = await this.cache.readSelected("previous");
+      if (cached === null) fail("bundle.cache.rollback_unavailable");
+      const verified = await this.verifyCached(cached, cached.identity, update);
+      const state = await this.mutateCache(attempt, () => this.cache.rollback(cached.identity));
+      if (state === null) fail("bundle.cache.rollback_unavailable");
+      return this.activate(verified, "rollback", state, update, attempt);
+    } catch (error) {
+      return this.finishFailure(error, "bundle.cache.rollback_unavailable", attempt, onStatus);
+    }
+  }
+
+  private async prepareManifest(buffer: ArrayBuffer): Promise<PreparedManifest> {
+    const manifest = validateManifest(parseJson(buffer, "bundle.manifest.invalid"));
+    return { manifest, buffer, sha256: await this.digest(buffer) };
+  }
+
+  private async verifyBundle(
+    prepared: PreparedManifest,
+    readAsset: (asset: ManifestAsset) => Promise<ArrayBuffer>,
+    update: StatusUpdate,
+  ): Promise<VerifiedModelBundle> {
+    const downloads = await Promise.all(
+      prepared.manifest.assets.map(async (asset) => ({ asset, buffer: await readAsset(asset) })),
+    );
+    update("verifying");
+    const buffers = {} as Record<ModelBundleAssetRole, ArrayBuffer>;
+    for (const { asset, buffer } of downloads) {
+      if (buffer.byteLength !== asset.size_bytes) fail("bundle.asset.size_mismatch");
+      if ((await this.digest(buffer)) !== asset.sha256) fail("bundle.asset.digest_mismatch");
+      buffers[asset.role] = buffer;
+    }
+    verifyComponents(prepared.manifest, buffers);
+    const bytesByRole = Object.freeze(
+      Object.fromEntries(
+        prepared.manifest.assets.map((asset) => [
+          asset.role,
+          new Blob([buffers[asset.role]], { type: asset.media_type }),
+        ]),
+      ) as Record<ModelBundleAssetRole, Blob>,
+    );
+    return Object.freeze({
+      id: prepared.manifest.bundle_id,
+      version: prepared.manifest.version,
+      manifest: prepared.manifest,
+      manifestBytes: new Blob([prepared.buffer], { type: "application/json" }),
+      manifestSha256: prepared.sha256,
+      bytesByRole,
+    });
+  }
+
+  private async verifyCached(
+    cached: CachedModelBundle,
+    expectedIdentity: string,
+    update: StatusUpdate,
+  ): Promise<VerifiedModelBundle> {
+    try {
+      const prepared = await this.prepareManifest(await cached.manifest.arrayBuffer());
+      if (prepared.sha256 !== expectedIdentity) fail("bundle.cache.corrupt");
+      return await this.verifyBundle(
+        prepared,
+        async (asset) => {
+          const bytes = await cached.asset(asset.role);
+          if (bytes === null) fail("bundle.cache.corrupt");
+          return await bytes.arrayBuffer();
+        },
+        update,
+      );
+    } catch (error) {
+      const code = this.failureCode(error);
+      if (code === "bundle.environment.unsupported" || code === "bundle.load.superseded") {
+        throw error;
+      }
+      return fail("bundle.cache.corrupt");
+    }
+  }
+
+  private async restoreActive(
+    error: unknown,
+    update: StatusUpdate,
+    attempt: number,
+  ): Promise<VerifiedModelBundle> {
+    const cached = await this.cache.readSelected("active");
+    if (cached === null) throw error;
+    update(
+      "loading",
+      undefined,
+      "fallback",
+      cached.state?.previous !== null && cached.state?.previous !== undefined,
+    );
+    return this.activate(
+      await this.verifyCached(cached, cached.identity, update),
+      "fallback",
+      cached.state,
+      update,
+      attempt,
+    );
+  }
+
+  private activate(
+    verified: VerifiedModelBundle,
+    source: ModelBundleSource,
+    state: ModelBundleCacheState | null,
+    update: StatusUpdate,
+    attempt: number,
+    cacheWarning?: string,
+  ): VerifiedModelBundle {
+    if (attempt !== this.attempt) fail("bundle.load.superseded");
+    this.activeValue = verified;
+    update(
+      "ready",
+      undefined,
+      source,
+      state?.previous !== null && state?.previous !== undefined,
+      cacheWarning ?? null,
+    );
+    return verified;
+  }
+
+  private updater(attempt: number, onStatus: (status: ModelBundleStatus) => void): StatusUpdate {
+    return (
+      phase,
+      reason,
+      source = this.statusValue.source,
+      rollbackAvailable = this.statusValue.rollbackAvailable,
+      cacheWarning = this.statusValue.cacheWarning,
+    ) => {
+      if (attempt !== this.attempt) fail("bundle.load.superseded");
+      this.statusValue = statusFor(
+        phase,
+        this.activeValue,
+        reason,
+        source,
+        rollbackAvailable,
+        cacheWarning ?? undefined,
+      );
+      onStatus(this.statusValue);
+    };
+  }
+
+  private mutateCache<T>(attempt: number, mutation: () => Promise<T>): Promise<T> {
+    const result = this.cacheMutation.then(() => {
+      if (attempt !== this.attempt) fail("bundle.load.superseded");
+      return mutation();
+    });
+    this.cacheMutation = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  }
+
+  private finishFailure(
+    error: unknown,
+    fallback: ModelBundleFailureCode,
+    attempt: number,
+    onStatus: (status: ModelBundleStatus) => void,
+  ): never {
+    const failure =
+      error instanceof ModelBundleLoadError ? error : new ModelBundleLoadError(fallback);
+    if (attempt === this.attempt) {
+      this.statusValue = statusFor(
+        "error",
+        this.activeValue,
+        failure.message,
+        this.statusValue.source,
+        this.statusValue.rollbackAvailable,
+        this.statusValue.cacheWarning,
+      );
+      onStatus(this.statusValue);
+    }
+    throw failure;
+  }
+
+  private async digest(buffer: ArrayBuffer): Promise<string> {
+    const subtle = this.environment.subtle;
+    if (subtle === undefined) fail("bundle.environment.unsupported");
+    try {
+      const digest = await subtle.digest("SHA-256", new Uint8Array(buffer));
+      return `sha256:${Array.from(new Uint8Array(digest), (byte) =>
+        byte.toString(16).padStart(2, "0"),
+      ).join("")}`;
+    } catch {
+      return fail("bundle.environment.unsupported");
+    }
+  }
+
+  private failureCode(error: unknown): ModelBundleFailureCode | undefined {
+    return error instanceof ModelBundleLoadError ? error.code : undefined;
   }
 
   private async fetchBytes(url: URL, code: ModelBundleFailureCode): Promise<ArrayBuffer> {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -56,9 +56,23 @@ The intended bundle-loading flow is manifest-first:
 Static model-bundle files
   -> load and validate manifest + schema versions
   -> verify every declared asset checksum
+  -> stage exact verified bytes in Cache Storage
+  -> commit one active/previous pointer last
   -> start landmark and inference workers from verified bytes
   -> expose readiness or a clear failure to the route UI
 ```
+
+Cached bytes cross the same validation boundary on every activation; a cache marker is
+never treated as proof of integrity. When a network manifest has the same exact-byte
+SHA-256 identity, its cached assets may be reused. If the bundle endpoint is unavailable
+after the application shell has loaded, the current cached bundle may be reverified and
+activated. A deliberate rollback reverifies the one retained previous bundle before the
+pointer is swapped. Cache failures never activate partial state: a verified network
+bundle remains usable in memory while the last committed pointer stays authoritative.
+
+This cache does not make the entire site offline-capable. There is no service worker, and
+the application shell, ONNX Runtime support files, and two separately pinned MediaPipe
+task files are outside the model-bundle cache.
 
 The shell uses one `@mediapipe/tasks-vision@1.0.1` landmark worker. It initializes one
 hand/pose task pair from externally verified buffers, returns


### PR DESCRIPTION
Closes #108

## Outcome

- persist exact verified manifest bytes and all eight bundle assets in Cache Storage
- reverify cached bundles through the existing manifest, size, digest, component, and compatibility checks
- recover from an unavailable bundle endpoint after the app shell has loaded
- retain one verified previous bundle and expose deliberate rollback
- keep storage, quota, corruption, unsupported-pointer, and cleanup failures recoverable
- distinguish network, warm-cache, endpoint-fallback, rollback, and sanitized storage-warning states in the live UI

## Scope

- one direct `modelBundleCache.ts` adapter
- no service worker, PWA shell cache, persistence framework, new dependency, or CSS
- retained nonblank production growth: 422 / 425 hard stop
- retained focused-test growth: 371 / 375 hard stop

## Verification

- 128/128 tests passed
- lint and formatting passed
- root and `/signlab/` production builds passed
- independent correctness review found no remaining blockers
- independent scope/UI review found no remaining blockers
- real-browser walkthrough proved:
  - Cache Storage survives a full reload
  - endpoint failure activates the reverified cached bundle
  - Restore previous model reverified and switched version 1.0.1 back to 1.0.0

This intentionally does not claim full offline operation; the application shell and separate runtime/task assets remain outside this cache.