### PR TITLE
Export and quarantine privacy-preserving feedback packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ Thumbs.db
 *.log
 
 # Private data and generated ML artifacts
+*.signlab-feedback.json
 data/raw/
 data/interim/
 data/processed/

--- a/apps/web/src/feedback/Feedback.test.tsx
+++ b/apps/web/src/feedback/Feedback.test.tsx
@@ -1,6 +1,9 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { IDBFactory } from "fake-indexeddb";
-import { describe, expect, it } from "vitest";
+import { createHash } from "node:crypto";
+import { describe, expect, it, vi } from "vitest";
+
+import browserFeedbackGolden from "../../../../tests/fixtures/public/feedback/browser-feedback-package-v1.json";
 
 import {
   CANDIDATE_INFERENCE_PROTOCOL_VERSION,
@@ -9,6 +12,11 @@ import {
 import { CANDIDATE_LABELS } from "../inference/candidateDecision";
 import type { LiveFeedbackContext } from "../live/liveRecognitionSession";
 import { FeedbackPage, FeedbackSaveForm } from "./Feedback";
+import {
+  createFeedbackPackage,
+  downloadFeedbackPackage,
+  summarizeFeedbackPackage,
+} from "./feedbackPackage";
 import { NativeFeedbackStore } from "./feedbackStore";
 
 const result: CandidateInferenceResult = {
@@ -120,8 +128,188 @@ describe("local feedback UI", () => {
     expect((await feedback.list()).records).toHaveLength(0);
   });
 
+  it("requires export consent and exports the current list after deletion", async () => {
+    const feedback = store("feedback-export");
+    await feedback.save({
+      result,
+      context,
+      correction: "hello",
+      includeLandmarks: true,
+      previewMirrored: false,
+    });
+    await feedback.save({
+      result,
+      context,
+      correction: "yes",
+      includeLandmarks: false,
+      previewMirrored: false,
+    });
+    const exporter = vi.fn().mockResolvedValue(undefined);
+    render(<FeedbackPage store={feedback} exporter={exporter} />);
+
+    await screen.findByText("2 feedback record(s) saved locally.");
+    const download = screen.getByRole("button", { name: "Download feedback package" });
+    fireEvent.submit(download.closest("form")!);
+    expect(exporter).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByLabelText(/Include stored landmark coordinates in this download/));
+    expect(screen.getByText("Yes (1)")).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText(/I consent to this local download/));
+    fireEvent.click(screen.getAllByRole("button", { name: "Delete this record" })[0]!);
+    expect(download).toBeDisabled();
+    await screen.findByText("1 feedback record(s) saved locally.");
+    fireEvent.click(download);
+
+    await screen.findByText(/Nothing was uploaded/);
+    expect(exporter).toHaveBeenCalledOnce();
+    expect(exporter.mock.calls[0]?.[0]).toHaveLength(1);
+    expect(exporter.mock.calls[0]?.[1]).toBe(true);
+  });
+
+  it("sanitizes export failures and disables an empty export", async () => {
+    const feedback = store("feedback-export-failure");
+    await feedback.save({
+      result,
+      context,
+      correction: "yes",
+      includeLandmarks: false,
+      previewMirrored: false,
+    });
+    const exporter = vi.fn().mockRejectedValue(new Error("private digest detail"));
+    const view = render(<FeedbackPage store={feedback} exporter={exporter} />);
+    await screen.findByText("1 feedback record(s) saved locally.");
+    fireEvent.click(screen.getByLabelText(/I consent to this local download/));
+    fireEvent.click(screen.getByRole("button", { name: "Download feedback package" }));
+    expect(await screen.findByText(/Saved feedback was not changed/)).toBeInTheDocument();
+    expect(screen.queryByText(/private digest detail/)).not.toBeInTheDocument();
+
+    view.unmount();
+    render(<FeedbackPage store={store("feedback-export-empty")} />);
+    await screen.findByText("There are no valid records to export.");
+    expect(screen.getByRole("button", { name: "Download feedback package" })).toBeDisabled();
+  });
+
   it("explains unavailable storage without falling back", async () => {
     render(<FeedbackPage store={new NativeFeedbackStore(null)} />);
     expect(await screen.findByText(/Local feedback storage is unavailable/)).toBeInTheDocument();
+  });
+});
+
+describe("feedback package", () => {
+  it("has deterministic identity, summaries, and explicit landmark stripping", async () => {
+    const feedback = store("feedback-package");
+    const withLandmarks = await feedback.save({
+      result: { ...result, bundle: { id: "candidate", version: "2" } },
+      context,
+      correction: "hello",
+      includeLandmarks: true,
+      previewMirrored: false,
+    });
+    const withoutLandmarks = await feedback.save({
+      result,
+      context,
+      correction: "yes",
+      includeLandmarks: false,
+      previewMirrored: false,
+    });
+    const records = [withoutLandmarks, withLandmarks];
+    const feedbackPackage = await createFeedbackPackage(records, false, "2026-08-31T13:00:00.000Z");
+    const payload = JSON.parse(feedbackPackage.payloadJson) as Record<string, unknown>[];
+
+    expect(Object.keys(feedbackPackage)).toEqual([
+      "format",
+      "manifest",
+      "payloadJson",
+      "payloadSha256",
+    ]);
+    expect(Object.keys(feedbackPackage.manifest)).toEqual([
+      "recordFormat",
+      "recordCount",
+      "bundleVersions",
+      "fields",
+      "localConsentScope",
+      "landmarkRecordCount",
+      "landmarksIncluded",
+      "exportConsent",
+    ]);
+    expect(payload.map(({ id }) => id)).toEqual([withLandmarks.id, withoutLandmarks.id]);
+    expect(payload.every((record) => !Object.hasOwn(record, "landmarks"))).toBe(true);
+    expect(
+      payload.map((record) => (record.consent as { landmarksIncluded: boolean }).landmarksIncluded),
+    ).toEqual([false, false]);
+    expect(feedbackPackage.manifest).toMatchObject({
+      recordFormat: "signlab-feedback-record/1",
+      recordCount: 2,
+      bundleVersions: [
+        { id: "candidate", version: "1" },
+        { id: "candidate", version: "2" },
+      ],
+      fields: Object.keys(payload[0]!).sort(),
+      localConsentScope: "local_feedback_only",
+      landmarkRecordCount: 0,
+      landmarksIncluded: false,
+      exportConsent: {
+        statementVersion: "signlab-feedback-export-consent/1",
+        granted: true,
+        grantedAt: "2026-08-31T13:00:00.000Z",
+        scope: "manual_research_review",
+        trainingUse: "requires_review_and_approval",
+      },
+    });
+    expect(feedbackPackage.payloadSha256).toBe(
+      `sha256:${createHash("sha256").update(feedbackPackage.payloadJson).digest("hex")}`,
+    );
+    expect(feedbackPackage.payloadJson).not.toMatch(/rawVideo|audio|freeText|fingerprint/);
+    expect(summarizeFeedbackPackage(records, true)).toMatchObject({
+      landmarkRecordCount: 1,
+      landmarksIncluded: true,
+    });
+    const included = await createFeedbackPackage(records, true, "2026-08-31T13:00:00.000Z");
+    expect(included).toEqual(browserFeedbackGolden);
+    expect(
+      (JSON.parse(included.payloadJson) as Record<string, unknown>[]).some((record) =>
+        Object.hasOwn(record, "landmarks"),
+      ),
+    ).toBe(true);
+  });
+
+  it("downloads readable JSON locally without a network request", async () => {
+    const feedback = store("feedback-download");
+    const record = await feedback.save({
+      result,
+      context,
+      correction: "yes",
+      includeLandmarks: false,
+      previewMirrored: false,
+    });
+    let downloaded: Blob | undefined;
+    const target = {
+      createObjectURL: vi.fn((blob: Blob) => {
+        downloaded = blob;
+        return "blob:feedback";
+      }),
+      revokeObjectURL: vi.fn(),
+      click: vi.fn(),
+    };
+    const network = vi.fn();
+    vi.stubGlobal("fetch", network);
+    await downloadFeedbackPackage([record], false, "2026-08-31T13:00:00.000Z", target);
+
+    const contents = await new Promise<string>((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onerror = () => reject(reader.error ?? new Error("FileReader failed"));
+      reader.onload = () =>
+        typeof reader.result === "string"
+          ? resolve(reader.result)
+          : reject(new Error("FileReader returned non-text"));
+      reader.readAsText(downloaded!);
+    });
+    expect(contents.endsWith("\n")).toBe(true);
+    expect(JSON.parse(contents)).toMatchObject({ format: "signlab-feedback-package/1" });
+    expect(target.click).toHaveBeenCalledWith(
+      "blob:feedback",
+      "signlab-feedback-2026-08-31.signlab-feedback.json",
+    );
+    expect(target.revokeObjectURL).toHaveBeenCalledWith("blob:feedback");
+    expect(network).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/feedback/Feedback.tsx
+++ b/apps/web/src/feedback/Feedback.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState, type FormEvent } from "react";
 
 import type { CandidateInferenceResult } from "../inference/candidateInferenceProtocol";
 import type { LiveFeedbackContext } from "../live/liveRecognitionSession";
+import { downloadFeedbackPackage, summarizeFeedbackPackage } from "./feedbackPackage";
 import {
   FEEDBACK_LABELS,
   NativeFeedbackStore,
@@ -27,6 +28,12 @@ function feedbackStorageMessage(error: unknown): string {
   if (code.includes("blocked")) return "Close other SignLab tabs, then try again.";
   if (code.includes("version")) return "This feedback was created by a newer SignLab version.";
   return "Local feedback storage is unavailable. Nothing was saved.";
+}
+
+function feedbackCountMessage(count: number): string {
+  return count
+    ? `${count} feedback record(s) saved locally.`
+    : "No feedback is saved in this browser.";
 }
 
 export function FeedbackSaveForm({
@@ -113,32 +120,70 @@ function RecordDetails({ record }: { record: FeedbackRecord }) {
   );
 }
 
-export function FeedbackPage({ store = browserStore }: { store?: FeedbackStore }) {
+type FeedbackExporter = typeof downloadFeedbackPackage;
+
+export function FeedbackPage({
+  store = browserStore,
+  exporter = downloadFeedbackPackage,
+}: {
+  store?: FeedbackStore;
+  exporter?: FeedbackExporter;
+}) {
   const headingRef = useRef<HTMLHeadingElement>(null);
   const [items, setItems] = useState<FeedbackListResult>({ records: [], damagedKeys: [] });
   const [message, setMessage] = useState("Loading local feedback.");
-  const [revision, setRevision] = useState(0);
+  const [includeLandmarks, setIncludeLandmarks] = useState(false);
+  const [exportMessage, setExportMessage] = useState("");
+  const [mutating, setMutating] = useState(false);
   useEffect(() => {
     document.title = "Feedback | SignLab";
     headingRef.current?.focus();
     void store.list().then(
       (next) => {
         setItems(next);
-        setMessage(
-          next.records.length
-            ? `${next.records.length} feedback record(s) saved locally.`
-            : "No feedback is saved in this browser.",
-        );
+        setMessage(feedbackCountMessage(next.records.length));
       },
       (error: unknown) => setMessage(feedbackStorageMessage(error)),
     );
-  }, [revision, store]);
+  }, [store]);
   const mutate = async (operation: () => Promise<void>) => {
+    if (mutating) return;
+    setMutating(true);
     try {
       await operation();
-      setRevision((value) => value + 1);
+      const next = await store.list();
+      setItems(next);
+      setMessage(feedbackCountMessage(next.records.length));
     } catch (error) {
+      setItems({ records: [], damagedKeys: [] });
       setMessage(feedbackStorageMessage(error));
+    } finally {
+      setMutating(false);
+    }
+  };
+  const summary = summarizeFeedbackPackage(items.records, includeLandmarks);
+  const storedLandmarkCount = items.records.filter((record) => "landmarks" in record).length;
+  const bundleVersions =
+    summary.bundleVersions.map(({ id, version }) => `${id} ${version}`).join(", ") || "None";
+  const exportedFields = summary.fields.join(", ") || "None";
+  const exporting = exportMessage === "Creating local download.";
+  const exportFeedback = async (event: FormEvent) => {
+    event.preventDefault();
+    if (
+      !new FormData(event.currentTarget as HTMLFormElement).has("exportConsent") ||
+      items.records.length === 0 ||
+      exporting ||
+      mutating
+    )
+      return;
+    setExportMessage("Creating local download.");
+    try {
+      await exporter(items.records, includeLandmarks);
+      setExportMessage("Feedback package downloaded locally. Nothing was uploaded.");
+    } catch {
+      setExportMessage(
+        "The feedback package could not be created. Saved feedback was not changed.",
+      );
     }
   };
 
@@ -164,6 +209,48 @@ export function FeedbackPage({ store = browserStore }: { store?: FeedbackStore }
           Clear all local feedback
         </button>
       </div>
+      <section aria-labelledby="feedback-export-heading">
+        <h2 id="feedback-export-heading">Download for manual research review</h2>
+        <p>
+          This creates a file on this device only; SignLab does not upload it. Sharing it would be a
+          manual contribution for review, and any possible training use requires later review and
+          approval.
+        </p>
+        <dl>
+          <dt>Valid records</dt>
+          <dd>{summary.recordCount}</dd>
+          <dt>Bundle versions</dt>
+          <dd>{bundleVersions}</dd>
+          <dt>Exported fields</dt>
+          <dd>{exportedFields}</dd>
+          <dt>Local consent scope</dt>
+          <dd>{summary.localConsentScope}</dd>
+          <dt>Stored records with landmarks</dt>
+          <dd>{storedLandmarkCount}</dd>
+          <dt>Landmarks included in this download</dt>
+          <dd>{summary.landmarksIncluded ? `Yes (${summary.landmarkRecordCount})` : "No"}</dd>
+        </dl>
+        <form onSubmit={(event) => void exportFeedback(event)}>
+          <label className="feedback-check">
+            <input
+              type="checkbox"
+              checked={includeLandmarks}
+              onChange={(event) => setIncludeLandmarks(event.target.checked)}
+            />{" "}
+            Include stored landmark coordinates in this download (off by default)
+          </label>
+          <label className="feedback-check">
+            <input name="exportConsent" type="checkbox" required /> I consent to this local download
+            for manual research review only. Possible training use requires later review and
+            approval.
+          </label>
+          <button type="submit" disabled={items.records.length === 0 || exporting || mutating}>
+            {exporting ? "Creating download" : "Download feedback package"}
+          </button>
+        </form>
+        {items.records.length === 0 && <p>There are no valid records to export.</p>}
+        {exportMessage && <p role="status">{exportMessage}</p>}
+      </section>
       <section className="feedback-list" aria-label="Locally saved feedback">
         {items.records.map((record) => (
           <article key={record.id}>

--- a/apps/web/src/feedback/feedbackPackage.ts
+++ b/apps/web/src/feedback/feedbackPackage.ts
@@ -1,0 +1,106 @@
+import type { FeedbackRecord } from "./feedbackStore";
+
+const compareText = (left: string, right: string) => (left < right ? -1 : left > right ? 1 : 0);
+
+function exportRecords(records: readonly FeedbackRecord[], includeLandmarks: boolean) {
+  return [...records]
+    .sort((left, right) => compareText(left.id, right.id))
+    .map((record) => {
+      const exported: Record<string, unknown> = { ...record };
+      if (!includeLandmarks) {
+        delete exported.landmarks;
+        exported.consent = { ...record.consent, landmarksIncluded: false };
+      }
+      return exported;
+    });
+}
+
+function summarizeExportedRecords(
+  records: readonly Record<string, unknown>[],
+  landmarksIncluded: boolean,
+) {
+  const bundleVersions = new Map<string, { id: string; version: string }>();
+  for (const record of records) {
+    const bundle = record.bundle as { id: string; version: string };
+    bundleVersions.set(JSON.stringify([bundle.id, bundle.version]), bundle);
+  }
+  return {
+    recordFormat: "signlab-feedback-record/1",
+    recordCount: records.length,
+    bundleVersions: [...bundleVersions.values()].sort(
+      (left, right) => compareText(left.id, right.id) || compareText(left.version, right.version),
+    ),
+    fields: [...new Set(records.flatMap((record) => Object.keys(record)))].sort(compareText),
+    localConsentScope: "local_feedback_only",
+    landmarkRecordCount: records.filter((record) => Object.hasOwn(record, "landmarks")).length,
+    landmarksIncluded,
+  };
+}
+
+export function summarizeFeedbackPackage(
+  records: readonly FeedbackRecord[],
+  includeLandmarks: boolean,
+) {
+  return summarizeExportedRecords(exportRecords(records, includeLandmarks), includeLandmarks);
+}
+
+export async function createFeedbackPackage(
+  records: readonly FeedbackRecord[],
+  includeLandmarks: boolean,
+  grantedAt = new Date().toISOString(),
+  subtle = globalThis.crypto.subtle,
+) {
+  if (new Date(grantedAt).toISOString() !== grantedAt) throw new Error("Invalid export time");
+  const exported = exportRecords(records, includeLandmarks);
+  const payloadJson = JSON.stringify(exported);
+  const bytes = new TextEncoder().encode(payloadJson);
+  const digest = new Uint8Array(await subtle.digest("SHA-256", bytes));
+  const payloadSha256 = `sha256:${[...digest]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("")}`;
+  return {
+    format: "signlab-feedback-package/1",
+    manifest: {
+      ...summarizeExportedRecords(exported, includeLandmarks),
+      exportConsent: {
+        statementVersion: "signlab-feedback-export-consent/1",
+        granted: true,
+        grantedAt,
+        scope: "manual_research_review",
+        trainingUse: "requires_review_and_approval",
+      },
+    },
+    payloadJson,
+    payloadSha256,
+  } as const;
+}
+
+const browserDownloadTarget = {
+  createObjectURL: (blob: Blob) => URL.createObjectURL(blob),
+  revokeObjectURL: (url: string) => URL.revokeObjectURL(url),
+  click: (url: string, filename: string) => {
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = filename;
+    anchor.click();
+  },
+};
+
+export async function downloadFeedbackPackage(
+  records: readonly FeedbackRecord[],
+  includeLandmarks: boolean,
+  grantedAt = new Date().toISOString(),
+  target = browserDownloadTarget,
+) {
+  const feedbackPackage = await createFeedbackPackage(records, includeLandmarks, grantedAt);
+  const blob = new Blob([`${JSON.stringify(feedbackPackage, null, 2)}\n`], {
+    type: "application/json",
+  });
+  const url = target.createObjectURL(blob);
+  try {
+    target.click(url, `signlab-feedback-${grantedAt.slice(0, 10)}.signlab-feedback.json`);
+  } finally {
+    target.revokeObjectURL(url);
+  }
+  return feedbackPackage;
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -86,7 +86,11 @@ gate and will exercise this assembled post-landmark path rather than a parallel 
 Feedback is a separate, explicit browser-local action. One completed event may be
 stored in IndexedDB with its correction and disclosed metadata; derived landmark
 coordinates require an additional opt-in. Raw video is never part of that record,
-and local consent does not authorize upload, export, research use, or training.
+and local consent does not authorize upload, export, research use, or training. A
+second consent can create a local-only [feedback contribution package](feedback-contributions.md).
+The Python boundary revalidates its exact allowlisted bytes into content-addressed,
+non-trainable quarantine; review, deduplication, split assignment, and a new DVC
+version remain separate gates.
 
 The [licensed external-data boundary](external-datasets.md) is intentionally
 separate from participant ingest. It registers source, license, attribution,

--- a/docs/feedback-contributions.md
+++ b/docs/feedback-contributions.md
@@ -1,0 +1,40 @@
+# Feedback contribution boundary
+
+SignLab keeps event corrections in the browser unless the user deliberately downloads
+a contribution package. Saving locally and exporting are separate consent decisions.
+The export action creates a file on the user's device; it does not upload or transmit
+anything.
+
+## Browser workflow
+
+1. Open **Feedback** and inspect the valid record count, model-bundle versions, fields,
+   local consent scope, and landmark count.
+2. Correct or delete records before exporting. Damaged records are never included.
+3. Leave landmark export off unless derived coordinates are intentionally required.
+4. Grant the separate export consent for manual research review, then download the
+   `.signlab-feedback.json` file.
+
+The package contains strict `signlab-feedback-record/1` copies, a readable manifest,
+the exact serialized record payload, and its SHA-256 digest. Excluding landmarks
+creates privacy-filtered copies and does not change the records stored in IndexedDB.
+Raw video, audio, free text, device details, and browser fingerprints are never part
+of the package.
+
+## Quarantine import
+
+Treat downloaded packages as untrusted private data. Do not commit them to Git.
+Validate and quarantine one package with:
+
+```powershell
+uv run signlab data import-feedback-package <downloaded-package.signlab-feedback.json>
+```
+
+The command verifies versions, consent, exact field allowlists, summaries, duplicate
+record IDs, landmark declarations, and the payload digest before writing anything. It
+then stores the exact package bytes and a sanitized receipt under the ignored,
+content-addressed `data/private/feedback-quarantine` directory. Re-importing identical
+package bytes is rejected.
+
+Every receipt says `trainable: false`. Human review, cross-package deduplication, a
+split decision, and a new DVC dataset version are still required. Story #120 owns that
+later decision; this workflow has no promotion or training path.

--- a/src/signlab/commands/data.py
+++ b/src/signlab/commands/data.py
@@ -18,6 +18,34 @@ app = create_group(
 )
 
 
+@app.command("import-feedback-package")
+def import_feedback_package_command(
+    package: Annotated[
+        Path,
+        typer.Argument(help="Browser-downloaded signlab-feedback-package/1 JSON file."),
+    ],
+    quarantine_root: Annotated[
+        Path,
+        typer.Option(
+            "--quarantine-root",
+            help="Ignored private root for content-addressed feedback quarantine.",
+        ),
+    ] = Path("data/private/feedback-quarantine"),
+) -> None:
+    """Validate and quarantine feedback; never promote it for training."""
+
+    from signlab.feedback_packages import import_feedback_package
+
+    try:
+        result = import_feedback_package(package, quarantine_root=quarantine_root)
+    except (OSError, TypeError, ValueError) as error:
+        typer.echo("Feedback package import failed.", err=True)
+        raise typer.Exit(code=1) from error
+    typer.echo(f"Feedback package quarantined: {result.record_count} records.")
+    typer.echo(f"Package SHA-256: {result.package_sha256}")
+    typer.echo("Trainable: no; manual review gates remain.")
+
+
 def _read_capture_source_map(path: Path) -> dict[str, str]:
     """Read the private path map without returning untrusted values in errors."""
 

--- a/src/signlab/feedback_packages.py
+++ b/src/signlab/feedback_packages.py
@@ -1,0 +1,280 @@
+"""Strict import boundary for consented browser feedback packages."""
+
+# ruff: noqa: E501, E731 -- compact, auditable mirrors of the browser rule tables.
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import shutil
+import tempfile
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import NoReturn, cast
+
+_PACKAGE = "signlab-feedback-package/1"
+_RECORD_FORMAT = "signlab-feedback-record/1"
+_EXPORT_CONSENT = "signlab-feedback-export-consent/1"
+_RECEIPT = "signlab-feedback-quarantine-receipt/1"
+_LABELS = ("hello", "no", "please", "thank_you", "yes", "other", "inactive")
+_HANDS = ("hand_0", "hand_1")
+# fmt: off
+_ANCHORS = ("left_shoulder", "right_shoulder", "left_elbow", "right_elbow", "left_wrist", "right_wrist")
+# fmt: on
+_MAX_SAFE_INTEGER = (2**53) - 1
+
+
+class FeedbackPackageError(ValueError):
+    """Sanitized rejection safe to surface at the command boundary."""
+
+    def __init__(self, code: str = "invalid") -> None:
+        self.code = code
+        super().__init__(f"feedback package {code}")
+
+
+@dataclass(frozen=True, slots=True)
+class FeedbackPackageImport:
+    """Aggregate result of one newly published quarantine package."""
+
+    package_sha256: str
+    record_count: int
+    destination: Path
+
+
+type Predicate = Callable[[object], bool]
+type Rule = Predicate | dict[str, Rule] | tuple[Rule, ...] | list[Rule]
+
+
+def _fail() -> NoReturn:
+    raise FeedbackPackageError()
+
+
+def _require(condition: object) -> None:
+    if not condition:
+        _fail()
+
+
+def _pairs(items: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in items:
+        if key in result:
+            _fail()
+        result[key] = value
+    return result
+
+
+def _parse(document: bytes | str) -> object:
+    try:
+        source = document.decode("utf-8", errors="strict") if isinstance(document, bytes) else document  # fmt: skip
+        return json.loads(
+            source,
+            object_pairs_hook=_pairs,
+            parse_constant=lambda _value: _fail(),
+        )
+    except FeedbackPackageError:
+        raise
+    except (UnicodeError, json.JSONDecodeError, RecursionError, ValueError) as error:
+        raise FeedbackPackageError() from error
+
+
+_text: Predicate = lambda value: isinstance(value, str)
+
+
+def _finite(value: object) -> bool:
+    try:
+        return type(value) in (int, float) and math.isfinite(cast(float, value))
+    except OverflowError:
+        return False
+
+
+_nonnegative: Predicate = lambda value: _finite(value) and cast(float, value) >= 0
+_whole: Predicate = lambda value: type(value) is int and 0 <= value <= _MAX_SAFE_INTEGER
+_probability: Predicate = lambda value: _nonnegative(value) and cast(float, value) <= 1
+
+
+def _iso(value: object) -> bool:
+    try:
+        return isinstance(value, str) and len(value) == 24 and datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ").isoformat(timespec="milliseconds") + "Z" == value  # fmt: skip
+    except ValueError:
+        return False
+
+
+def _one(*values: str) -> Predicate:
+    return lambda value: type(value) is str and value in values
+
+
+def _nullable(rule: Rule) -> Predicate:
+    return lambda value: value is None or _matches(value, rule)
+
+
+def _matches(value: object, rule: Rule) -> bool:
+    if callable(rule):
+        return rule(value)
+    if isinstance(rule, dict):
+        if type(value) is not dict:
+            return False
+        checked = cast(dict[str, object], value)
+        return checked.keys() == rule.keys() and all(
+            _matches(checked[key], child) for key, child in rule.items()
+        )
+    if isinstance(rule, tuple):
+        return (
+            isinstance(value, list)
+            and len(value) == len(rule)
+            and all(_matches(item, child) for item, child in zip(value, rule, strict=True))
+        )
+    return isinstance(value, list) and all(_matches(item, rule[0]) for item in value)
+
+
+_bool: Predicate = lambda value: type(value) is bool
+# fmt: off
+_POINT: Rule = {"x": _finite, "y": _finite, "z": _finite, "visibility": _nullable(_probability), "presence": _nullable(_probability)}
+
+def _hand(slot: str) -> Rule:
+    return {"slotId": _one(slot), "present": _bool, "detectorIndex": _nullable(_whole), "trackingId": _nullable(_one(*_HANDS)), "handedness": _nullable(_one("left", "right")), "handednessConfidence": _nullable(_probability), "imageLandmarks": _nullable([_POINT]), "worldLandmarks": _nullable([_POINT])}
+
+def _anchor(name: str) -> Rule:
+    return {"name": _one(name), "present": _bool, "imagePoint": _nullable(_POINT), "worldPoint": _nullable(_POINT)}
+
+_FRAME: Rule = {"relativeTimestampUs": _whole, "valid": _bool, "hands": tuple(_hand(slot) for slot in _HANDS), "bodyAnchors": tuple(_anchor(name) for name in _ANCHORS)}
+
+def _decision(value: object) -> bool:
+    rules: tuple[Rule, ...] = ({"kind": _one("abstain")}, {"kind": _one("other"), "label": _one("other"), "confidence": _probability}, {"kind": _one("target"), "label": _one(*_LABELS[:5]), "confidence": _probability})
+    return any(_matches(value, rule) for rule in rules)
+
+_RECORD: dict[str, Rule] = {
+    "format": _one(_RECORD_FORMAT), "id": _text, "savedAt": _iso,
+    "bundle": {"id": _text, "version": _text},
+    "prediction": {"decision": _decision, "reason": _one("accepted_target", "accepted_other", "below_threshold")},
+    "scores": [{"label": _one(*_LABELS[:6]), "confidence": _probability}],
+    "timings": {"preprocessingMs": _nonnegative, "inferenceMs": _nonnegative, "decisionMs": _nonnegative, "totalMs": _nonnegative},
+    "event": {"firstFrameIndex": _whole, "lastFrameIndex": _whole, "firstTimestampUs": _whole, "lastTimestampUs": _whole, "terminationReason": _one("settled", "signal_gap", "max_duration", "stream_end"), "configSha256": _text, "durationUs": _nonnegative},
+    "conditions": {"sourceMirrorState": _one("mirrored", "not_mirrored"), "previewMirrored": _bool},
+    "correction": _one(*_LABELS),
+    "consent": {"mode": _one("per_event"), "scope": _one("local_feedback_only"), "grantedAt": _iso, "landmarksIncluded": _bool},
+}
+
+
+def _record(value: object) -> dict[str, object]:
+    _require(type(value) is dict)
+    checked = cast(dict[str, object], value)
+    has_landmarks = "landmarks" in checked
+    _require(_matches(checked, {**_RECORD, **({"landmarks": [_FRAME]} if has_landmarks else {})}))
+    consent, scores, event = cast(dict[str, object], checked["consent"]), cast(list[dict[str, object]], checked["scores"]), cast(dict[str, object], checked["event"])
+    _require(consent["landmarksIncluded"] is has_landmarks and consent["grantedAt"] == checked["savedAt"] and len(scores) == 6 and len({score["label"] for score in scores}) == 6)
+    _require(cast(int, event["lastFrameIndex"]) >= cast(int, event["firstFrameIndex"]) and event["durationUs"] == cast(int, event["lastTimestampUs"]) - cast(int, event["firstTimestampUs"]))
+    return checked
+# fmt: on
+
+
+def _digest(content: bytes) -> str:
+    return f"sha256:{hashlib.sha256(content).hexdigest()}"
+
+
+def _receipt(package_bytes: bytes) -> dict[str, object]:
+    package = _parse(package_bytes)
+    _require(type(package) is dict)
+    package = cast(dict[str, object], package)
+    _require(package.keys() == {"format", "manifest", "payloadJson", "payloadSha256"})
+    _require(package["format"] == _PACKAGE and _text(package["payloadJson"]))
+    try:
+        payload_bytes = cast(str, package["payloadJson"]).encode("utf-8")
+    except UnicodeEncodeError as error:
+        raise FeedbackPackageError() from error
+    _require(package["payloadSha256"] == _digest(payload_bytes))
+    payload = _parse(payload_bytes)
+    _require(isinstance(payload, list))
+    records = [_record(value) for value in cast(list[object], payload)]
+    ids = [cast(str, record["id"]) for record in records]
+    _require(ids == sorted(ids) and len(ids) == len(set(ids)))
+
+    manifest = package["manifest"]
+    _require(type(manifest) is dict)
+    manifest = cast(dict[str, object], manifest)
+    manifest_keys = {"recordFormat", "recordCount", "bundleVersions", "fields", "localConsentScope", "landmarkRecordCount", "landmarksIncluded", "exportConsent"}  # fmt: skip
+    _require(manifest.keys() == manifest_keys)
+    pairs = {
+        (
+            cast(dict[str, object], record["bundle"])["id"],
+            cast(dict[str, object], record["bundle"])["version"],
+        )
+        for record in records
+    }
+    bundles = [{"id": identity, "version": version} for identity, version in sorted(pairs)]
+    fields = sorted({field for record in records for field in record})
+    landmark_count = sum("landmarks" in record for record in records)
+    _require(manifest["recordFormat"] == _RECORD_FORMAT)
+    _require(_whole(manifest["recordCount"]) and manifest["recordCount"] == len(records))
+    _require(manifest["bundleVersions"] == bundles and manifest["fields"] == fields)
+    _require(manifest["localConsentScope"] == "local_feedback_only")
+    _require(_whole(manifest["landmarkRecordCount"]))
+    _require(manifest["landmarkRecordCount"] == landmark_count)
+    _require(type(manifest["landmarksIncluded"]) is bool)
+    _require(cast(bool, manifest["landmarksIncluded"]) or landmark_count == 0)
+
+    consent = manifest["exportConsent"]
+    _require(type(consent) is dict)
+    consent = cast(dict[str, object], consent)
+    consent_keys = {"statementVersion", "granted", "grantedAt", "scope", "trainingUse"}
+    _require(consent.keys() == consent_keys)
+    _require(consent["statementVersion"] == _EXPORT_CONSENT and consent["granted"] is True)
+    _require(_iso(consent["grantedAt"]) and consent["scope"] == "manual_research_review")
+    _require(consent["trainingUse"] == "requires_review_and_approval")
+    # fmt: off
+    return {
+        "format": _RECEIPT, "packageSha256": _digest(package_bytes),
+        "payloadSha256": package["payloadSha256"], "recordFormat": _RECORD_FORMAT,
+        "recordCount": len(records), "bundleVersions": bundles,
+        "landmarkRecordCount": landmark_count, "landmarksIncluded": manifest["landmarksIncluded"],
+        "exportConsent": {"statementVersion": consent["statementVersion"], "scope": consent["scope"], "grantedAt": consent["grantedAt"]},
+        "trainable": False,
+        "remainingGates": ["human_review", "cross_package_deduplication", "split_decision", "new_dvc_version"],
+    }
+    # fmt: on
+
+
+def import_feedback_package(
+    package: str | Path,
+    *,
+    quarantine_root: str | Path = Path("data/private/feedback-quarantine"),
+) -> FeedbackPackageImport:
+    """Validate exact bytes, then publish one immutable quarantine directory."""
+
+    try:
+        package_bytes = Path(package).read_bytes()
+    except OSError as error:
+        raise FeedbackPackageError() from error
+    receipt = _receipt(package_bytes)
+    root = Path(quarantine_root)
+    digest = cast(str, receipt["packageSha256"])
+    destination = root / digest.replace(":", "-")
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+        if destination.exists():
+            raise FeedbackPackageError("duplicate")
+        staging = Path(tempfile.mkdtemp(prefix=".feedback-package-", dir=root))
+        try:
+            (staging / "package.signlab-feedback.json").write_bytes(package_bytes)
+            serialized = (json.dumps(receipt, indent=2, sort_keys=True) + "\n").encode("utf-8")
+            (staging / "receipt.json").write_bytes(serialized)
+            staging.rename(destination)
+        finally:
+            if staging.exists():
+                shutil.rmtree(staging)
+    except FeedbackPackageError:
+        raise
+    except OSError as error:
+        if destination.exists():
+            raise FeedbackPackageError("duplicate") from error
+        raise FeedbackPackageError("storage_failed") from error
+    return FeedbackPackageImport(
+        package_sha256=digest,
+        record_count=cast(int, receipt["recordCount"]),
+        destination=destination,
+    )
+
+
+__all__ = ["FeedbackPackageError", "FeedbackPackageImport", "import_feedback_package"]

--- a/tests/fixtures/public/README.md
+++ b/tests/fixtures/public/README.md
@@ -39,6 +39,10 @@ flags, and quantized motion. It exercises candidate-event state transitions with
 including camera, landmark, public-corpus, or participant-derived values. Its metrics
 are conformance evidence only, not natural-use performance.
 
+`feedback/` contains one MIT-licensed package of invented records emitted by the real
+browser serializer. Browser and Python tests share its exact bytes to prove local
+download compatibility without including a person, camera, or participant data.
+
 `replay/` contains MIT-licensed invented truth intervals and final decisions for one
 mixed and one negative-only session. It proves scoring counts and grouping mechanics;
 its rates and timing values are not measurements of people, models, or runtimes. It

--- a/tests/fixtures/public/feedback/browser-feedback-package-v1.json
+++ b/tests/fixtures/public/feedback/browser-feedback-package-v1.json
@@ -1,0 +1,43 @@
+{
+  "format": "signlab-feedback-package/1",
+  "manifest": {
+    "recordFormat": "signlab-feedback-record/1",
+    "recordCount": 2,
+    "bundleVersions": [
+      {
+        "id": "candidate",
+        "version": "1"
+      },
+      {
+        "id": "candidate",
+        "version": "2"
+      }
+    ],
+    "fields": [
+      "bundle",
+      "conditions",
+      "consent",
+      "correction",
+      "event",
+      "format",
+      "id",
+      "landmarks",
+      "prediction",
+      "savedAt",
+      "scores",
+      "timings"
+    ],
+    "localConsentScope": "local_feedback_only",
+    "landmarkRecordCount": 1,
+    "landmarksIncluded": true,
+    "exportConsent": {
+      "statementVersion": "signlab-feedback-export-consent/1",
+      "granted": true,
+      "grantedAt": "2026-08-31T13:00:00.000Z",
+      "scope": "manual_research_review",
+      "trainingUse": "requires_review_and_approval"
+    }
+  },
+  "payloadJson": "[{\"format\":\"signlab-feedback-record/1\",\"id\":\"feedback-package-1\",\"savedAt\":\"2026-08-31T12:00:00.000Z\",\"bundle\":{\"id\":\"candidate\",\"version\":\"2\"},\"prediction\":{\"decision\":{\"kind\":\"target\",\"label\":\"hello\",\"confidence\":0.8},\"reason\":\"accepted_target\"},\"scores\":[{\"label\":\"hello\",\"confidence\":0.8},{\"label\":\"no\",\"confidence\":0.8},{\"label\":\"please\",\"confidence\":0.8},{\"label\":\"thank_you\",\"confidence\":0.8},{\"label\":\"yes\",\"confidence\":0.8},{\"label\":\"other\",\"confidence\":0.8}],\"timings\":{\"preprocessingMs\":1,\"inferenceMs\":2,\"decisionMs\":1,\"totalMs\":4},\"event\":{\"firstFrameIndex\":1,\"lastFrameIndex\":2,\"firstTimestampUs\":10,\"lastTimestampUs\":20,\"terminationReason\":\"settled\",\"configSha256\":\"sha256:detector\",\"durationUs\":10},\"conditions\":{\"sourceMirrorState\":\"not_mirrored\",\"previewMirrored\":false},\"correction\":\"hello\",\"consent\":{\"mode\":\"per_event\",\"scope\":\"local_feedback_only\",\"grantedAt\":\"2026-08-31T12:00:00.000Z\",\"landmarksIncluded\":true},\"landmarks\":[]},{\"format\":\"signlab-feedback-record/1\",\"id\":\"feedback-package-2\",\"savedAt\":\"2026-08-31T12:00:00.000Z\",\"bundle\":{\"id\":\"candidate\",\"version\":\"1\"},\"prediction\":{\"decision\":{\"kind\":\"target\",\"label\":\"hello\",\"confidence\":0.8},\"reason\":\"accepted_target\"},\"scores\":[{\"label\":\"hello\",\"confidence\":0.8},{\"label\":\"no\",\"confidence\":0.8},{\"label\":\"please\",\"confidence\":0.8},{\"label\":\"thank_you\",\"confidence\":0.8},{\"label\":\"yes\",\"confidence\":0.8},{\"label\":\"other\",\"confidence\":0.8}],\"timings\":{\"preprocessingMs\":1,\"inferenceMs\":2,\"decisionMs\":1,\"totalMs\":4},\"event\":{\"firstFrameIndex\":1,\"lastFrameIndex\":2,\"firstTimestampUs\":10,\"lastTimestampUs\":20,\"terminationReason\":\"settled\",\"configSha256\":\"sha256:detector\",\"durationUs\":10},\"conditions\":{\"sourceMirrorState\":\"not_mirrored\",\"previewMirrored\":false},\"correction\":\"yes\",\"consent\":{\"mode\":\"per_event\",\"scope\":\"local_feedback_only\",\"grantedAt\":\"2026-08-31T12:00:00.000Z\",\"landmarksIncluded\":false}}]",
+  "payloadSha256": "sha256:4da8f287690ed4051894bf1ea1d57f8407a977ec9d99e070cfbff98b1e51fa24"
+}

--- a/tests/test_feedback_packages.py
+++ b/tests/test_feedback_packages.py
@@ -1,0 +1,201 @@
+"""Browser-package quarantine tests kept independent of private participant data."""
+
+# ruff: noqa: E501 -- compact literal mirrors of the browser feedback contract.
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from signlab import cli
+from signlab.feedback_packages import FeedbackPackageError, import_feedback_package
+
+_NOW = "2026-08-31T12:34:56.789Z"
+_LABELS = ("hello", "no", "please", "thank_you", "yes", "other")
+
+
+def _digest(content: bytes) -> str:
+    return f"sha256:{hashlib.sha256(content).hexdigest()}"
+
+
+# fmt: off
+def _frame() -> dict[str, Any]:
+    point = {"x": 0.1, "y": 0.2, "z": -0.1, "visibility": 0.9, "presence": 0.8}
+    hands = [
+        {"slotId": "hand_0", "present": True, "detectorIndex": 0, "trackingId": "hand_0", "handedness": "left", "handednessConfidence": 0.9, "imageLandmarks": [point], "worldLandmarks": None},
+        {"slotId": "hand_1", "present": False, "detectorIndex": None, "trackingId": None, "handedness": None, "handednessConfidence": None, "imageLandmarks": None, "worldLandmarks": None},
+    ]
+    anchors = [{"name": name, "present": False, "imagePoint": None, "worldPoint": None} for name in ("left_shoulder", "right_shoulder", "left_elbow", "right_elbow", "left_wrist", "right_wrist")]
+    return {"relativeTimestampUs": 0, "valid": True, "hands": hands, "bodyAnchors": anchors}
+
+
+def _record(identity: str, *, landmarks: bool = False) -> dict[str, Any]:
+    record: dict[str, Any] = {
+        "format": "signlab-feedback-record/1", "id": identity, "savedAt": _NOW,
+        "bundle": {"id": "candidate-five", "version": "1.0.0"},
+        "prediction": {"decision": {"kind": "target", "label": "hello", "confidence": 0.9}, "reason": "accepted_target"},
+        "scores": [{"label": label, "confidence": 0.5} for label in _LABELS],
+        "timings": {"preprocessingMs": 1, "inferenceMs": 2, "decisionMs": 0, "totalMs": 3},
+        "event": {"firstFrameIndex": 0, "lastFrameIndex": 1, "firstTimestampUs": 0, "lastTimestampUs": 10, "terminationReason": "settled", "configSha256": "sha256:fixture", "durationUs": 10},
+        "conditions": {"sourceMirrorState": "not_mirrored", "previewMirrored": True},
+        "correction": "hello",
+        "consent": {"mode": "per_event", "scope": "local_feedback_only", "grantedAt": _NOW, "landmarksIncluded": landmarks},
+    }
+    if landmarks:
+        record["landmarks"] = [_frame()]
+    return record
+
+
+def _package(records: list[dict[str, Any]], *, landmarks_included: bool | None = None) -> bytes:
+    payload = json.dumps(records, ensure_ascii=False, separators=(",", ":"))
+    pairs = sorted({(record["bundle"]["id"], record["bundle"]["version"]) for record in records})
+    landmark_count = sum("landmarks" in record for record in records)
+    consent = {"statementVersion": "signlab-feedback-export-consent/1", "granted": True, "grantedAt": _NOW, "scope": "manual_research_review", "trainingUse": "requires_review_and_approval"}
+    manifest = {"recordFormat": "signlab-feedback-record/1", "recordCount": len(records), "bundleVersions": [{"id": identity, "version": version} for identity, version in pairs], "fields": sorted({field for record in records for field in record}), "localConsentScope": "local_feedback_only", "landmarkRecordCount": landmark_count, "landmarksIncluded": landmark_count > 0 if landmarks_included is None else landmarks_included, "exportConsent": consent}
+    package = {"format": "signlab-feedback-package/1", "manifest": manifest, "payloadJson": payload, "payloadSha256": _digest(payload.encode())}
+    return (json.dumps(package, ensure_ascii=False, indent=2) + "\n").encode()
+# fmt: on
+
+
+def _encode(value: object) -> bytes:
+    return (json.dumps(value, ensure_ascii=False, indent=2) + "\n").encode()
+
+
+# fmt: off
+def test_valid_package_is_stored_exactly_with_sanitized_nontrainable_receipt(
+    tmp_path: Path,
+) -> None:
+    raw = (Path(__file__).parent / "fixtures/public/feedback/browser-feedback-package-v1.json").read_bytes()
+    source, root = tmp_path / "private-name.json", tmp_path / "quarantine"
+    source.write_bytes(raw)
+
+    result = import_feedback_package(source, quarantine_root=root)
+    receipt = json.loads((result.destination / "receipt.json").read_bytes())
+
+    assert result.package_sha256 == _digest(raw)
+    assert result.record_count == 2
+    assert result.destination == root / _digest(raw).replace(":", "-")
+    assert (result.destination / "package.signlab-feedback.json").read_bytes() == raw
+    assert set(receipt) == {"format", "packageSha256", "payloadSha256", "recordFormat", "recordCount", "bundleVersions", "landmarkRecordCount", "landmarksIncluded", "exportConsent", "trainable", "remainingGates"}
+    assert receipt["format"] == "signlab-feedback-quarantine-receipt/1"
+    assert receipt["recordCount"] == 2
+    assert receipt["landmarkRecordCount"] == 1
+    assert receipt["trainable"] is False
+    assert receipt["remainingGates"] == ["human_review", "cross_package_deduplication", "split_decision", "new_dvc_version"]
+    assert receipt["exportConsent"] == {"statementVersion": "signlab-feedback-export-consent/1", "scope": "manual_research_review", "grantedAt": "2026-08-31T13:00:00.000Z"}
+    evidence = json.dumps(receipt)
+    assert "record-a" not in evidence
+    assert str(tmp_path) not in evidence
+    assert list(root.iterdir()) == [result.destination]
+
+
+@pytest.mark.parametrize(
+    "case",
+    ["package_key", "manifest_key", "package_version", "record_version", "privacy_record", "privacy_landmark", "local_scope", "record_landmark", "record_consent_time", "scores", "event_order", "event_duration", "duplicate_id", "unsorted", "consent_key", "consent_false", "consent_missing", "consent_version", "consent_scope", "consent_time", "training_use", "checksum", "record_count", "bundles", "fields", "landmark_count", "landmark_excluded", "duplicate_key", "surrogate"],
+)
+def test_invalid_packages_are_rejected_before_quarantine(case: str, tmp_path: Path) -> None:
+    records = [_record("record-a"), _record("record-b")]
+    if case == "record_version":
+        records[0]["format"] = "signlab-feedback-record/2"
+    if case == "privacy_record":
+        records[0]["rawVideo"] = "private.mp4"
+    if case == "privacy_landmark":
+        records[0] = _record("record-a", landmarks=True)
+        records[0]["landmarks"][0]["hands"][0]["imageLandmarks"][0]["deviceFingerprint"] = "private"
+    if case == "local_scope":
+        records[0]["consent"]["scope"] = "training"
+    if case == "record_landmark":
+        records[0]["landmarks"] = []
+    if case == "record_consent_time":
+        records[0]["consent"]["grantedAt"] = "2026-08-31T12:34:57.789Z"
+    if case == "scores":
+        records[0]["scores"] = [records[0]["scores"][0]] * 6
+    if case == "event_order":
+        records[0]["event"]["lastFrameIndex"] = -1
+    if case == "event_duration":
+        records[0]["event"]["durationUs"] = 11
+    if case == "duplicate_id":
+        records[1]["id"] = "record-a"
+    if case == "unsorted":
+        records.reverse()
+    raw = _package(records, landmarks_included=False if case == "landmark_excluded" else None)
+    if case == "landmark_excluded":
+        raw = _package([_record("record-a", landmarks=True)], landmarks_included=False)
+    package = json.loads(raw)
+    manifest = package["manifest"]
+    consent = manifest["exportConsent"]
+    if case == "package_key":
+        package["sourcePath"] = "private"
+    if case == "manifest_key":
+        manifest["recordIds"] = ["private"]
+    if case == "package_version":
+        package["format"] = "signlab-feedback-package/2"
+    if case == "consent_key":
+        consent["reviewerName"] = "private"
+    if case == "consent_false":
+        consent["granted"] = False
+    if case == "consent_missing":
+        del consent["granted"]
+    if case == "consent_version":
+        consent["statementVersion"] = "signlab-feedback-export-consent/2"
+    if case == "consent_scope":
+        consent["scope"] = "training"
+    if case == "consent_time":
+        consent["grantedAt"] = "2026-8-31T12:34:56.7890Z"
+    if case == "training_use":
+        consent["trainingUse"] = "approved"
+    if case == "checksum":
+        package["payloadSha256"] = "sha256:" + "0" * 64
+    if case == "record_count":
+        manifest["recordCount"] += 1
+    if case == "bundles":
+        manifest["bundleVersions"] = []
+    if case == "fields":
+        manifest["fields"] = []
+    if case == "landmark_count":
+        manifest["landmarkRecordCount"] += 1
+    if case == "duplicate_key":
+        raw = b'{"format":"one","format":"two"}'
+    elif case == "surrogate":
+        raw = b'{"format":"signlab-feedback-package/1","manifest":{},"payloadJson":"\\ud800","payloadSha256":"x"}'
+    else:
+        raw = _encode(package)
+    source = tmp_path / "private-package.json"
+    source.write_bytes(raw)
+
+    with pytest.raises(FeedbackPackageError, match="feedback package invalid"):
+        import_feedback_package(source, quarantine_root=tmp_path / "quarantine")
+    assert not (tmp_path / "quarantine").exists()
+
+
+def test_duplicate_package_is_never_replaced(tmp_path: Path) -> None:
+    source = tmp_path / "package.json"
+    source.write_bytes(_package([_record("record-a")]))
+    first = import_feedback_package(source, quarantine_root=tmp_path / "quarantine")
+
+    with pytest.raises(FeedbackPackageError, match="duplicate"):
+        import_feedback_package(source, quarantine_root=tmp_path / "quarantine")
+    assert (first.destination / "package.signlab-feedback.json").read_bytes() == source.read_bytes()
+
+
+def test_cli_reports_only_sanitized_aggregate_success_and_failure(tmp_path: Path) -> None:
+    source, root = tmp_path / "participant-private.json", tmp_path / "quarantine"
+    source.write_bytes((Path(__file__).parent / "fixtures/public/feedback/browser-feedback-package-v1.json").read_bytes())
+    runner = CliRunner(env={"NO_COLOR": "1"})
+
+    success = runner.invoke(cli.app, ["data", "import-feedback-package", str(source), "--quarantine-root", str(root)])
+    assert success.exit_code == 0
+    assert success.output.splitlines() == ["Feedback package quarantined: 2 records.", f"Package SHA-256: {_digest(source.read_bytes())}", "Trainable: no; manual review gates remain."]
+    missing = tmp_path / "secret-missing.json"
+    failure = runner.invoke(cli.app, ["data", "import-feedback-package", str(missing), "--quarantine-root", str(root)])
+    assert failure.exit_code == 1
+    assert failure.output.strip() == "Feedback package import failed."
+    assert source.name not in success.output
+    assert missing.name not in failure.output
+    assert str(tmp_path) not in success.output + failure.output
+# fmt: on


### PR DESCRIPTION
Closes #49

## Outcome
- add an explicit-consent, local-only browser feedback download with landmark export off by default
- validate exact package bytes and atomically store them in content-addressed, non-trainable Python quarantine
- share one synthetic golden package across the real browser serializer and Python CLI
- keep promotion, identity, deduplication, split assignment, DVC mutation, and training connection deferred to #120

## Scope evidence
- executable production: 434/450 nonblank lines
- focused tests: 350/350 nonblank lines
- CSS: 0
- documentation: 38/75 nonblank lines
- dependencies: 0

## Verification
- 32 focused Python tests passed; feedback-package module coverage 91.67%
- 132 browser tests across 19 files passed
- 1,479 full Python tests passed; 14 Windows capability skips
- repository-wide Ruff and strict mypy passed
- browser lint, typecheck, formatting, standard build, and subpath build passed
- repository hygiene and generated DVC/candidate-golden checks passed
- real CLI quarantined the shared browser golden with exact-byte SHA-256 and a `trainable: false` receipt
- manual frontend verification passed
- independent privacy/correctness and scope reviews found no remaining release blocker