### PR TITLE
Add cross-browser release smoke gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,11 @@ jobs:
       - name: Build for a root domain
         run: npm run build
 
+      - name: Install pinned engines and smoke test the built release
+        run: |
+          npx playwright install --with-deps chromium firefox webkit
+          npm run test:browser
+
       - name: Build for a configured subpath
         run: npm run build:subpath
 

--- a/README.md
+++ b/README.md
@@ -225,9 +225,9 @@ and continuous-replay scorer evidence. Its
 [nomination report](docs/reports/popsign-tcn-portable-export-nomination-v1.json)
 freeze the exact evidence and nominate it for portable export only. No champion or
 natural-use, test, release, or production claim is made.
-The registered DVC graph remains the Story #14 fixture receipt scaffold rather
-than a production extraction runner. No headline model result is considered valid
-until the remaining licensed-corpus and grouped-evaluation foundations are complete.
+The public DVC graph remains fixture-only by design. The remaining release limits
+are the candidate's unresolved redistribution status, sealed locked test, missing
+natural continuous-use evidence, and not-yet-deployed public site.
 
 ## Data and privacy
 

--- a/README.md
+++ b/README.md
@@ -191,12 +191,13 @@ three exact representation variants, optional geometry and elapsed-time kinemati
 masked training-only statistics, and content-addressed cache objects. Licensed
 PopSign execution now produces one deterministic, leakage-checked 80-sample public
 smoke split from the verified retained landmark inventory without rerunning MediaPipe.
-A responsive React/Vite shell now exposes the planned public routes without a backend
-and includes a dormant MediaPipe landmark-worker boundary. Its live route now provides
-an explicit, consent-first local camera preview with pause, stop, device switching,
-and lifecycle cleanup; it neither saves nor uploads video, and it does not send frames
-to the worker. Model-bundle delivery, replay, feedback storage, and gesture inference
-remain explicitly unconnected. A minimal local MLflow ledger can now log, query, and byte-verify one
+A static React/Vite app now exposes the public routes without a backend and runs its
+verified MediaPipe and ONNX paths in workers. Its live route provides consent-first
+camera controls and on-device event results; model bundles can be cached and rolled
+back, deterministic post-landmark replay is tested, and explicitly saved feedback
+stays local until a separate export. The exact PopSign candidate remains an
+unpublished development checkpoint, not a configured public release. A minimal local
+MLflow ledger can now log, query, and byte-verify one
 portable baseline result without a server or custom dashboard. The first frozen
 signer-disjoint benchmark now compares majority, seeded stratified-random, and
 train-only multinomial-logistic references from one checked-in configuration. The

