### PR TITLE
Publish curated research evidence and limitations

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,14 +9,15 @@
   },
   "scripts": {
     "dev": "vite --host 127.0.0.1",
-    "build": "npm run typecheck && vite build && npm run benchmark:check",
-    "build:subpath": "npm run typecheck && vite build --base=/signlab/ && npm run benchmark:check",
+    "build": "npm run evidence:check && npm run typecheck && vite build && npm run benchmark:check",
+    "build:subpath": "npm run evidence:check && npm run typecheck && vite build --base=/signlab/ && npm run benchmark:check",
     "benchmark:check": "node benchmark/releaseMetrics.mjs --check dist",
     "benchmark:reference": "node benchmark/runReference.mjs",
+    "evidence:check": "node scripts/validateResearchEvidence.mjs",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "lint": "eslint . --max-warnings=0",
-    "test": "vitest run",
+    "test": "npm run evidence:check && vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit -p tsconfig.app.json && tsc --noEmit -p tsconfig.node.json"
   },

--- a/apps/web/scripts/validateResearchEvidence.mjs
+++ b/apps/web/scripts/validateResearchEvidence.mjs
@@ -1,0 +1,93 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptPath = fileURLToPath(import.meta.url);
+const repositoryRoot = fileURLToPath(new URL("../../../", import.meta.url));
+const artifactPath = resolve(repositoryRoot, "docs/reports/signlab-public-results-v1.json");
+const reviewedArtifactDigest = "6544e447267e04cd1dc225c9d54cc3ce515368fa99c8b27048da40ff3ef6c179";
+
+const requiredClaims = {
+  dataset: ["Public dataset facts", "dataset_fact"],
+  baseline: ["Signer-held-out logistic baseline", "signer_held_out_baseline"],
+  architecture: ["Development architecture evidence", "development_architecture_support"],
+  calibration: ["Constructed calibration mechanics", "constructed_mechanics"],
+  runtime: ["Runtime equivalence evidence", "runtime_equivalence"],
+  browser: ["Reference-machine browser measurement", "reference_machine_only"],
+};
+const requiredUnavailable =
+  "exact_candidate_locked_test fairness natural_continuous_false_activations natural_other population_claims robustness".split(
+    " ",
+  );
+const unsafeText =
+  /(?:[a-z]:[\\/]|\\\\|\/(?:users|home|tmp)\/|gh[pousr]_[a-z0-9]{20,}|akia[a-z0-9]{16}|-----begin .*private key-----|\.(?:avi|bmp|gif|heic|jpe?g|mkv|mov|mp4|png|webm)\b|participant[_-]?media|raw[_-]?videos?)/i;
+const identityKey = /"(?:email|participant_?id|signer_?id|user_?name)"\s*:/i;
+
+export async function validateResearchEvidence(evidence, root = repositoryRoot) {
+  const errors = [];
+  const check = (condition, message) => {
+    if (!condition) errors.push(message);
+  };
+  check(evidence.format === "signlab-public-results/1", "format must be signlab-public-results/1");
+  check(
+    evidence.evidenceCommit === "5fb187c5a36678f868b14200452fcdc7c8650f94",
+    "evidence commit changed",
+  );
+
+  for (const [id, [label, scope]] of Object.entries(requiredClaims)) {
+    const claim = evidence[id];
+    check(claim?.label === label && claim?.scope === scope, `${id} claim label or scope changed`);
+  }
+  check(evidence.unavailable?.scope === "unavailable", "unavailable scope changed");
+  const unavailableIds = (evidence.unavailable?.items ?? []).map(({ id }) => id).sort();
+  check(unavailableIds.join() === requiredUnavailable.join(), "unavailable evidence list changed");
+
+  const sourceIds = new Set(Object.keys(evidence.sources ?? {}));
+  const owners = [
+    ...Object.keys(requiredClaims).map((id) => evidence[id]),
+    ...(evidence.unavailable?.items ?? []),
+  ];
+  owners.forEach((owner) =>
+    (owner?.sources ?? []).forEach((id) => check(sourceIds.has(id), `unknown source: ${id}`)),
+  );
+  for (const [id, source] of Object.entries(evidence.sources ?? {})) {
+    const pathAllowed = /^docs\/(?:cards|reports)\/[a-z0-9.-]+\.(?:json|md)$/.test(
+      source.path ?? "",
+    );
+    check(pathAllowed, `${id} source path is not public evidence`);
+    if (!pathAllowed) continue;
+    const bytes = await readFile(resolve(root, source.path));
+    const actual = `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+    check(actual === source.sha256, `${id} source hash changed`);
+  }
+
+  const candidateText = JSON.stringify([
+    evidence.dataset,
+    evidence.architecture,
+    evidence.calibration,
+    evidence.runtime,
+    evidence.browser,
+  ]);
+  check(
+    !/(?:(?:test|locked-test).{0,40}(?:accuracy|f1|macro|\b0\.\d+)|(?:accuracy|f1|macro|\b0\.\d+).{0,40}(?:test|locked-test))/i.test(
+      candidateText,
+    ),
+    "candidate test claim is not allowed",
+  );
+  const serialized = JSON.stringify(evidence);
+  check(
+    createHash("sha256").update(serialized).digest("hex") === reviewedArtifactDigest,
+    "reviewed artifact content changed",
+  );
+  check(!unsafeText.test(serialized.replaceAll("\\\\", "\\")), "private or unsafe text found");
+  check(!identityKey.test(serialized), "private identity field found");
+  if (errors.length > 0) throw new Error(`research evidence invalid:\n- ${errors.join("\n- ")}`);
+  return { claims: Object.keys(requiredClaims).length, sources: sourceIds.size };
+}
+
+if (process.argv[1] !== undefined && resolve(process.argv[1]) === scriptPath) {
+  const evidence = JSON.parse(await readFile(artifactPath, "utf8"));
+  const result = await validateResearchEvidence(evidence);
+  console.log(`Research evidence verified: ${result.claims} claims, ${result.sources} sources.`);
+}

--- a/apps/web/scripts/validateResearchEvidence.test.mjs
+++ b/apps/web/scripts/validateResearchEvidence.test.mjs
@@ -1,0 +1,58 @@
+// @vitest-environment node
+
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, it } from "vitest";
+
+import { validateResearchEvidence } from "./validateResearchEvidence.mjs";
+
+const artifactUrl = new URL(
+  "../../../docs/reports/signlab-public-results-v1.json",
+  import.meta.url,
+);
+const evidence = JSON.parse(await readFile(artifactUrl, "utf8"));
+const copy = () => structuredClone(evidence);
+async function rejects(change, message) {
+  const changed = copy();
+  change(changed);
+  await expect(validateResearchEvidence(changed)).rejects.toThrow(message);
+}
+
+describe("public research evidence", () => {
+  it("accepts the reviewed artifact and its exact source bytes", async () => {
+    await expect(validateResearchEvidence(copy())).resolves.toEqual({ claims: 6, sources: 9 });
+  });
+
+  it("rejects content drift and changed claim boundaries", async () => {
+    await rejects((item) => {
+      item.baseline.metrics[0][1] = "0.999";
+    }, "reviewed artifact content changed");
+    await rejects((item) => {
+      item.architecture.scope = "candidate_performance";
+    }, "claim label or scope changed");
+    await rejects((item) => {
+      item.browser.statement = "Candidate accuracy 0.900 on the locked test.";
+    }, "candidate test claim is not allowed");
+  });
+
+  it("rejects private, secret, identity, and raw-media text", async () => {
+    for (const unsafe of [
+      ["C:", "Users", "person", "result.json"].join("\\"),
+      ["", "home", "person", "result.json"].join("/"),
+      "ghp_12345678901234567890",
+      "raw_videos/signer.mov",
+      "portrait.gif",
+    ]) {
+      await rejects((item) => {
+        item.dataset.statement = unsafe;
+      }, "private or unsafe text found");
+    }
+    await rejects((item) => {
+      item.baseline.participantId = "hidden";
+    }, "private identity field");
+  });
+
+  it("requires every named evidence gap", async () => {
+    await rejects((item) => item.unavailable.items.pop(), "unavailable evidence list changed");
+  });
+});

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -2,6 +2,7 @@ import { Route, Routes } from "react-router-dom";
 
 import { AppShell } from "./AppShell";
 import { FeedbackPage } from "../feedback/Feedback";
+import { ResultsPage } from "../results/ResultsPage";
 import { staticPages } from "./routeDefinitions";
 import { LivePage, NotFoundPage, OverviewPage, StaticPage } from "./routes";
 
@@ -15,7 +16,15 @@ export function App() {
           <Route
             key={page.path}
             path={page.path}
-            element={page.path === "/feedback" ? <FeedbackPage /> : <StaticPage page={page} />}
+            element={
+              page.path === "/feedback" ? (
+                <FeedbackPage />
+              ) : page.path === "/results" ? (
+                <ResultsPage />
+              ) : (
+                <StaticPage page={page} />
+              )
+            }
           />
         ))}
         <Route path="*" element={<NotFoundPage />} />

--- a/apps/web/src/app/accessibility.test.tsx
+++ b/apps/web/src/app/accessibility.test.tsx
@@ -5,7 +5,7 @@ import { describe, expect, it } from "vitest";
 
 import { App } from "./App";
 
-const routes = ["/", "/live", "/feedback", "/privacy", "/missing"] as const;
+const routes = ["/", "/live", "/results", "/feedback", "/privacy", "/missing"] as const;
 
 describe("automated accessibility smoke", () => {
   it.each(routes)("has no detectable A/AA violations on %s", async (path) => {

--- a/apps/web/src/results/ResultsPage.test.tsx
+++ b/apps/web/src/results/ResultsPage.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ResultsPage } from "./ResultsPage";
+
+const evidenceCommit = "5fb187c5a36678f868b14200452fcdc7c8650f94";
+
+describe("research results page", () => {
+  it("publishes bounded, pinned evidence without human media", () => {
+    const { container } = render(<ResultsPage />);
+
+    expect(screen.getByRole("heading", { level: 1, name: "Research results" })).toHaveFocus();
+    expect(screen.getByText("No headline candidate accuracy is published.")).toBeInTheDocument();
+    expect(screen.getByText("Signer-held-out logistic baseline")).toBeVisible();
+    expect(screen.getByText("0.725")).toBeVisible();
+    expect(screen.getByRole("table", { name: "Aggregate test errors by prompt" })).toBeVisible();
+    expect(screen.getByRole("heading", { name: "Runtime equivalence evidence" })).toBeVisible();
+    expect(screen.getByText(/session count is not defined/i)).toBeVisible();
+    expect(screen.getByText(/5 warmups followed by 50 measured calls/)).toBeVisible();
+    for (const heading of [
+      "Exact-candidate locked-test performance",
+      "Natural other movement",
+      "Natural continuous false activations",
+      "Fairness",
+      "Robustness",
+      "Population performance",
+    ]) {
+      expect(screen.getByRole("heading", { level: 3, name: heading })).toBeVisible();
+    }
+    const links = screen.getAllByRole("link");
+
+    expect(
+      links.every((link) => link.getAttribute("href")?.includes(`/blob/${evidenceCommit}/docs/`)),
+    ).toBe(true);
+    links.forEach((link) => expect(link.title).toMatch(/^sha256:[a-f0-9]{64}$/));
+    expect(container.querySelector("img, video")).toBeNull();
+  });
+});

--- a/apps/web/src/results/ResultsPage.tsx
+++ b/apps/web/src/results/ResultsPage.tsx
@@ -1,0 +1,182 @@
+import evidence from "../../../../docs/reports/signlab-public-results-v1.json";
+
+type Source = { path: string; sha256: string };
+const sources: Record<string, Source> = evidence.sources;
+
+function focusResultsHeading(heading: HTMLHeadingElement | null) {
+  if (heading === null) return;
+  document.title = "Results | SignLab";
+  heading.focus();
+}
+
+function SourceLinks({ ids }: { ids: readonly string[] }) {
+  return (
+    <div className="evidence-sources">
+      <strong>Exact sources</strong>
+      <ul>
+        {ids.map((id) => {
+          const source = sources[id];
+          if (source === undefined) return null;
+          const href = `https://github.com/peterbucci/signlab/blob/${evidence.evidenceCommit}/${source.path}`;
+          return (
+            <li key={id}>
+              <a href={href} title={source.sha256}>
+                {source.path.split("/").at(-1)}
+              </a>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+function Metrics({ values }: { values: readonly (readonly string[])[] }) {
+  return (
+    <dl className="evidence-metrics">
+      {values.map(([label, value]) => (
+        <div key={`${label}:${value}`}>
+          <dt>{label}</dt>
+          <dd>{value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+function ComparisonTable({
+  caption,
+  columns,
+  rows,
+}: {
+  caption: string;
+  columns: readonly string[];
+  rows: readonly (readonly (number | string)[])[];
+}) {
+  return (
+    <div className="evidence-table-wrap">
+      <table aria-label={caption}>
+        <thead>
+          <tr>
+            <th scope="col">Measure</th>
+            {columns.map((column) => (
+              <th scope="col" key={column}>
+                {column}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map(([label, ...values]) => (
+            <tr key={label}>
+              <th scope="row">{label}</th>
+              {values.map((value, index) => (
+                <td key={`${label}:${columns[index]}`}>{value}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export function ResultsPage() {
+  return (
+    <article className="results-page" aria-labelledby="results-heading">
+      <header className="results-intro">
+        <p className="eyebrow">Reviewed evidence only</p>
+        <h1 id="results-heading" ref={focusResultsHeading} tabIndex={-1}>
+          Research results
+        </h1>
+        <p className="page-summary">
+          A compact record of what SignLab has measured, which model each number belongs to, and
+          what the evidence cannot support yet.
+        </p>
+        <aside className="results-boundary" aria-label="Current evidence boundary">
+          <strong>No headline candidate accuracy is published.</strong>
+          <p>
+            The real held-out score below belongs to a simple reference baseline. Candidate evidence
+            currently covers architecture development, constructed calibration, runtime equivalence,
+            and one-machine browser measurements.
+          </p>
+          <SourceLinks ids={["datasetCard", "modelCard"]} />
+        </aside>
+      </header>
+
+      <div className="evidence-grid">
+        <section className="evidence-card" aria-labelledby="dataset-evidence-heading">
+          <h2 id="dataset-evidence-heading">{evidence.dataset.label}</h2>
+          <p>
+            <strong>{`${evidence.dataset.clips} clips · ${evidence.dataset.signers} signers · ${evidence.dataset.split.train} / ${evidence.dataset.split.validation} / ${evidence.dataset.split.test} train/validation/test`}</strong>
+          </p>
+          <p>{evidence.dataset.statement}</p>
+          <SourceLinks ids={evidence.dataset.sources} />
+        </section>
+
+        <section className="evidence-card" aria-labelledby="baseline-evidence-heading">
+          <h2 id="baseline-evidence-heading">{evidence.baseline.label}</h2>
+          <p>{evidence.baseline.statement}</p>
+          <Metrics values={evidence.baseline.metrics} />
+          <ComparisonTable
+            caption="Aggregate test errors by prompt"
+            columns={["Errors", "Support"]}
+            rows={evidence.baseline.errors}
+          />
+          <SourceLinks ids={evidence.baseline.sources} />
+        </section>
+
+        {[evidence.architecture, evidence.calibration, evidence.runtime].map((claim) => (
+          <section
+            className="evidence-card"
+            aria-labelledby={`${claim.scope}-heading`}
+            key={claim.scope}
+          >
+            <h2 id={`${claim.scope}-heading`}>{claim.label}</h2>
+            <p>{claim.statement}</p>
+            <Metrics values={claim.metrics} />
+            <SourceLinks ids={claim.sources} />
+          </section>
+        ))}
+
+        <section
+          className="evidence-card evidence-card-wide"
+          aria-labelledby="browser-evidence-heading"
+        >
+          <h2 id="browser-evidence-heading">{evidence.browser.label}</h2>
+          <p>{evidence.browser.statement}</p>
+          <p>{evidence.browser.environment}</p>
+          <p>{evidence.browser.sampleNote}</p>
+          <ComparisonTable
+            caption="Cold and warm browser reference runs"
+            columns={evidence.browser.runLabels}
+            rows={evidence.browser.metrics}
+          />
+          <ul className="evidence-limitations">
+            {evidence.browser.limitations.map((limitation) => (
+              <li key={limitation}>{limitation}</li>
+            ))}
+          </ul>
+          <SourceLinks ids={evidence.browser.sources} />
+        </section>
+
+        <section
+          className="evidence-card evidence-card-wide unavailable-evidence"
+          aria-labelledby="unavailable-evidence-heading"
+        >
+          <h2 id="unavailable-evidence-heading">{evidence.unavailable.label}</h2>
+          <p>These are unknowns, not zeroes and not implied successes.</p>
+          <ul>
+            {evidence.unavailable.items.map((item) => (
+              <li key={item.id}>
+                <h3>{item.label}</h3>
+                <p>{item.statement}</p>
+                <SourceLinks ids={item.sources} />
+              </li>
+            ))}
+          </ul>
+        </section>
+      </div>
+    </article>
+  );
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -726,6 +726,90 @@ h1 {
   content: "";
 }
 
+.results-page {
+  width: min(100% - 3rem, 76rem);
+  margin: 0 auto;
+  padding: clamp(5rem, 10vw, 9rem) 0;
+}
+
+.results-boundary,
+.unavailable-evidence {
+  padding: 1.25rem;
+  border-left: 0.3rem solid #e8623c;
+}
+
+.evidence-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.25rem;
+}
+
+.evidence-card {
+  padding: clamp(1.25rem, 3vw, 2rem);
+  border: 1px solid rgb(21 48 47 / 16%);
+  border-radius: 1.25rem;
+}
+
+.evidence-card-wide {
+  grid-column: 1 / -1;
+}
+
+.evidence-metrics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.evidence-metrics div {
+  padding-top: 0.7rem;
+  border-top: 1px solid rgb(21 48 47 / 14%);
+}
+
+.evidence-metrics dt {
+  color: #526967;
+  font-size: 0.75rem;
+}
+
+.evidence-metrics dd {
+  margin: 0.2rem 0 0;
+  font-weight: 800;
+}
+
+.evidence-table-wrap {
+  margin: 1.25rem 0;
+  overflow-x: auto;
+}
+
+.evidence-card table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.evidence-card th,
+.evidence-card td {
+  padding: 0.6rem;
+  border-bottom: 1px solid rgb(21 48 47 / 14%);
+  text-align: left;
+}
+
+.evidence-sources ul,
+.unavailable-evidence > ul {
+  padding: 0;
+  list-style: none;
+}
+
+.evidence-sources a {
+  display: block;
+  overflow-wrap: anywhere;
+  color: #b54428;
+  font-weight: 750;
+}
+
+.unavailable-evidence > ul > li {
+  padding-top: 1rem;
+  border-top: 1px solid rgb(21 48 47 / 14%);
+}
+
 .text-link {
   display: inline-block;
   margin-top: 0.5rem;
@@ -851,6 +935,10 @@ h1 {
 
   .detail-card {
     max-width: 38rem;
+  }
+
+  .evidence-grid {
+    grid-template-columns: 1fr;
   }
 
   .principle-grid {

--- a/docs/reports/signlab-public-results-v1.json
+++ b/docs/reports/signlab-public-results-v1.json
@@ -1,0 +1,169 @@
+{
+  "format": "signlab-public-results/1",
+  "evidenceCommit": "5fb187c5a36678f868b14200452fcdc7c8650f94",
+  "sources": {
+    "datasetCard": {
+      "path": "docs/cards/popsign-five-isolated-smoke-v1.md",
+      "sha256": "sha256:e8ccbfb9fed7e0d2529b24d18f2ea29a40593d5d4f3ac2a666e6ede0d0a76109"
+    },
+    "modelCard": {
+      "path": "docs/cards/popsign-tcn-portable-export-candidate-v1.md",
+      "sha256": "sha256:ed58c02d6692396675554ac607d35f8681e68a6eaeed4a5165dde1b26ffd2705"
+    },
+    "baselineReport": {
+      "path": "docs/reports/popsign-reference-baselines-v1.md",
+      "sha256": "sha256:0fe9c35ad0fddd084ed3afaaad5c304e035a302ebdbcb5f0ea7ce0b34b455524"
+    },
+    "architectureReport": {
+      "path": "docs/reports/popsign-representation-ablations-v1.md",
+      "sha256": "sha256:dddbba8e6aa5b1f7537005e91669ef73e9c2151a79f76971779d1d134f25dabc"
+    },
+    "calibrationReport": {
+      "path": "docs/reports/popsign-constructed-calibration-v1.md",
+      "sha256": "sha256:f4d5ef440a509c50a56ada1dbf45dc66f2f545f3c120f9e2656155788518e561"
+    },
+    "nativeParityReport": {
+      "path": "docs/reports/popsign-tcn-native-onnx-parity-v1.json",
+      "sha256": "sha256:9e6446a5f6c0eb6a03c194dfe2f875880b3ea46e1ca7bf6cea3ba78c59045e6d"
+    },
+    "webParityReport": {
+      "path": "docs/reports/popsign-tcn-onnx-web-parity-v1.json",
+      "sha256": "sha256:4d1bb0a728f73552989a88fd4d1a6c55fc5706728ad0cd19a68b4da4e6e5f3e4"
+    },
+    "browserReference": {
+      "path": "docs/reports/browser-reference-v1.json",
+      "sha256": "sha256:88fcb8c6c2f59f155c452e5a32d527d6d5e49971564736375e511cef0ee9ed79"
+    },
+    "continuousReplay": {
+      "path": "docs/reports/constructed-continuous-replay-v1.json",
+      "sha256": "sha256:4f8f5969b8a1b92b88a9a59ee12f2a414bd5b4365dd2197abb4e99d8247d489f"
+    }
+  },
+  "dataset": {
+    "label": "Public dataset facts",
+    "scope": "dataset_fact",
+    "statement": "PopSign ASL v1.0 (CC BY 4.0) is a small, isolated five-prompt corpus. A session count is not defined by the public evidence.",
+    "clips": 80,
+    "signers": 40,
+    "split": { "train": 50, "validation": 15, "test": 15 },
+    "sessionCount": null,
+    "sources": ["datasetCard"]
+  },
+  "baseline": {
+    "label": "Signer-held-out logistic baseline",
+    "scope": "signer_held_out_baseline",
+    "statement": "These are real held-out results for the five-class logistic baseline, not performance for the browser candidate.",
+    "metrics": [
+      ["Test macro-F1", "0.725"],
+      ["Test balanced accuracy", "0.733"]
+    ],
+    "errors": [
+      ["Hello", 2, 3],
+      ["No", 0, 3],
+      ["Please", 1, 3],
+      ["Thank you", 1, 3],
+      ["Yes", 0, 3]
+    ],
+    "sources": ["baselineReport", "datasetCard"]
+  },
+  "architecture": {
+    "label": "Development architecture evidence",
+    "scope": "development_architecture_support",
+    "statement": "Three signer-grouped development folds support carrying the hand-local TCN architecture forward. They do not measure the exact browser checkpoint.",
+    "metrics": [
+      ["OOF macro-F1", "0.834"],
+      ["Balanced accuracy", "0.831"]
+    ],
+    "sources": ["architectureReport", "modelCard"]
+  },
+  "calibration": {
+    "label": "Constructed calibration mechanics",
+    "scope": "constructed_mechanics",
+    "statement": "The exact candidate used reused development examples and three constructed transition fragments. Temperature 0.050 hit the search boundary; the selected 0% threshold abstained on no rows. This checks mechanics, not model quality or natural use.",
+    "metrics": [
+      ["Development rows", "18"],
+      ["Constructed other rows", "3"],
+      ["Temperature", "0.050"],
+      ["NLL", "0.173056 → 0.000076"]
+    ],
+    "sources": ["calibrationReport", "modelCard"]
+  },
+  "runtime": {
+    "label": "Runtime equivalence evidence",
+    "scope": "runtime_equivalence",
+    "statement": "The exported candidate matched its reference implementation on the measured fixtures. This does not establish recognition quality or behavior on unmeasured inputs.",
+    "metrics": [
+      ["Native → ONNX", "18 rows; 0 decision mismatches"],
+      ["Maximum native difference", "0.0000019073"],
+      ["Python → Web/WASM", "3 cases; matching decisions"],
+      ["Maximum web difference", "0.0000002384"]
+    ],
+    "sources": ["nativeParityReport", "webParityReport"]
+  },
+  "browser": {
+    "label": "Reference-machine browser measurement",
+    "scope": "reference_machine_only",
+    "statement": "One reference-machine benchmark measured cold and warm Chromium runs on a Windows computer under a generated no-person camera workload.",
+    "environment": "Chromium 151.0.7922.34; Windows 10.0.26200 x64; Intel i9-14900HX; 32 logical CPUs; WASM with one thread.",
+    "sampleNote": "Each inference percentile uses 5 warmups followed by 50 measured calls.",
+    "runLabels": ["Cold", "Warm"],
+    "metrics": [
+      ["Startup", "2327.2 ms", "981.2 ms"],
+      ["Processed frames", "107", "121"],
+      ["Dropped frames", "14", "0"],
+      ["Processed FPS", "17.83", "20.13"],
+      ["Inference p50", "0.5 ms", "0.5 ms"],
+      ["Inference p95", "0.8 ms", "0.9 ms"],
+      ["Longest UI task", "89 ms", "55 ms"]
+    ],
+    "limitations": [
+      "One machine and browser cannot predict other devices.",
+      "The generated no-person workload is easier than real hand video.",
+      "Inference timing excludes capture, worker transfer, event detection, and rendering.",
+      "Memory was unavailable, and these timings are not CI thresholds."
+    ],
+    "sources": ["browserReference"]
+  },
+  "unavailable": {
+    "label": "Evidence not available",
+    "scope": "unavailable",
+    "items": [
+      {
+        "id": "exact_candidate_locked_test",
+        "label": "Exact-candidate locked-test performance",
+        "statement": "The exact browser candidate has not been evaluated on the locked test set.",
+        "sources": ["modelCard"]
+      },
+      {
+        "id": "natural_other",
+        "label": "Natural other movement",
+        "statement": "The available other examples are constructed transition fragments, not natural recordings.",
+        "sources": ["calibrationReport", "modelCard"]
+      },
+      {
+        "id": "natural_continuous_false_activations",
+        "label": "Natural continuous false activations",
+        "statement": "Constructed replay checks scorer behavior but cannot estimate false activations in natural sessions.",
+        "sources": ["continuousReplay", "modelCard"]
+      },
+      {
+        "id": "fairness",
+        "label": "Fairness",
+        "statement": "The current evidence does not support subgroup comparisons.",
+        "sources": ["datasetCard", "modelCard"]
+      },
+      {
+        "id": "robustness",
+        "label": "Robustness",
+        "statement": "The current evidence does not establish behavior across varied capture conditions or devices.",
+        "sources": ["datasetCard", "modelCard"]
+      },
+      {
+        "id": "population_claims",
+        "label": "Population performance",
+        "statement": "This small corpus cannot support broad population or sign-language generalization claims.",
+        "sources": ["datasetCard", "modelCard"]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Closes #53

## Summary

- publish one versioned, reviewed evidence artifact and a static accessible Results page
- separate the signer-held-out logistic baseline from development architecture, constructed calibration, runtime equivalence, and single-machine browser evidence
- publish aggregate per-class errors, exact source links, dataset/model cards, browser samples and limitations, and all currently unavailable claims
- verify the reviewed artifact digest and every pinned source hash during normal test and build commands
- fail closed on claim drift, misleading candidate-test claims, secrets, identities, machine paths, and raw-media references
- add no backend, runtime fetch, charting, Markdown renderer, media, analytics, or dependency

## Verification

- 152 web tests passed
- format, lint, and TypeScript checks passed
- root-domain and subpath production builds passed
- release asset budgets passed
- repository hygiene and diff checks passed
- focused adversarial review passed
- story guardrails: production/data/helper 442/450; CSS 73/120; focused tests 85/175; total 600/600