### PR TITLE
Secure the browser release boundary

### DIFF
--- a/apps/web/src/feedback/Feedback.test.tsx
+++ b/apps/web/src/feedback/Feedback.test.tsx
@@ -312,4 +312,31 @@ describe("feedback package", () => {
     expect(target.revokeObjectURL).toHaveBeenCalledWith("blob:feedback");
     expect(network).not.toHaveBeenCalled();
   });
+
+  it("rejects an oversized export before creating a download Blob", async () => {
+    const feedback = store("feedback-oversized");
+    const record = await feedback.save({
+      result,
+      context,
+      correction: "yes",
+      includeLandmarks: false,
+      previewMirrored: false,
+    });
+    const target = {
+      createObjectURL: vi.fn(() => "blob:feedback"),
+      revokeObjectURL: vi.fn(),
+      click: vi.fn(),
+    };
+
+    await expect(
+      downloadFeedbackPackage(
+        [{ ...record, id: "x".repeat(16 * 1024 * 1024 + 1) }],
+        false,
+        "2026-08-31T13:00:00.000Z",
+        target,
+      ),
+    ).rejects.toThrow("Feedback package exceeds the 16 MiB export limit.");
+    expect(target.createObjectURL).not.toHaveBeenCalled();
+    expect(target.click).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/feedback/feedbackPackage.ts
+++ b/apps/web/src/feedback/feedbackPackage.ts
@@ -1,5 +1,7 @@
 import type { FeedbackRecord } from "./feedbackStore";
 
+const MAX_FEEDBACK_PACKAGE_BYTES = 16 * 1024 * 1024;
+
 const compareText = (left: string, right: string) => (left < right ? -1 : left > right ? 1 : 0);
 
 function exportRecords(records: readonly FeedbackRecord[], includeLandmarks: boolean) {
@@ -93,7 +95,11 @@ export async function downloadFeedbackPackage(
   target = browserDownloadTarget,
 ) {
   const feedbackPackage = await createFeedbackPackage(records, includeLandmarks, grantedAt);
-  const blob = new Blob([`${JSON.stringify(feedbackPackage, null, 2)}\n`], {
+  const serialized = `${JSON.stringify(feedbackPackage, null, 2)}\n`;
+  if (new TextEncoder().encode(serialized).byteLength > MAX_FEEDBACK_PACKAGE_BYTES) {
+    throw new Error("Feedback package exceeds the 16 MiB export limit.");
+  }
+  const blob = new Blob([serialized], {
     type: "application/json",
   });
   const url = target.createObjectURL(blob);

--- a/apps/web/src/landmarks/landmarkModelAssets.test.ts
+++ b/apps/web/src/landmarks/landmarkModelAssets.test.ts
@@ -9,6 +9,8 @@ const HAND_URL =
   "https://storage.googleapis.com/mediapipe-models/hand_landmarker/hand_landmarker/float16/1/hand_landmarker.task?generation=1682480004222387";
 const POSE_URL =
   "https://storage.googleapis.com/mediapipe-models/pose_landmarker/pose_landmarker_lite/float16/1/pose_landmarker_lite.task?generation=1682624736756847";
+const RELEASE_HAND_URL = "https://example.test/signlab/models/mediapipe/hand_landmarker.task";
+const RELEASE_POSE_URL = "https://example.test/signlab/models/mediapipe/pose_landmarker_lite.task";
 
 function bytesForSha256(value: string): ArrayBuffer {
   const hex = value.replace("sha256:", "");
@@ -32,7 +34,7 @@ function environment(
 ): LandmarkModelAssetEnvironment {
   return {
     fetch: vi.fn((url: URL) => {
-      const size = url.href === HAND_URL ? HAND_SIZE : POSE_SIZE;
+      const size = [HAND_URL, RELEASE_HAND_URL].includes(url.href) ? HAND_SIZE : POSE_SIZE;
       return Promise.resolve(new Response(new Uint8Array(size)));
     }),
     subtle: mockSubtle(
@@ -61,9 +63,28 @@ describe("loadLandmarkModelAssets", () => {
     expect(injected.fetch).toHaveBeenNthCalledWith(2, new URL(POSE_URL));
   });
 
-  it("rejects an exact-size mismatch without revealing its URL", async () => {
+  it("uses fixed same-origin, subpath-safe model URLs in production", async () => {
     const injected = environment({
-      fetch: vi.fn(() => Promise.resolve(new Response(new Uint8Array(HAND_SIZE - 1)))),
+      production: true,
+      documentBaseUrl: "https://example.test/signlab/",
+    });
+
+    await loadLandmarkModelAssets(injected);
+
+    expect(injected.fetch).toHaveBeenNthCalledWith(1, new URL(RELEASE_HAND_URL), {
+      redirect: "error",
+    });
+    expect(injected.fetch).toHaveBeenNthCalledWith(2, new URL(RELEASE_POSE_URL), {
+      redirect: "error",
+    });
+  });
+
+  it.each([
+    ["short", HAND_SIZE - 1],
+    ["oversized streamed", HAND_SIZE + 1],
+  ])("rejects a %s task without revealing its URL", async (_case, size) => {
+    const injected = environment({
+      fetch: vi.fn(() => Promise.resolve(new Response(new Uint8Array(size)))),
     });
     const promise = loadLandmarkModelAssets(injected);
 

--- a/apps/web/src/landmarks/landmarkModelAssets.ts
+++ b/apps/web/src/landmarks/landmarkModelAssets.ts
@@ -1,8 +1,11 @@
 import landmarkerConfig from "../../../../src/signlab/resources/extraction/config/mediapipe-extraction-config-1.default.json";
+import { readBoundedResponse } from "../network/readBoundedResponse";
 
 export interface LandmarkModelAssetEnvironment {
-  readonly fetch: (input: URL) => Promise<Response>;
+  readonly fetch: (input: URL, init?: RequestInit) => Promise<Response>;
   readonly subtle?: SubtleCrypto;
+  readonly production?: boolean;
+  readonly documentBaseUrl?: string;
 }
 
 export interface LandmarkModelAssetBuffers {
@@ -12,17 +15,23 @@ export interface LandmarkModelAssetBuffers {
 
 const TASKS = [
   {
-    url: "https://storage.googleapis.com/mediapipe-models/hand_landmarker/hand_landmarker/float16/1/hand_landmarker.task?generation=1682480004222387",
+    developmentUrl:
+      "https://storage.googleapis.com/mediapipe-models/hand_landmarker/hand_landmarker/float16/1/hand_landmarker.task?generation=1682480004222387",
+    productionPath: "models/mediapipe/hand_landmarker.task",
     spec: landmarkerConfig.hand_task_asset,
   },
   {
-    url: "https://storage.googleapis.com/mediapipe-models/pose_landmarker/pose_landmarker_lite/float16/1/pose_landmarker_lite.task?generation=1682624736756847",
+    developmentUrl:
+      "https://storage.googleapis.com/mediapipe-models/pose_landmarker/pose_landmarker_lite/float16/1/pose_landmarker_lite.task?generation=1682624736756847",
+    productionPath: "models/mediapipe/pose_landmarker_lite.task",
     spec: landmarkerConfig.pose_task_asset,
   },
 ] as const;
 
+class LandmarkModelAssetError extends Error {}
+
 function fail(code: string): never {
-  throw new Error(code);
+  throw new LandmarkModelAssetError(code);
 }
 
 function digestString(buffer: ArrayBuffer): string {
@@ -37,10 +46,20 @@ async function loadOne(
 ): Promise<ArrayBuffer> {
   let buffer: ArrayBuffer;
   try {
-    const response = await environment.fetch(new URL(task.url));
+    const url =
+      environment.production === true
+        ? new URL(task.productionPath, environment.documentBaseUrl)
+        : new URL(task.developmentUrl);
+    const response =
+      environment.production === true
+        ? await environment.fetch(url, { redirect: "error" })
+        : await environment.fetch(url);
     if (!response.ok) fail("landmark.models.unavailable");
-    buffer = await response.arrayBuffer();
-  } catch {
+    buffer = await readBoundedResponse(response, task.spec.size_bytes, () =>
+      fail("landmark.models.size_mismatch"),
+    );
+  } catch (error) {
+    if (error instanceof LandmarkModelAssetError) throw error;
     fail("landmark.models.unavailable");
   }
   if (buffer.byteLength !== task.spec.size_bytes) fail("landmark.models.size_mismatch");
@@ -58,8 +77,10 @@ async function loadOne(
 
 export async function loadLandmarkModelAssets(
   environment: LandmarkModelAssetEnvironment = {
-    fetch: (input) => globalThis.fetch(input),
+    fetch: (input, init) => globalThis.fetch(input, init),
     subtle: globalThis.crypto?.subtle,
+    production: import.meta.env.PROD,
+    documentBaseUrl: globalThis.document?.baseURI,
   },
 ): Promise<LandmarkModelAssetBuffers> {
   if (environment.subtle === undefined) fail("landmark.models.environment.unsupported");

--- a/apps/web/src/modelBundle/modelBundleSession.test.ts
+++ b/apps/web/src/modelBundle/modelBundleSession.test.ts
@@ -120,6 +120,7 @@ function harness(
   bytes: Record<ModelBundleAssetRole, Uint8Array>,
   manifestBody: unknown = manifest,
   cache?: MemoryCacheStorage,
+  environmentOverrides: Partial<ModelBundleEnvironment> = {},
 ) {
   const requests: string[] = [];
   const responses = { ...bytes };
@@ -146,6 +147,7 @@ function harness(
     fetch,
     subtle: webcrypto.subtle as SubtleCrypto,
     cacheStorage: cache?.storage,
+    ...environmentOverrides,
   };
   return {
     session: new ModelBundleSession(environment),
@@ -175,6 +177,70 @@ describe("ModelBundleSession", () => {
     expect(Object.isFrozen(loaded.manifest)).toBe(true);
     expect(Object.isFrozen(loaded.bytesByRole)).toBe(true);
     expect(await loaded.bytesByRole.model.text()).toBe("tiny structural ONNX fixture");
+  });
+
+  it("pins a same-origin production manifest before requesting its assets", async () => {
+    const data = await fixture();
+    const digest = await sha256(jsonBytes(data.manifest));
+    const release = harness(data.manifest, data.bytes, data.manifest, undefined, {
+      production: true,
+      documentBaseUrl: "https://example.test/signlab/",
+      trustedManifestSha256: `sha256:${"0".repeat(64)}, ${digest}`,
+    });
+
+    await expect(release.session.load(BASE_URL)).resolves.toMatchObject({
+      manifestSha256: digest,
+    });
+    expect(release.requests).toHaveLength(9);
+    expect(release.fetch).toHaveBeenNthCalledWith(1, new URL(MANIFEST_URL), {
+      redirect: "error",
+    });
+  });
+
+  it("rejects a missing or mismatched production manifest pin before asset requests", async () => {
+    const data = await fixture();
+    for (const trustedManifestSha256 of [undefined, `sha256:${"0".repeat(64)}`]) {
+      const release = harness(data.manifest, data.bytes, data.manifest, undefined, {
+        production: true,
+        documentBaseUrl: "https://example.test/signlab/",
+        trustedManifestSha256,
+      });
+
+      await expect(release.session.load(BASE_URL)).rejects.toMatchObject({
+        code: "bundle.manifest.untrusted",
+      });
+      expect(release.requests).toEqual([MANIFEST_URL]);
+    }
+  });
+
+  it("rejects a cross-origin production bundle before any network request", async () => {
+    const data = await fixture();
+    const release = harness(data.manifest, data.bytes, data.manifest, undefined, {
+      production: true,
+      documentBaseUrl: "https://release.example/signlab/",
+      trustedManifestSha256: await sha256(jsonBytes(data.manifest)),
+    });
+
+    await expect(release.session.load(BASE_URL)).rejects.toMatchObject({
+      code: "bundle.manifest.untrusted",
+    });
+    expect(release.requests).toEqual([]);
+  });
+
+  it("caps actual manifest bytes and declared bundle bytes before asset requests", async () => {
+    const data = await fixture();
+    const oversizedManifest = harness(data.manifest, data.bytes, " ".repeat(64 * 1024 + 1));
+    await expect(oversizedManifest.session.load(BASE_URL)).rejects.toMatchObject({
+      code: "bundle.manifest.invalid",
+    });
+    expect(oversizedManifest.requests).toEqual([MANIFEST_URL]);
+
+    data.manifest.assets[4]!.size_bytes = 8 * 1024 * 1024;
+    const oversizedBundle = harness(data.manifest, data.bytes);
+    await expect(oversizedBundle.session.load(BASE_URL)).rejects.toMatchObject({
+      code: "bundle.manifest.invalid",
+    });
+    expect(oversizedBundle.requests).toEqual([MANIFEST_URL]);
   });
 
   it.each([
@@ -252,12 +318,16 @@ describe("ModelBundleSession", () => {
 
   it.each([
     ["size", "bundle.asset.size_mismatch"],
+    ["oversized stream", "bundle.asset.size_mismatch"],
     ["digest", "bundle.asset.digest_mismatch"],
     ["network", "bundle.asset.unavailable"],
   ])("rejects an asset %s failure", async (failure, code) => {
     const data = await fixture();
     const test = harness(data.manifest, data.bytes);
     if (failure === "size") test.responses.model = encoder.encode("short");
+    if (failure === "oversized stream") {
+      test.responses.model = new Uint8Array(data.bytes.model.byteLength + 1);
+    }
     if (failure === "digest") {
       const altered = data.bytes.model.slice();
       altered[0] = altered[0]! ^ 1;
@@ -360,6 +430,32 @@ describe("ModelBundleSession", () => {
       source: "fallback",
       rollbackAvailable: false,
     });
+  });
+
+  it("applies production manifest pins to fallback and rollback cache reads", async () => {
+    const cache = new MemoryCacheStorage();
+    const version1 = await fixture("1.0.0");
+    const saved1 = await harness(
+      version1.manifest,
+      version1.bytes,
+      version1.manifest,
+      cache,
+    ).session.load(BASE_URL);
+    const version2 = await fixture("1.1.0");
+    await harness(version2.manifest, version2.bytes, version2.manifest, cache).session.load(
+      BASE_URL,
+    );
+    const release = harness(version2.manifest, version2.bytes, version2.manifest, cache, {
+      production: true,
+      documentBaseUrl: "https://example.test/signlab/",
+      trustedManifestSha256: saved1.manifestSha256,
+    });
+    release.network.manifestUnavailable = true;
+
+    await expect(release.session.load(BASE_URL)).rejects.toMatchObject({
+      code: "bundle.cache.corrupt",
+    });
+    await expect(release.session.rollback()).resolves.toMatchObject({ version: "1.0.0" });
   });
 
   it("repairs a corrupt warm entry from verified network bytes", async () => {

--- a/apps/web/src/modelBundle/modelBundleSession.ts
+++ b/apps/web/src/modelBundle/modelBundleSession.ts
@@ -11,6 +11,7 @@ import {
   type CachedModelBundle,
   type ModelBundleCacheState,
 } from "./modelBundleCache";
+import { readBoundedResponse } from "../network/readBoundedResponse";
 
 const LABELS = ["hello", "no", "please", "thank_you", "yes", "other"] as const;
 const ASSETS = [
@@ -31,6 +32,9 @@ const COMPONENTS = {
   decision_policy_sha256: "sha256:6eb700443dbb50de5094868d564e8a72aff6af0182c8394ab8c6a28844572e41",
 } as const;
 const TAXONOMY_SHA256 = "sha256:c0f6cbddfe43e3a6eb3de01dbbbbc1ceebcb83d50cc197999776f58e3d9ce20d";
+const SHA256 = /^sha256:[0-9a-f]{64}$/;
+const MAX_MANIFEST_BYTES = 64 * 1024;
+const MAX_BUNDLE_BYTES = 8 * 1024 * 1024;
 const ONNX = {
   format: "onnx",
   opset: 18,
@@ -69,6 +73,7 @@ export type ModelBundleFailureCode =
   | "bundle.load.superseded"
   | "bundle.manifest.unavailable"
   | "bundle.manifest.invalid"
+  | "bundle.manifest.untrusted"
   | "bundle.manifest.unsupported"
   | "bundle.asset.unavailable"
   | "bundle.asset.size_mismatch"
@@ -117,10 +122,12 @@ export interface ModelBundleStatus {
 }
 
 export interface ModelBundleEnvironment {
-  readonly fetch: (input: URL) => Promise<Response>;
+  readonly fetch: (input: URL, init?: RequestInit) => Promise<Response>;
   readonly subtle?: SubtleCrypto;
   readonly documentBaseUrl?: string;
   readonly cacheStorage?: Pick<CacheStorage, "open">;
+  readonly production?: boolean;
+  readonly trustedManifestSha256?: string;
 }
 
 const FAILURE_MESSAGES: Record<ModelBundleFailureCode, string> = {
@@ -128,6 +135,7 @@ const FAILURE_MESSAGES: Record<ModelBundleFailureCode, string> = {
   "bundle.load.superseded": "A newer model bundle load replaced this request.",
   "bundle.manifest.unavailable": "The model bundle manifest could not be loaded.",
   "bundle.manifest.invalid": "The model bundle manifest is incomplete or invalid.",
+  "bundle.manifest.untrusted": "This release does not trust that model bundle.",
   "bundle.manifest.unsupported": "This model bundle version is not supported.",
   "bundle.asset.unavailable": "A required model bundle file could not be loaded.",
   "bundle.asset.size_mismatch": "A model bundle file has the wrong size.",
@@ -202,6 +210,7 @@ function validateManifest(value: unknown): ModelBundleManifest {
   ) {
     fail("bundle.component.incompatible");
   }
+  let declaredBytes = 0;
   manifest.assets.forEach((asset, index) => {
     const expected = ASSETS[index];
     if (
@@ -211,10 +220,12 @@ function validateManifest(value: unknown): ModelBundleManifest {
       asset.locator.kind !== "workspace_relative" ||
       asset.locator.path !== expected[1] ||
       asset.media_type !== expected[2] ||
-      asset.size_bytes <= 0
+      asset.size_bytes <= 0 ||
+      asset.size_bytes > MAX_BUNDLE_BYTES - declaredBytes
     ) {
       fail("bundle.manifest.invalid");
     }
+    declaredBytes += asset.size_bytes;
   });
   return deepFreeze(manifest);
 }
@@ -324,10 +335,12 @@ export class ModelBundleSession {
 
   constructor(
     private readonly environment: ModelBundleEnvironment = {
-      fetch: (input) => globalThis.fetch(input),
+      fetch: (input, init) => globalThis.fetch(input, init),
       subtle: globalThis.crypto?.subtle,
       documentBaseUrl: globalThis.document?.baseURI,
       cacheStorage: globalThis.caches,
+      production: import.meta.env.PROD,
+      trustedManifestSha256: import.meta.env.VITE_SIGNLAB_TRUSTED_MODEL_MANIFEST_SHA256,
     },
   ) {
     this.cache = new ModelBundleCache(environment.cacheStorage);
@@ -351,9 +364,15 @@ export class ModelBundleSession {
     try {
       update("loading");
       const manifestUrl = bundleManifestUrl(baseUrl, this.environment.documentBaseUrl);
+      this.assertProductionBoundary(manifestUrl);
       let manifestBuffer: ArrayBuffer;
       try {
-        manifestBuffer = await this.fetchBytes(manifestUrl, "bundle.manifest.unavailable");
+        manifestBuffer = await this.fetchBytes(
+          manifestUrl,
+          "bundle.manifest.unavailable",
+          MAX_MANIFEST_BYTES,
+          "bundle.manifest.invalid",
+        );
       } catch (error) {
         return await this.restoreActive(error, update, attempt);
       }
@@ -387,6 +406,8 @@ export class ModelBundleSession {
             await this.fetchBytes(
               assetUrl(manifestUrl, asset.locator.path),
               "bundle.asset.unavailable",
+              asset.size_bytes,
+              "bundle.asset.size_mismatch",
             ),
           update,
         );
@@ -435,8 +456,11 @@ export class ModelBundleSession {
   }
 
   private async prepareManifest(buffer: ArrayBuffer): Promise<PreparedManifest> {
+    if (buffer.byteLength > MAX_MANIFEST_BYTES) fail("bundle.manifest.invalid");
+    const sha256 = await this.digest(buffer);
+    this.assertTrustedManifest(sha256);
     const manifest = validateManifest(parseJson(buffer, "bundle.manifest.invalid"));
-    return { manifest, buffer, sha256: await this.digest(buffer) };
+    return { manifest, buffer, sha256 };
   }
 
   private async verifyBundle(
@@ -479,6 +503,7 @@ export class ModelBundleSession {
     update: StatusUpdate,
   ): Promise<VerifiedModelBundle> {
     try {
+      if (cached.manifest.size > MAX_MANIFEST_BYTES) fail("bundle.cache.corrupt");
       const prepared = await this.prepareManifest(await cached.manifest.arrayBuffer());
       if (prepared.sha256 !== expectedIdentity) fail("bundle.cache.corrupt");
       return await this.verifyBundle(
@@ -486,6 +511,7 @@ export class ModelBundleSession {
         async (asset) => {
           const bytes = await cached.asset(asset.role);
           if (bytes === null) fail("bundle.cache.corrupt");
+          if (bytes.size > asset.size_bytes) fail("bundle.cache.corrupt");
           return await bytes.arrayBuffer();
         },
         update,
@@ -613,11 +639,45 @@ export class ModelBundleSession {
     return error instanceof ModelBundleLoadError ? error.code : undefined;
   }
 
-  private async fetchBytes(url: URL, code: ModelBundleFailureCode): Promise<ArrayBuffer> {
+  private assertProductionBoundary(manifestUrl: URL): void {
+    if (this.environment.production !== true) return;
     try {
-      const response = await this.environment.fetch(url);
+      const page = new URL(this.environment.documentBaseUrl ?? "");
+      if (manifestUrl.origin !== page.origin) fail("bundle.manifest.untrusted");
+    } catch (error) {
+      if (error instanceof ModelBundleLoadError) throw error;
+      fail("bundle.manifest.untrusted");
+    }
+  }
+
+  private assertTrustedManifest(sha256: string): void {
+    if (this.environment.production !== true) return;
+    const trusted = (this.environment.trustedManifestSha256 ?? "")
+      .split(",")
+      .map((value) => value.trim())
+      .filter(Boolean);
+    if (
+      trusted.length === 0 ||
+      trusted.some((value) => !SHA256.test(value)) ||
+      !trusted.includes(sha256)
+    ) {
+      fail("bundle.manifest.untrusted");
+    }
+  }
+
+  private async fetchBytes(
+    url: URL,
+    code: ModelBundleFailureCode,
+    limit: number,
+    oversized: ModelBundleFailureCode,
+  ): Promise<ArrayBuffer> {
+    try {
+      const response =
+        this.environment.production === true
+          ? await this.environment.fetch(url, { redirect: "error" })
+          : await this.environment.fetch(url);
       if (!response.ok) fail(code);
-      return await response.arrayBuffer();
+      return await readBoundedResponse(response, limit, () => fail(oversized));
     } catch (error) {
       if (error instanceof ModelBundleLoadError) throw error;
       return fail(code);

--- a/apps/web/src/network/readBoundedResponse.ts
+++ b/apps/web/src/network/readBoundedResponse.ts
@@ -1,0 +1,25 @@
+export async function readBoundedResponse(
+  response: Response,
+  limit: number,
+  onOversized: () => never,
+): Promise<ArrayBuffer> {
+  if (Number(response.headers.get("content-length")) > limit) onOversized();
+  const reader = response.body?.getReader();
+  if (reader === undefined) return new ArrayBuffer(0);
+  const result = new Uint8Array(limit);
+  let total = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) return result.slice(0, total).buffer;
+      if (total + value.byteLength > limit) {
+        await reader.cancel().catch(() => undefined);
+        onOversized();
+      }
+      result.set(value, total);
+      total += value.byteLength;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -2,6 +2,7 @@
 
 interface ImportMetaEnv {
   readonly VITE_SIGNLAB_MODEL_BUNDLE_URL?: string;
+  readonly VITE_SIGNLAB_TRUSTED_MODEL_MANIFEST_SHA256?: string;
 }
 
 interface ImportMeta {

--- a/docs/browser-security.md
+++ b/docs/browser-security.md
@@ -1,0 +1,109 @@
+# Browser release security boundary
+
+Status: release contract for Story #51; provider application and live verification belong to
+Story #57. The machine-readable header values are
+[`contracts/web-release-headers.v1.json`](contracts/web-release-headers.v1.json).
+
+## Claim and scope
+
+The production demo is a static browser application. Camera frames, derived landmarks,
+decisions, and optional feedback stay in the browser unless the user explicitly downloads a
+feedback package. The application has no account, application server, analytics, telemetry,
+upload endpoint, advertising, remote font, beacon, or WebSocket.
+
+This claim covers SignLab's application code and configured release assets. It does not claim
+that an operating system, browser, extension, network, hosting provider, or compromised release
+origin is trustworthy. It is a privacy boundary, not a claim that gesture predictions are safe
+for consequential use.
+
+## Data and trust boundaries
+
+| Item | Path and lifetime | Release boundary |
+| --- | --- | --- |
+| Camera frames | Camera to video element to landmark worker | User starts the camera; raw frames are not recorded, persisted, or uploaded. |
+| Frame bitmaps | Main thread to landmark worker | At most one in flight and the newest waiting frame are retained; replaced and processed images are closed. |
+| Landmarks | Landmark worker to event detector | Kept only for the bounded event unless the user separately opts to save that event locally. |
+| Decisions | ONNX worker to the page | The latest event result is displayed locally; it is not transmitted. |
+| Feedback | Explicit per-event save to IndexedDB | Raw video and free text are excluded. Landmarks require a separate opt-in. Records remain local until deleted by the user or site storage is cleared. |
+| Feedback package | Explicit second consent to a Blob download | Maximum serialized size is 16 MiB. Download does not authorize upload, research use, or training. |
+| Model bundle | Same-origin manifest and assets to Cache Storage and workers | Every declared asset has an exact size and SHA-256 check before activation; cached and rollback bytes are reverified. |
+| MediaPipe tasks | Same-origin release files to verified buffers | Exact expected size and SHA-256 are checked before worker initialization. |
+| Runtime code | Release origin to the browser | React, MediaPipe JavaScript/WASM, and ONNX Runtime JavaScript/WASM are bundled release assets. |
+
+The release trust anchors are TLS and control of the release origin, the reviewed source and
+locked dependencies used to build it, the approved model-manifest digests supplied to the
+release build, and the committed task-asset hashes. Hash checks detect bytes that differ from
+those anchors; they do not make a maliciously approved artifact safe.
+
+## Production network allowlist
+
+The production browser may make only `GET` requests to its own origin for:
+
+- the HTML document and generated JavaScript, CSS, and WASM assets;
+- the configured model-bundle manifest and its declared assets; and
+- the two pinned MediaPipe task files staged by Story #57.
+
+The release build accepts `VITE_SIGNLAB_MODEL_BUNDLE_URL` only on the page origin and requires
+its full manifest digest in the comma-separated
+`VITE_SIGNLAB_TRUSTED_MODEL_MANIFEST_SHA256` allowlist. The task files resolve relative to the
+deployed document at `models/mediapipe/hand_landmarker.task` and
+`models/mediapipe/pose_landmarker_lite.task`, including subpath deployments.
+
+Camera capture, inference, IndexedDB feedback, Cache Storage, and Blob downloads do not require
+network requests. A release must not make `POST`, `PUT`, beacon, WebSocket, analytics, telemetry,
+font, or tracker requests. The production CSP therefore uses `connect-src 'self'`.
+
+Development may fetch the two exact digest-pinned task files from
+`https://storage.googleapis.com/mediapipe-models/`. That fallback exposes ordinary request
+metadata such as an IP address to Google and is not part of the production privacy claim. A
+build that still needs that fallback is not release-ready. Story #57 owns copying the reviewed
+bytes to the release origin, configuring their paths, applying the header contract, and checking
+the deployed site.
+
+## Required response headers
+
+The provider-neutral JSON contract is authoritative. Its CSP denies everything by default,
+allows only same-origin connections, scripts, styles, and workers, and permits the narrow
+`'wasm-unsafe-eval'` source needed for WebAssembly. It does not allow wildcards, inline scripts,
+inline styles, or the general `'unsafe-eval'` source. `frame-ancestors 'none'` and
+`X-Frame-Options: DENY` prevent framing. `Permissions-Policy` limits camera access to this
+origin and denies microphone and geolocation. `Referrer-Policy: no-referrer`,
+`X-Content-Type-Options: nosniff`, and `Cross-Origin-Resource-Policy: same-origin` reduce
+metadata leakage, MIME confusion, and cross-origin reuse of release responses.
+
+The ONNX runtime deliberately imports the WASM build, selects only the WASM execution provider,
+and sets `numThreads=1`. Cross-origin isolation is therefore not required. The contract
+intentionally omits COOP and COEP; enabling WASM threads later requires a separate measured
+decision and an asset-compatibility review.
+
+## Existing limits and failure behavior
+
+- Only one landmark frame is processed while at most one newer frame waits.
+- Candidate events stop at the configured four-second maximum and become a fixed `64 x 126`
+  tensor before inference.
+- Model manifests are capped at 64 KiB and declared bundle assets at 8 MiB total. Network reads
+  stop at those limits before parsing, hashing, or persistence.
+- Bundle and task bytes fail closed on type, structure, size, digest, or compatibility mismatch.
+- Partial cache writes never become the active bundle; activation and rollback reverify bytes.
+- Feedback export fails above 16 MiB and never deletes or changes the saved local records.
+- Camera tracks, workers, frame handles, and model resources are released when the session stops.
+
+## Threats and controls
+
+| Threat | Control | Remaining exposure |
+| --- | --- | --- |
+| Accidental camera use | Permission is requested only after the user starts the demo; tracks stop on stop, navigation, hiding, or interruption. | Browser permission indicators and controls remain browser-owned. |
+| Frame or landmark exfiltration | Same-origin CSP, explicit request allowlist, no upload/telemetry code, and browser tests for forbidden request methods/channels. | A compromised origin, dependency, browser, or extension could bypass application intent. |
+| Tampered model/task bytes | Exact byte length and SHA-256 verification before use; strict manifest and runtime contracts. | A compromised reviewed hash or release build remains trusted. |
+| Unbounded frame or asset pressure | One in-flight plus one newest-waiting bitmap; bounded stream readers stop manifests and bundle assets at their reviewed limits. | The browser and network stack may transiently buffer transport data outside application control. |
+| Feedback used without consent | Per-event local consent, separate landmark opt-in, separate export consent, and non-trainable quarantine on Python import. | IndexedDB is not encrypted and has no application retention timer; users or same-origin code can access local records. |
+| UI embedded for deceptive permission prompts | CSP `frame-ancestors 'none'` plus `X-Frame-Options: DENY`. | Top-level phishing on another origin is outside this application. |
+| Unnecessary browser capabilities | Camera is self-only; microphone and geolocation are denied; no service worker or backend exists. | Hosting-provider logs still contain normal HTTP request metadata. |
+
+## Release check
+
+Story #57 must translate the JSON values without weakening them, serve all runtime and model
+assets from the release origin with correct MIME types, and inspect the deployed page for
+unexpected requests. Any required third-party origin, upload path, analytics, WebGPU backend,
+WASM threading, service worker, user account, or server API is a new design decision—not an
+implicit exception to this contract.

--- a/docs/contracts/web-release-headers.v1.json
+++ b/docs/contracts/web-release-headers.v1.json
@@ -1,0 +1,18 @@
+{
+  "format": "signlab-web-release-headers/1",
+  "environment": "production",
+  "applies_to": "all_html_and_static_asset_responses",
+  "deployment_owner": "#57",
+  "headers": {
+    "Content-Security-Policy": "default-src 'none'; base-uri 'none'; connect-src 'self'; font-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self' data:; manifest-src 'self'; media-src 'self' blob:; object-src 'none'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self'; worker-src 'self'",
+    "Cross-Origin-Resource-Policy": "same-origin",
+    "Permissions-Policy": "camera=(self), microphone=(), geolocation=()",
+    "Referrer-Policy": "no-referrer",
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "DENY"
+  },
+  "cross_origin_isolation": {
+    "required": false,
+    "reason": "The release uses single-threaded ONNX Runtime Web WASM with numThreads=1. Reconsider these headers only with a measured, reviewed multithreading change."
+  }
+}

--- a/src/signlab/feedback_packages.py
+++ b/src/signlab/feedback_packages.py
@@ -25,6 +25,7 @@ _HANDS = ("hand_0", "hand_1")
 _ANCHORS = ("left_shoulder", "right_shoulder", "left_elbow", "right_elbow", "left_wrist", "right_wrist")
 # fmt: on
 _MAX_SAFE_INTEGER = (2**53) - 1
+_MAX_PACKAGE_BYTES = 16 * 1024 * 1024
 
 
 class FeedbackPackageError(ValueError):
@@ -244,9 +245,12 @@ def import_feedback_package(
     """Validate exact bytes, then publish one immutable quarantine directory."""
 
     try:
-        package_bytes = Path(package).read_bytes()
+        with Path(package).open("rb") as source:
+            package_bytes = source.read(_MAX_PACKAGE_BYTES + 1)
     except OSError as error:
         raise FeedbackPackageError() from error
+    if len(package_bytes) > _MAX_PACKAGE_BYTES:
+        raise FeedbackPackageError()
     receipt = _receipt(package_bytes)
     root = Path(quarantine_root)
     digest = cast(str, receipt["packageSha256"])

--- a/tests/test_feedback_packages.py
+++ b/tests/test_feedback_packages.py
@@ -183,6 +183,16 @@ def test_duplicate_package_is_never_replaced(tmp_path: Path) -> None:
     assert (first.destination / "package.signlab-feedback.json").read_bytes() == source.read_bytes()
 
 
+def test_oversized_package_is_rejected_before_parsing_or_quarantine(tmp_path: Path) -> None:
+    source = tmp_path / "oversized.json"
+    source.write_bytes(b"x" * ((16 * 1024 * 1024) + 1))
+
+    with pytest.raises(FeedbackPackageError, match="feedback package invalid"):
+        import_feedback_package(source, quarantine_root=tmp_path / "quarantine")
+
+    assert not (tmp_path / "quarantine").exists()
+
+
 def test_cli_reports_only_sanitized_aggregate_success_and_failure(tmp_path: Path) -> None:
     source, root = tmp_path / "participant-private.json", tmp_path / "quarantine"
     source.write_bytes((Path(__file__).parent / "fixtures/public/feedback/browser-feedback-package-v1.json").read_bytes())

--- a/tests/test_web_release_security.py
+++ b/tests/test_web_release_security.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, cast
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+CONTRACT_PATH = REPOSITORY_ROOT / "docs/contracts/web-release-headers.v1.json"
+
+
+def _contract() -> dict[str, Any]:
+    return cast(dict[str, Any], json.loads(CONTRACT_PATH.read_text(encoding="utf-8")))
+
+
+def _csp(value: str) -> dict[str, list[str]]:
+    directives: dict[str, list[str]] = {}
+    for raw_directive in value.split(";"):
+        parts = raw_directive.strip().split()
+        assert parts
+        name, *sources = parts
+        assert name not in directives
+        directives[name] = sources
+    return directives
+
+
+def test_release_header_contract_is_exact_and_restrictive() -> None:
+    contract = _contract()
+
+    assert contract["format"] == "signlab-web-release-headers/1"
+    assert contract["environment"] == "production"
+    assert contract["applies_to"] == "all_html_and_static_asset_responses"
+    assert contract["deployment_owner"] == "#57"
+    assert contract["headers"] == {
+        "Content-Security-Policy": (
+            "default-src 'none'; base-uri 'none'; connect-src 'self'; font-src 'none'; "
+            "form-action 'none'; frame-ancestors 'none'; img-src 'self' data:; "
+            "manifest-src 'self'; media-src 'self' blob:; object-src 'none'; "
+            "script-src 'self' 'wasm-unsafe-eval'; style-src 'self'; worker-src 'self'"
+        ),
+        "Cross-Origin-Resource-Policy": "same-origin",
+        "Permissions-Policy": "camera=(self), microphone=(), geolocation=()",
+        "Referrer-Policy": "no-referrer",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "DENY",
+    }
+
+    directives = _csp(contract["headers"]["Content-Security-Policy"])
+    assert directives == {
+        "default-src": ["'none'"],
+        "base-uri": ["'none'"],
+        "connect-src": ["'self'"],
+        "font-src": ["'none'"],
+        "form-action": ["'none'"],
+        "frame-ancestors": ["'none'"],
+        "img-src": ["'self'", "data:"],
+        "manifest-src": ["'self'"],
+        "media-src": ["'self'", "blob:"],
+        "object-src": ["'none'"],
+        "script-src": ["'self'", "'wasm-unsafe-eval'"],
+        "style-src": ["'self'"],
+        "worker-src": ["'self'"],
+    }
+    sources = [source for values in directives.values() for source in values]
+    assert "*" not in sources
+    assert "'unsafe-eval'" not in sources
+    assert "'unsafe-inline'" not in sources
+    assert all(not source.startswith("http") for source in sources)
+
+
+def test_cross_origin_isolation_decision_matches_runtime() -> None:
+    isolation = _contract()["cross_origin_isolation"]
+    assert isolation["required"] is False
+    assert {"Cross-Origin-Embedder-Policy", "Cross-Origin-Opener-Policy"}.isdisjoint(
+        _contract()["headers"]
+    )
+    assert "numThreads=1" in isolation["reason"]
+
+    runtime = (REPOSITORY_ROOT / "apps/web/src/inference/candidateInferenceSession.ts").read_text(
+        encoding="utf-8"
+    )
+    assert 'import * as ort from "onnxruntime-web/wasm";' in runtime
+    assert "ort.env.wasm.numThreads = 1;" in runtime
+    assert 'executionProviders: ["wasm"]' in runtime
+
+
+def test_threat_model_marks_deployment_and_development_boundaries() -> None:
+    threat_model = (REPOSITORY_ROOT / "docs/browser-security.md").read_text(encoding="utf-8")
+    normalized = " ".join(threat_model.split())
+
+    for statement in (
+        "Development may fetch the two exact digest-pinned task files",
+        "is not part of the production privacy claim",
+        "Story #57 owns copying the reviewed bytes to the release origin",
+        "no account, application server, analytics, telemetry",
+        "one in flight and the newest waiting frame",
+        "Maximum serialized size is 16 MiB",
+        "IndexedDB is not encrypted",
+    ):
+        assert statement in normalized


### PR DESCRIPTION
Closes #51

## What changed

- documents the browser threat model, network inventory, trust anchors, and residual risks
- requires same-origin production model/task requests and refuses redirects
- pins trusted production model manifests by full SHA-256 digest
- bounds manifest, model asset, MediaPipe task, and feedback-package reads
- adds a provider-neutral production security-header contract
- keeps COOP/COEP intentionally omitted for the current single-threaded WASM runtime

Story #57 remains responsible for choosing the host, staging the reviewed task files, applying these headers, configuring the trusted manifest digest, and recording a live network/header scan.

## Verification

- 141 browser tests passed
- TypeScript, ESLint, and Prettier passed
- root and `/signlab/` production builds passed
- 36 focused Python/security tests passed
- Ruff and mypy passed
- repository hygiene and diff checks passed
- independent security and scope reviews found no blockers
- scope caps: 149 implementation/config, 221 focused tests, 87 documentation nonblank added lines

## Checklist

- [x] No raw participant video, secrets, machine-specific paths, or unlicensed data were committed.
- [x] Acceptance criteria are covered by automated tests.
- [x] Deployment-specific work is explicitly deferred to #57.