--- a/apps/web/browser/releaseSmoke.mjs
+++ b/apps/web/browser/releaseSmoke.mjs
@@ -1,0 +1,222 @@
+import { readFile, stat } from "node:fs/promises";
+import { createServer } from "node:http";
+import { dirname, extname, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { chromium, firefox, webkit } from "playwright";
+
+const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const distRoot = resolve(appRoot, "dist");
+const types = new Map([
+  [".css", "text/css; charset=utf-8"],
+  [".html", "text/html; charset=utf-8"],
+  [".js", "text/javascript; charset=utf-8"],
+  [".json", "application/json; charset=utf-8"],
+  [".svg", "image/svg+xml"],
+  [".wasm", "application/wasm"],
+]);
+const routes = [
+  ["/", "Five gestures, tested honestly."],
+  ["/live", "Live recognition"],
+  ["/replay", "Deterministic replay"],
+  ["/results", "Research results"],
+  ["/methodology", "How the research is built"],
+  ["/feedback", "Feedback stays local by default"],
+  ["/privacy", "Designed for on-device processing"],
+  ["/limitations", "What SignLab does—and does not—claim"],
+  ["/missing", "Page not found"],
+];
+
+function check(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+async function startServer() {
+  check((await stat(resolve(distRoot, "index.html"))).isFile(), "browser.smoke.build_missing");
+  const server = createServer(async (request, response) => {
+    try {
+      const url = new URL(request.url ?? "/", "http://localhost");
+      const relative = decodeURIComponent(url.pathname === "/" ? "/index.html" : url.pathname);
+      const path = resolve(distRoot, `.${relative}`);
+      check(path.startsWith(`${distRoot}${sep}`), "browser.smoke.path_invalid");
+      const bytes = await readFile(path);
+      response.writeHead(200, {
+        "Content-Type": types.get(extname(path)) ?? "application/octet-stream",
+      });
+      response.end(bytes);
+    } catch {
+      response.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
+      response.end("Not found");
+    }
+  });
+  await new Promise((accept, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", accept);
+  });
+  const address = server.address();
+  check(typeof address === "object" && address !== null, "browser.smoke.server_invalid");
+  return { origin: `http://127.0.0.1:${address.port}`, server };
+}
+
+function installBrowserMocks() {
+  const media = new WeakMap();
+  const state = {
+    channels: [],
+    constraints: [],
+    denyNext: false,
+    lastTrack: null,
+    stopCount: 0,
+  };
+  Object.defineProperty(globalThis, "__signlabSmoke", { value: state });
+  Object.defineProperty(HTMLMediaElement.prototype, "srcObject", {
+    configurable: true,
+    get() {
+      return media.get(this) ?? null;
+    },
+    set(value) {
+      media.set(this, value);
+    },
+  });
+  const mediaDevices = {
+    async enumerateDevices() {
+      return [
+        { deviceId: "mock-camera", groupId: "mock", kind: "videoinput", label: "Mock camera" },
+      ];
+    },
+    async getUserMedia(constraints) {
+      state.constraints.push(constraints);
+      if (state.denyNext) {
+        state.denyNext = false;
+        throw new DOMException("Mock permission denial", "NotAllowedError");
+      }
+      const events = new EventTarget();
+      const track = {
+        addEventListener: events.addEventListener.bind(events),
+        enabled: true,
+        getSettings: () => ({ deviceId: "mock-camera" }),
+        removeEventListener: events.removeEventListener.bind(events),
+        stop() {
+          if (this.stopped) return;
+          this.stopped = true;
+          state.stopCount += 1;
+        },
+        stopped: false,
+      };
+      state.lastTrack = track;
+      return { getTracks: () => [track], getVideoTracks: () => [track] };
+    },
+  };
+  Object.defineProperty(navigator, "mediaDevices", { configurable: true, value: mediaDevices });
+  Object.defineProperty(navigator, "sendBeacon", {
+    configurable: true,
+    value: () => {
+      state.channels.push("beacon");
+      return false;
+    },
+  });
+  if (typeof EventSource === "function") {
+    globalThis.EventSource = new Proxy(EventSource, {
+      construct(target, argumentsList) {
+        state.channels.push("eventsource");
+        return Reflect.construct(target, argumentsList);
+      },
+    });
+  }
+}
+
+async function runEngine(name, launcher, origin) {
+  const browser = await launcher.launch({ headless: true });
+  let context;
+  try {
+    context = await browser.newContext();
+    await context.addInitScript(installBrowserMocks);
+    const page = await context.newPage();
+    const errors = [];
+    const requests = [];
+    const sockets = [];
+    page.on("console", (message) => {
+      if (message.type() === "error") errors.push(`console: ${message.text()}`);
+    });
+    page.on("pageerror", (error) => errors.push(`page: ${error.message}`));
+    page.on("request", (request) => requests.push([request.method(), request.url()]));
+    page.on("websocket", (socket) => sockets.push(socket.url()));
+
+    await page.goto(`${origin}/#/`);
+    await page.getByRole("heading", { level: 1, name: routes[0][1] }).waitFor();
+    for (const [path, heading] of routes.slice(1, -1)) {
+      await page.locator(`nav[aria-label="Primary navigation"] a[href="#${path}"]`).click();
+      await page.getByRole("heading", { level: 1, name: heading }).waitFor();
+    }
+    await page.goto(`${origin}/#${routes.at(-1)[0]}`);
+    await page.getByRole("heading", { level: 1, name: routes.at(-1)[1] }).waitFor();
+
+    await page.goto(`${origin}/#/live`);
+    await page.getByRole("button", { name: "Start camera" }).click();
+    await page
+      .getByText("Camera is on. Raw video stays on this page and is not saved or uploaded.")
+      .waitFor();
+    await page.getByRole("button", { name: "Pause preview" }).click();
+    check(
+      (await page.evaluate(() => globalThis.__signlabSmoke.lastTrack.enabled)) === false,
+      `${name}.camera.pause`,
+    );
+    await page.getByRole("button", { name: "Resume preview" }).click();
+    check(
+      (await page.evaluate(() => globalThis.__signlabSmoke.lastTrack.enabled)) === true,
+      `${name}.camera.resume`,
+    );
+    await page.getByRole("button", { name: "Stop camera" }).click();
+    check(
+      (await page.evaluate(() => globalThis.__signlabSmoke.stopCount)) === 1,
+      `${name}.camera.stop`,
+    );
+    const constraints = await page.evaluate(() => globalThis.__signlabSmoke.constraints);
+    check(
+      constraints.length === 1 &&
+        constraints[0].audio === false &&
+        typeof constraints[0].video === "object",
+      `${name}.camera.constraints`,
+    );
+
+    await page.evaluate(() => {
+      globalThis.__signlabSmoke.denyNext = true;
+    });
+    await page.getByRole("button", { name: "Start camera" }).click();
+    await page
+      .getByText(
+        "Camera permission was denied. Allow camera access in site settings, then try again.",
+      )
+      .waitFor();
+
+    const channels = await page.evaluate(() => globalThis.__signlabSmoke.channels);
+    check(errors.length === 0, `${name}.browser.errors: ${errors.join(" | ")}`);
+    check(sockets.length === 0 && channels.length === 0, `${name}.network.channel`);
+    for (const [method, url] of requests) {
+      check(
+        method === "GET" && new URL(url).origin === origin,
+        `${name}.network.request: ${method} ${url}`,
+      );
+    }
+    process.stdout.write(
+      `PASS ${name}: ${routes.length} routes, camera lifecycle, same-origin GET-only shell requests\n`,
+    );
+  } finally {
+    await context?.close().catch(() => undefined);
+    await browser.close().catch(() => undefined);
+  }
+}
+
+const { origin, server } = await startServer();
+try {
+  for (const [name, launcher] of [
+    ["Chromium", chromium],
+    ["Firefox", firefox],
+    ["WebKit", webkit],
+  ]) {
+    await runEngine(name, launcher, origin);
+  }
+} finally {
+  await new Promise((accept, reject) =>
+    server.close((error) => (error ? reject(error) : accept())),
+  );
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
     "format:check": "prettier --check .",
     "lint": "eslint . --max-warnings=0",
     "test": "npm run evidence:check && vitest run",
+    "test:browser": "node browser/releaseSmoke.mjs",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit -p tsconfig.app.json && tsc --noEmit -p tsconfig.node.json"
   },

--- a/docs/development.md
+++ b/docs/development.md
@@ -5,7 +5,7 @@
 | Path | Owner | Responsibility |
 | --- | --- | --- |
 | `src/signlab/` | Python application | Importable domain, application, and adapter code; no private data |
-| `apps/web/` | Public browser application | Static React/Vite shell and, after later review gates, on-device inference |
+| `apps/web/` | Public browser application | Static React/Vite app with verified worker-based on-device inference |
 | `tests/` | Verification | Fast unit/integration tests and tiny public fixtures |
 | `docs/` | Evidence and decisions | Architecture, protocols, cards, audits, and tutorials |
 | `configs/` | Portable inputs | Reviewed versioned configuration; never resolved local state |
@@ -38,7 +38,7 @@ The native landmark boundary is an optional `extraction` extra containing exact
 `mediapipe==1.0.1` and `av==18.1.0` pins. Core contract, governance, dataset, and CLI
 imports must remain usable without loading either native package. The developer
 workflow installs all extras so Linux and Windows exercise that boundary; consumers
-that do not extract video can install the base wheel. The future browser runtime is
+that do not extract video can install the base wheel. The browser runtime is
 separately pinned to `@mediapipe/tasks-vision@1.0.1` by the extraction contract.
 
 The local experiment ledger and simple reference models are a separate optional
@@ -84,6 +84,8 @@ npm run lint
 npm run typecheck
 npm test
 npm run build
+npx playwright install chromium firefox webkit
+npm run test:browser
 npm run build:subpath
 ```
 
@@ -91,12 +93,21 @@ The two builds prove the static files can be published at a root domain or a
 configured `/signlab/` subpath. Hash-based routes keep every page usable on a plain
 static host without rewrite rules. The live route requests camera access only after
 the user selects **Start camera**, keeps its preview local, and releases tracks during
-its documented lifecycle transitions. It does not send frames to the dormant worker,
-load a model, process replay inputs, save feedback, or call a backend.
+its documented lifecycle transitions. MediaPipe and ONNX workers run only after an
+exact model bundle and the two task assets pass verification; there is no backend,
+upload path, analytics, or automatic feedback save.
 
-The normal web checks also compile and test the dormant landmark worker. MediaPipe
-`.task` models remain external to Git, and neither task starts until a later boundary
-supplies verified model buffers and frames.
+The browser smoke runs the built root-domain application sequentially in Playwright
+Chromium, Firefox, and WebKit. It uses a deterministic no-person camera mock to check
+route rendering, camera start/pause/resume/stop and denial behavior, and the
+observed shell's same-origin `GET`-only requests. Model-bundle and MediaPipe task
+requests remain part of the later packaged-release check. This is compatibility
+automation, not a physical-device, Safari, model-inference, or recognition-quality
+claim.
+
+The MediaPipe `.task` models and generated candidate bundle remain external to Git.
+The three-engine smoke deliberately supplies neither, so it tests release rendering,
+camera lifecycle, and network behavior—not landmark extraction or inference.
 
 ## Local experiment ledger
 


### PR DESCRIPTION
Closes #57

## Summary

- run the built static app through pinned Playwright Chromium, Firefox, and WebKit
- verify every hash route, primary navigation, not-found behavior, and uncaught browser errors
- exercise deterministic no-person camera start, pause, resume, stop, and denial behavior
- fail on observed shell requests that are not same-origin GETs, plus WebSocket, EventSource, or beacon use
- run the bounded smoke after the root build in pull-request CI
- correct directly contradictory browser-status documentation

## Deliberate boundary

This gate does not stage the unpublished PopSign candidate or MediaPipe task files and therefore does not claim full live inference, physical-device, Safari, or release-asset network coverage. Those remain in #126, #127, #129, and #130.

## Verification

- 152 Vitest tests
- formatting, ESLint, TypeScript
- root and /signlab/ builds plus asset budgets
- Chromium, Firefox, and WebKit release smoke
- repository hygiene and browser-security tests
- focused pre-commit checks
- 243 added nonblank lines against the 250-line target